### PR TITLE
Add immutable external schema families

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,40 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Verify built-package typing
+        shell: bash
+        run: |
+          uv sync --frozen --python 3.12 --no-install-project
+
+          mapfile -t WHEELS < <(find "$GITHUB_WORKSPACE/dist" -maxdepth 1 -type f -name '*.whl')
+          test "${#WHEELS[@]}" -eq 1
+
+          VENV_DIR="$RUNNER_TEMP/built-package-typing-venv"
+          CONSUMER_DIR="$RUNNER_TEMP/built-package-typing-consumer"
+          uv venv --python 3.12 "$VENV_DIR"
+          uv pip install --python "$VENV_DIR/bin/python" "${WHEELS[0]}"
+          mkdir -p "$CONSUMER_DIR"
+          cp tests/typing/schema_family_contract.py "$CONSUMER_DIR/"
+
+          cd "$RUNNER_TEMP"
+          "$GITHUB_WORKSPACE/.venv/bin/ty" check \
+            --python "$VENV_DIR" \
+            --project "$CONSUMER_DIR" \
+            "$CONSUMER_DIR/schema_family_contract.py"
+          "$VENV_DIR/bin/python" "$CONSUMER_DIR/schema_family_contract.py"
+          "$VENV_DIR/bin/python" - <<'PY'
+          import os
+          from pathlib import Path
+
+          import pydantic_versions
+
+          package_file = Path(pydantic_versions.__file__).resolve()
+          workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+          assert not package_file.is_relative_to(workspace), package_file
+          marker = package_file.with_name("py.typed")
+          assert marker.is_file(), marker
+          PY
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -28,43 +28,49 @@ the schema it uses, and the latest software can still validate and upgrade it:
 ```python
 from pydantic import BaseModel
 from pydantic_versions import (
-    dump_versioned,
+    SchemaFamily,
+    SchemaVersion,
+    VersionTransition,
     field_default,
     field_removed,
-    migration,
-    schema_version,
-    validate_versioned,
-    versioned_schema,
 )
 
 
-@versioned_schema(
-    name="app_config",
-    versions=["1", "2"],
-    current="2",
-    version_field="schema_version",
-    missing_version="1",
-)
-@schema_version("1", patches=[
-    field_default("timeout", 5.0),
-    field_removed("new_feature"),
-])
 class AppConfig(BaseModel):
     timeout: float = 10.0
     retries: int = 3
     new_feature: bool = False
 
 
-@migration(AppConfig, "1", "2")
-def migrate_v1_to_v2(data: dict) -> dict:
+def upgrade_v1(data: dict) -> dict:
     data.setdefault("new_feature", False)
     return data
 
 
-result = validate_versioned(AppConfig, {"schema_version": "1", "retries": 2})
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5.0),
+                field_removed("new_feature"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
+    transitions=(
+        VersionTransition("1", "2", upgrade=upgrade_v1),
+    ),
+    missing_version="1",
+)
+
+
+result = APP_CONFIG_SCHEMA.validate({"schema_version": "1", "retries": 2})
 assert result.current_model == AppConfig(timeout=5.0, retries=2, new_feature=False)
 
-v1_config = dump_versioned(AppConfig, version="1")
+v1_config = APP_CONFIG_SCHEMA.dump(version="1")
 assert v1_config == {"timeout": 5.0, "retries": 3, "schema_version": "1"}
 ```
 
@@ -73,8 +79,10 @@ version field. For example, `missing_version="1"` means "if a payload has no
 `schema_version`, treat it as an old v1 config." If you do not set it,
 unversioned input raises `MissingSchemaVersionError`.
 
-The docs include a larger nested config example and adoption guidance for
-deciding when to use patches, migrations, nested version fields, and legacy
+The current model remains ordinary; its growing history can live in another
+module. The decorators remain available as a compact compatibility style. The
+docs include external-family guidance, a larger nested config example, and
+adoption guidance for choosing patches, migrations, metadata, and legacy
 unversioned fallbacks.
 
 ## Development

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Added immutable external `SchemaFamily`, `SchemaVersion`, and
+  `VersionTransition` declarations so schema history can live outside the
+  current model and two isolated families can safely reuse one model.
+- Made family compilation lazy, thread-safe, collision-resistant, and
+  authoritative for generated models, field projections, validation upgrades,
+  and rendering projections; unreachable transition declarations now fail.
+- Kept decorators and model-first free functions as explicit-default adapters
+  to the same compiler, with contextual errors for missing or conflicting
+  default-family selection.
 - Added Python 3.14 package metadata and raised the supported Pydantic v2 floor
   to 2.12.3.
 - Added explicit registration-time errors for Pydantic v1 and other models that

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -9,37 +9,51 @@ loading it.
 
 ## Current model
 
-The model you decorate is the current schema. Application code should usually
-use this model after validation:
+The current model is the authoritative application schema. It can remain an
+ordinary model while an external family in another module owns its history.
+Application code should usually use this model after validation:
 
 ```python
 from pydantic import BaseModel
-from pydantic_versions import validate_versioned, versioned_schema
+from pydantic_versions import SchemaFamily, SchemaVersion
 
 
-@versioned_schema(name="app_config", versions=["1", "2"], current="2")
 class AppConfig(BaseModel):
     timeout: float = 10.0
 
 
-result = validate_versioned(AppConfig, {"schema_version": "2"})
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+)
+
+result = APP_CONFIG_SCHEMA.validate({"schema_version": "2"})
 config = result.current_model
 ```
 
 ## Historical schemas
 
-Historical schemas are derived from the current model with patches. This keeps
-simple default-only versions compact while still allowing validation against the
-older shape:
+Historical schemas are independently derived from the current model with
+patches. This keeps simple default-only versions compact while still allowing
+validation against the older shape:
 
 ```python
-from pydantic_versions import field_default, schema_version
+from pydantic_versions import SchemaFamily, SchemaVersion, field_default
 
 
-@versioned_schema(name="app_config", versions=["1", "2"], current="2")
-@schema_version("1", patches=[field_default("timeout", 5.0)])
 class AppConfig(BaseModel):
     timeout: float = 10.0
+
+
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion("1", patches=(field_default("timeout", 5.0),)),
+        SchemaVersion("2"),
+    ),
+)
 ```
 
 For a larger nested example that shows why this matters in practice, see the
@@ -47,7 +61,7 @@ For a larger nested example that shows why this matters in practice, see the
 
 ## Validation flow
 
-`validate_versioned()`:
+`SchemaFamily.validate()` and `validate_versioned()`:
 
 1. discovers the source schema version;
 2. validates input against that source version;
@@ -58,7 +72,7 @@ For a larger nested example that shows why this matters in practice, see the
 The result preserves both sides:
 
 ```python
-result = validate_versioned(AppConfig, {"schema_version": "1"})
+result = APP_CONFIG_SCHEMA.validate({"schema_version": "1"})
 
 assert result.source_version == "1"
 assert result.current_version == "2"
@@ -68,14 +82,12 @@ assert result.current_model.timeout == 5.0
 
 ## Rendering flow
 
-`dump_versioned()` renders a payload in a requested schema version. This is for
+`SchemaFamily.dump()` and `dump_versioned()` render a payload in a requested
+schema version. This is for
 writing example configs, preserving legacy output formats, or showing users what
 a specific schema version looks like.
 
 ```python
-from pydantic_versions import dump_versioned
-
-
-dumped = dump_versioned(AppConfig, version="1")
+dumped = APP_CONFIG_SCHEMA.dump(version="1")
 assert dumped == {"timeout": 5.0, "schema_version": "1"}
 ```

--- a/docs/guide/external-families.md
+++ b/docs/guide/external-families.md
@@ -1,0 +1,150 @@
+# External Schema Families
+
+An external `SchemaFamily` keeps schema history beside the application model
+instead of stacking an ever-growing declaration above it. This is the primary
+configuration style for histories that need their own module, tooling, or more
+than one interpretation of the same current model.
+
+## Keep the current model ordinary
+
+The model module does not need to import `pydantic_versions`:
+
+```python
+# models.py
+from pydantic import BaseModel
+
+
+class AppConfig(BaseModel):
+    timeout: float = 10.0
+    retries: int = 3
+    new_feature: bool = False
+```
+
+Declare its history elsewhere:
+
+```python
+# schema_history.py
+from models import AppConfig
+from pydantic_versions import (
+    SchemaFamily,
+    SchemaVersion,
+    VersionTransition,
+    field_default,
+    field_removed,
+)
+
+
+def upgrade_v1(data: dict) -> dict:
+    data.setdefault("new_feature", False)
+    return data
+
+
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5.0),
+                field_removed("new_feature"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
+    transitions=(
+        VersionTransition("1", "2", upgrade=upgrade_v1),
+    ),
+)
+```
+
+The final declared label is current. Historical versions are projected
+independently from the current model; patches are not accumulated from one
+historical declaration into the next.
+
+## Use the family explicitly
+
+Direct family calls cannot be confused with another history:
+
+```python
+result = APP_CONFIG_SCHEMA.validate(
+    {"schema_version": "1", "retries": 2},
+)
+
+assert result.current_model == AppConfig(
+    timeout=5.0,
+    retries=2,
+    new_feature=False,
+)
+
+v1_model = APP_CONFIG_SCHEMA.model_for("1")
+v1_defaults = APP_CONFIG_SCHEMA.defaults_for(version="1")
+```
+
+The compatibility free functions also accept a family as their first argument:
+
+```python
+from pydantic_versions import model_for_version, validate_versioned
+
+
+v1_model = model_for_version(APP_CONFIG_SCHEMA, "1")
+result = validate_versioned(
+    APP_CONFIG_SCHEMA,
+    {"schema_version": "1", "retries": 2},
+)
+```
+
+## Reuse one model in two families
+
+Families own their declarations, compiled projections, transitions, and
+generated-model cache. Two families can therefore reuse the same application
+model without overwriting each other:
+
+```python
+PUBLIC_CONFIG = SchemaFamily(
+    model=AppConfig,
+    name="public_config",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+)
+INTERNAL_CONFIG = SchemaFamily(
+    model=AppConfig,
+    name="internal_config",
+    versions=(SchemaVersion("legacy"), SchemaVersion("current")),
+)
+```
+
+Constructing either family does not select it globally. A model-only call has no
+basis for choosing and raises `SchemaFamilySelectionError`.
+
+## Select one compatibility default deliberately
+
+Applications that still need model-only helper calls can select one family
+during configuration startup:
+
+```python
+PUBLIC_CONFIG.as_default()
+```
+
+After that call, `validate_versioned(AppConfig, data)` delegates to
+`PUBLIC_CONFIG`. Repeating `as_default()` on the same family is safe. Selecting a
+different second default raises `SchemaFamilySelectionError` and leaves the
+first selection unchanged.
+
+The `@versioned_schema` compatibility decorator performs this selection for its
+own family automatically. External family construction never does.
+
+## Compilation rules
+
+Compilation happens on first use or through an explicit `compile()` call. It is
+thread-safe and idempotent; repeated calls on one family return the same family
+and generated model objects.
+
+Declarations are copied into immutable tuples before compilation. Labels must
+already be non-empty strings, the final label is current, and custom transitions
+must connect adjacent forward labels. Duplicate, reverse, skipped, or otherwise
+unreachable transitions fail instead of becoming silent dead code.
+
+The current foundation covers flat patch projections and forward upgrades.
+Explicit historical wire models, explicit nested-family mappings, and downgrade
+execution are rejected rather than silently ignored until their dedicated 0.2
+runtime support lands.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,8 +1,8 @@
 # Getting Started
 
-This guide walks through the smallest useful setup: install the package, declare
-a current model, describe one historical schema version, validate old input into
-the current model, and render an old config shape.
+This guide walks through the smallest useful setup: install the package, keep a
+current application model ordinary, declare its history in another module,
+validate old input into the current model, and render an old config shape.
 
 ## Install
 
@@ -23,9 +23,11 @@ supported.
 
 ## Define the current schema
 
-Start with the model your current application wants to use:
+Start with the model your current application wants to use. It does not need a
+version decorator or a `pydantic_versions` import:
 
 ```python
+# models.py
 from pydantic import BaseModel
 
 
@@ -35,58 +37,65 @@ class AppConfig(BaseModel):
     new_feature: bool = False
 ```
 
-In current application code, this is still the shape you want to work with.
+## Declare schema history
 
-## Register schema versions
-
-Decorate the current model with the schema versions you support:
+Put the growing history in a dedicated module:
 
 ```python
-from pydantic_versions import field_default, field_removed, schema_version, versioned_schema
+# schema_history.py
+from models import AppConfig
+from pydantic_versions import (
+    SchemaFamily,
+    SchemaVersion,
+    field_default,
+    field_removed,
+)
 
 
-@versioned_schema(
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
     name="app_config",
-    versions=["1", "2"],
-    current="2",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5.0),
+                field_removed("new_feature"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
 )
-@schema_version(
-    "1",
-    patches=[
-        field_default("timeout", 5.0),
-        field_removed("new_feature"),
-    ],
-)
-class AppConfig(BaseModel):
-    timeout: float = 10.0
-    retries: int = 3
-    new_feature: bool = False
 ```
 
 This says:
 
-- version `2` is the current schema;
+- version `2`, the final declared label, is current;
 - version `1` had `timeout=5.0`;
 - version `1` did not have `new_feature`.
+
+Adding another historical version changes `schema_history.py`, not the
+authoritative application model.
 
 ## Validate historical input
 
 Users can keep older config files:
 
 ```python
-from pydantic_versions import validate_versioned
-
-
 old_config = {
     "schema_version": "1",
     "retries": 2,
 }
 
-result = validate_versioned(AppConfig, old_config)
+result = APP_CONFIG_SCHEMA.validate(old_config)
 
 assert result.source_version == "1"
 assert result.current_version == "2"
-assert result.current_model == AppConfig(timeout=5.0, retries=2, new_feature=False)
+assert result.current_model == AppConfig(
+    timeout=5.0,
+    retries=2,
+    new_feature=False,
+)
 ```
 
 Application code can use `result.current_model` and ignore the historical shape
@@ -94,14 +103,10 @@ after validation.
 
 ## Render a historical config
 
-Use `dump_versioned()` when you need to generate examples or output for a
-specific schema version:
+Use `dump()` when you need defaults or output for a specific schema version:
 
 ```python
-from pydantic_versions import dump_versioned
-
-
-v1_config = dump_versioned(AppConfig, version="1")
+v1_config = APP_CONFIG_SCHEMA.dump(version="1")
 
 assert v1_config == {
     "timeout": 5.0,
@@ -110,26 +115,66 @@ assert v1_config == {
 }
 ```
 
-## Add a migration when patches are not enough
+## Add an upgrade when patches are not enough
 
-Patches describe field-level schema differences. Use a migration for custom data
-changes:
+Patches describe field-level schema differences. Declare adjacent forward
+transitions for custom value changes:
 
 ```python
-from pydantic_versions import migration
+from pydantic_versions import VersionTransition
 
 
-@migration(AppConfig, "1", "2")
-def migrate_v1_to_v2(data: dict) -> dict:
+def upgrade_v1(data: dict) -> dict:
     data.setdefault("new_feature", False)
     return data
+
+
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5.0),
+                field_removed("new_feature"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
+    transitions=(
+        VersionTransition("1", "2", upgrade=upgrade_v1),
+    ),
+)
 ```
 
-Migrations run after historical validation and before final current-model
-validation.
+This replaces the earlier family declaration with the same v1 projection plus
+an upgrade. Transitions run after historical validation and before final
+current-model validation. Every declared transition must connect adjacent
+labels, so accepted upgrade code cannot become an unreachable registration.
+
+## Keep the decorator style when it stays small
+
+The 0.1 decorators remain compatibility and convenience adapters. They build a
+default family and delegate to the same compiler:
+
+```python
+from pydantic_versions import schema_version, versioned_schema
+
+
+@versioned_schema(name="small_config", versions=("1", "2"), current="2")
+@schema_version("1", patches=(field_default("timeout", 5.0),))
+class SmallConfig(BaseModel):
+    timeout: float = 10.0
+```
+
+Use an external family when the history would obscure the current model, when
+two histories share one model, or when configuration must be explicit rather
+than import-order dependent.
 
 ## Next steps
 
+- Read [External Schema Families](external-families.md) for defaults, isolation, and compilation rules.
 - Read [Version Discovery](version-discovery.md) before using `missing_version`.
 - Read [Schema Patches](schema-patches.md) for defaults, removed fields, renamed fields, and grouped patches.
 - Read [Migrations](migrations.md) for upgrade behavior.

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -1,59 +1,101 @@
 # Migrations
 
 Migrations upgrade already-validated historical data toward the current model.
-They are optional: if adjacent versions are compatible, identity steps are used.
+They are optional: if adjacent versions are compatible, the compiler records an
+identity edge.
+
+## Declare transitions with the family
+
+External families keep transition topology beside their version declarations:
 
 ```python
-from pydantic_versions import migration
+from models import AppConfig
+from pydantic_versions import SchemaFamily, SchemaVersion, VersionTransition
 
 
-@migration(AppConfig, "1", "2")
+def upgrade_v1(data: dict) -> dict:
+    data.setdefault("new_feature", False)
+    return data
+
+
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+    transitions=(
+        VersionTransition("1", "2", upgrade=upgrade_v1),
+    ),
+)
+```
+
+Constructor declarations are deterministic and complete before first use. The
+legacy `@migration` builder remains available for decorator-based families:
+
+```python
+from pydantic import BaseModel
+from pydantic_versions import migration, versioned_schema
+
+
+@versioned_schema(name="legacy_app_config", versions=("1", "2"), current="2")
+class LegacyAppConfig(BaseModel):
+    new_feature: bool = False
+
+
+@migration(LegacyAppConfig, "1", "2")
 def migrate_v1_to_v2(data: dict) -> dict:
     data.setdefault("new_feature", False)
     return data
 ```
 
-## Direction
+Legacy registrations must finish before the family's first compilation.
+Registering another migration after `compile()`, `model_for_version()`,
+`validate_versioned()`, or `dump_versioned()` has compiled that family raises
+`InvalidMigrationError` instead of mutating live plans.
 
-The first release supports forward migrations only. A migration must move from an
-earlier declared version to a later declared version.
+## Direction and topology
+
+Forward upgrades connect adjacent declared versions only:
 
 ```python
-@versioned_schema(name="app_config", versions=["1", "2", "3"], current="3")
+from pydantic import BaseModel
+from pydantic_versions import versioned_schema
+
+
+@versioned_schema(name="app_config", versions=("1", "2", "3"), current="3")
 class AppConfig(BaseModel):
     ...
 ```
 
-Valid:
-
-```python
-@migration(AppConfig, "1", "2")
-def migrate_v1_to_v2(data: dict) -> dict:
-    return data
-```
-
-Invalid:
-
-```python
-@migration(AppConfig, "3", "1")
-def downgrade(data: dict) -> dict:
-    return data
-```
+Valid edges are `1 -> 2` and `2 -> 3`. A direct `1 -> 3` registration, a reverse
+edge, an unknown endpoint, or a duplicate edge fails during declaration. This
+guarantees that every accepted custom upgrade has an execution path.
 
 ## Chained upgrades
 
-When validating version `1` against current version `3`, migrations are checked
-between adjacent declared versions:
+When validating version `1` against current version `3`, the immutable compiled
+topology is:
 
 ```text
 1 -> 2 -> 3
 ```
 
-Registered migrations run in that order. Missing migration steps are treated as
-identity steps, which is useful when a version only changed defaults or when the
-historical model already renders a current-compatible payload.
+Custom upgrades run in that order. An edge with no upgrade callable remains an
+explicit internal identity step, which is useful when a version changed only
+field defaults or when its historical projection is already current-compatible.
+
+`SchemaFamily.transitions` exposes the frozen custom declarations for tooling
+and review. After validation, `VersionedValidation.migrations_applied` reports
+the custom upgrade edges that actually ran. Compiler-added identity steps are
+not presented as user migrations; the public compiled-plan API will provide the
+complete topology.
 
 ## Return values
 
-Migration functions receive and return dictionaries using current field names.
-Returning anything other than `dict` raises `InvalidMigrationError`.
+Migration functions receive a fresh dictionary using current field names and
+must return a dictionary. Returning any other type raises
+`InvalidMigrationError`.
+
+Downgrade declarations and historical rendering across value-changing upgrades
+are part of the broader 0.2 conversion contract, but this foundation does not
+execute them yet. A downgrade declaration is rejected rather than accepted and
+silently ignored.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,11 @@
 `pydantic-versions` brings explicit schema versioning to Pydantic models.
 
 It focuses on config and API payloads where schema versions are independent from
-software versions. The core API lets projects register ordered schema versions,
-derive historical Pydantic models from a current model, validate historical
-payloads, render historical config shapes, and upgrade inputs to the current
-model through explicit migrations.
+software versions. External schema families keep growing history outside the
+current application model, derive historical Pydantic models, validate
+historical payloads, render historical config shapes, and upgrade inputs through
+explicit transitions. Decorators remain available as a compact compatibility
+style.
 
 ## Install
 
@@ -26,24 +27,31 @@ uv add pydantic-versions
 
 ## Quick example
 
-This example uses an explicit historical schema version. The input validates as
-version `1`, then upgrades to the current model.
+This example declares history without decorating the current model. The input
+validates as version `1`, then upgrades to the current model.
 
 ```python
 from pydantic import BaseModel
-from pydantic_versions import field_default, schema_version, validate_versioned, versioned_schema
+from pydantic_versions import SchemaFamily, SchemaVersion, field_default
 
 
-@versioned_schema(name="app_config", versions=["1", "2"], current="2")
-@schema_version("1", patches=[field_default("timeout", 5.0)])
 class AppConfig(BaseModel):
     timeout: float = 10.0
 
 
-result = validate_versioned(AppConfig, {"schema_version": "1"})
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion("1", patches=(field_default("timeout", 5.0),)),
+        SchemaVersion("2"),
+    ),
+)
+
+result = APP_CONFIG_SCHEMA.validate({"schema_version": "1"})
 assert result.current_model.timeout == 5.0
 ```
 
-See the user guide for the important details around version discovery,
-`missing_version`, schema patches, migrations, rendering historical configs, and
-the [complex config example](guide/complex-config-example.md).
+See the user guide for [external families](guide/external-families.md), version
+discovery, `missing_version`, schema patches, migrations, rendering historical
+configs, and the [complex config example](guide/complex-config-example.md).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,79 +1,180 @@
 # API Reference
 
-## Decorators
+## External declarations
 
-`versioned_schema(name, versions, current, version_field="schema_version", missing_version=None)`
+### `SchemaFamily`
 
-Registers a Pydantic model as a versioned schema family.
+```python
+class SchemaFamily[T: BaseModel]:
+    def __init__(
+        self,
+        *,
+        model: type[T],
+        name: str,
+        versions: Sequence[SchemaVersion],
+        transitions: Sequence[VersionTransition] = (),
+        nested: Sequence[NestedFamily] = (),
+        version_metadata: VersionMetadata | None = VersionMetadata(),
+        missing_version: str | None = None,
+    ) -> None: ...
+```
 
-- `versions`: explicit ordered schema version strings.
-- `current`: the current schema version.
-- `version_field`: a top-level field name or tuple path used to read/write version metadata.
-- `missing_version`: optional legacy fallback for unversioned input.
+Owns one named history for a current Pydantic model. Construction copies every
+declaration sequence and has no default-selection side effect.
+
+- `model`, `name`, `versions`, `transitions`, `nested`, `version_metadata`, and
+  `missing_version`: read-only copies of the family declarations.
+- `current_version`: the final declared version label.
+- `compile()`: lazily and atomically compile the immutable family state; returns the family.
+- `as_default()`: deliberately select this family for model-only compatibility calls; returns the family.
+- `model_for(version)`: return the family-local generated wire model.
+- `validate(data, *, version=None)`: validate historical input and upgrade it to the current model.
+- `defaults_for(*, version, include_version=True, **dump_kwargs)`: render target defaults.
+- `dump(*, version, data=None, include_version=True, **dump_kwargs)`: return a target-version dictionary.
+
+Compilation is idempotent and thread-safe. A family owns its generated-model
+identities and cache, so two families can reuse one current model without
+sharing state.
+
+### `SchemaVersion`
+
+```python
+@dataclass(frozen=True)
+class SchemaVersion:
+    label: str
+    patches: tuple[VersionPatch, ...] = ()
+    wire_model: type[BaseModel] | None = None
+```
+
+Labels are exact non-empty strings. The final label is current and cannot carry
+historical patches or an explicit wire model. `wire_model` is reserved by the
+0.2 contract; the current foundation rejects non-empty use until explicit
+historical-model support lands.
+
+### `VersionTransition`
+
+```python
+@dataclass(frozen=True)
+class VersionTransition:
+    source: str
+    target: str
+    upgrade: TransitionFunc | None = None
+    downgrade: TransitionFunc | None = None
+    downgrade_semantics: Literal["exact", "lossy"] | None = None
+```
+
+Custom transitions must connect adjacent forward labels. An adjacent pair with
+no `VersionTransition` declaration is compiled as an identity edge; every
+declared transition must contain at least one callable. The current foundation
+executes forward upgrades; downgrade execution lands with the
+historical-rendering work and non-empty downgrade declarations are rejected in
+the meantime.
+
+### `VersionMetadata`
+
+```python
+@dataclass(frozen=True)
+class VersionMetadata:
+    path: str | tuple[str, ...] = "schema_version"
+    owner: Literal["family", "model"] = "family"
+```
+
+Describes the version-discriminator path and its ownership. Full collision and
+alias semantics are defined by the 0.2 architecture decision and implemented by
+the later top-level conversion work.
+
+### Reserved nested declarations
+
+`NestedFamily`, `MatchingLabels`, and `matching_labels()` are exported as frozen
+declaration types so the final constructor remains stable. Non-empty explicit
+nested mappings currently fail compilation instead of being ignored; graph
+compilation and nested execution land in their dedicated 0.2 changes.
+
+## Decorator compatibility
+
+`versioned_schema(name, versions, current, version_field="schema_version", missing_version=None, transitions=(), ...)`
+
+Builds a default family for a Pydantic model and returns the original model
+class. `current` must equal the final label. The deterministic `transitions=`
+argument uses `VersionTransition` records.
 
 `schema_version(version, patches=())`
 
-Applies patches to one declared version.
+Applies patches to one declared historical version.
 
 `schema_versions(versions, patches=())`
 
-Applies the same patches to multiple explicitly declared versions.
+Applies the same patches to multiple explicitly declared historical versions.
 
-`migration(model_cls, from_version, to_version)`
+`migration(subject, from_version, to_version)`
 
-Registers a forward upgrade migration. Migration functions receive and return
-`dict` values using current field names.
+Registers a legacy forward upgrade before first compilation. `subject` may be a
+family or a model with an explicit default family. Late, reverse, skipped, and
+duplicate registrations fail.
 
-## Patch Helpers
+## Patch helpers and records
 
 `field_default(name, default)` or `field_default(name, default_factory=callable)`
 
-Changes a field default for a historical version.
+Changes a field default for a historical version and returns `FieldDefault`.
 
 `field_removed(name)`
 
-Removes a field from a historical version.
+Removes a field from a historical version and returns `FieldRemoved`.
 
 `field_renamed(current_name, version_name)`
 
 Uses `version_name` in the historical schema and maps it back to `current_name`
-during upgrade validation.
+during upgrade validation. Returns `FieldRenamed`.
 
-## Runtime Helpers
+`VersionPatch` is the public union of those three frozen record types.
 
-`model_for_version(model_cls, version)`
+## Runtime compatibility helpers
 
-Returns the generated Pydantic model for a declared schema version.
+`model_for_version(subject, version)`
 
-`validate_versioned(model_cls, data, version=None)`
+Returns the generated Pydantic model for a declared version. `subject` may be a
+family or a model with an explicit default family.
 
-Validates `data` against the discovered source version, applies forward
-migrations, and validates the current model.
+`validate_versioned(subject, data, *, version=None)`
 
-`dump_versioned(model_cls, version, data=None, include_version=True, **dump_kwargs)`
+Validates `data` against the discovered source version, applies adjacent
+forward upgrades, and validates the current model.
 
-Renders defaults, model data, or mapping data using a requested schema version.
-Extra keyword arguments are passed to Pydantic `model_dump()`.
+`dump_versioned(subject, *, version, data=None, include_version=True, **dump_kwargs)`
+
+Renders defaults, model data, or mapping data using a requested version and
+returns a dictionary. Extra keyword arguments are passed to Pydantic
+`model_dump()`.
 
 ## Result
 
-`VersionedValidation`
+`VersionedValidation[T]`
 
 ```python
 @dataclass(frozen=True)
-class VersionedValidation:
+class VersionedValidation[T: BaseModel]:
     source_version: str
     current_version: str
     source_model: BaseModel
-    current_model: BaseModel
+    current_model: T
     migrations_applied: tuple[tuple[str, str], ...]
 ```
+
+## Public type aliases
+
+- `TransitionData`: `dict[str, Any]`
+- `TransitionFunc`: `Callable[[TransitionData], TransitionData]`
+- `VersionPath`: `str | tuple[str, ...]`
+- `JsonValue`: recursive JSON-safe primitive type
 
 ## Exceptions
 
 - `SchemaVersionError`
-- `MissingSchemaVersionError`
-- `UnknownSchemaVersionError`
-- `DuplicateSchemaVersionError`
-- `InvalidMigrationError`
-- `VersionedValidationError`
+  - `SchemaCompilationError`
+  - `SchemaFamilySelectionError`
+  - `MissingSchemaVersionError`
+  - `UnknownSchemaVersionError`
+  - `DuplicateSchemaVersionError`
+  - `InvalidMigrationError`
+  - `VersionedValidationError`

--- a/src/pydantic_versions/__init__.py
+++ b/src/pydantic_versions/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from pydantic_versions.core import (
-    VersionedValidation,
     dump_versioned,
     migration,
     model_for_version,
@@ -12,15 +11,39 @@ from pydantic_versions.core import (
     validate_versioned,
     versioned_schema,
 )
+from pydantic_versions.declarations import (
+    JsonValue,
+    MatchingLabels,
+    NestedFamily,
+    SchemaVersion,
+    TransitionData,
+    TransitionFunc,
+    VersionedValidation,
+    VersionMetadata,
+    VersionPath,
+    VersionTransition,
+    matching_labels,
+)
 from pydantic_versions.exceptions import (
     DuplicateSchemaVersionError,
     InvalidMigrationError,
     MissingSchemaVersionError,
+    SchemaCompilationError,
+    SchemaFamilySelectionError,
     SchemaVersionError,
     UnknownSchemaVersionError,
     VersionedValidationError,
 )
-from pydantic_versions.patches import field_default, field_removed, field_renamed
+from pydantic_versions.family import SchemaFamily
+from pydantic_versions.patches import (
+    FieldDefault,
+    FieldRemoved,
+    FieldRenamed,
+    VersionPatch,
+    field_default,
+    field_removed,
+    field_renamed,
+)
 
 
 def _package_version(distribution: str = "pydantic-versions") -> str:
@@ -34,10 +57,26 @@ __version__ = _package_version()
 
 __all__ = [
     "DuplicateSchemaVersionError",
+    "FieldDefault",
+    "FieldRemoved",
+    "FieldRenamed",
     "InvalidMigrationError",
+    "JsonValue",
+    "MatchingLabels",
     "MissingSchemaVersionError",
+    "NestedFamily",
+    "SchemaCompilationError",
+    "SchemaFamily",
+    "SchemaFamilySelectionError",
+    "SchemaVersion",
     "SchemaVersionError",
+    "TransitionData",
+    "TransitionFunc",
     "UnknownSchemaVersionError",
+    "VersionMetadata",
+    "VersionPatch",
+    "VersionPath",
+    "VersionTransition",
     "VersionedValidation",
     "VersionedValidationError",
     "__version__",
@@ -45,6 +84,7 @@ __all__ = [
     "field_default",
     "field_removed",
     "field_renamed",
+    "matching_labels",
     "migration",
     "model_for_version",
     "schema_version",

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import hashlib
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel
+
+from pydantic_versions.declarations import (
+    NestedFamily,
+    SchemaVersion,
+    TransitionFunc,
+    VersionMetadata,
+    VersionTransition,
+    _require_label,
+)
+from pydantic_versions.exceptions import (
+    DuplicateSchemaVersionError,
+    SchemaCompilationError,
+    SchemaVersionError,
+    UnknownSchemaVersionError,
+)
+from pydantic_versions.patches import FieldDefault, FieldRemoved, FieldRenamed, VersionPatch
+
+type UpgradeKind = Literal["implicit_identity", "custom_transition"]
+
+
+@dataclass(frozen=True)
+class _CompiledField:
+    current_name: str
+    version_name: str | None
+    default: FieldDefault | None
+
+
+@dataclass(frozen=True)
+class _VersionProjection:
+    label: str
+    fields: tuple[_CompiledField, ...]
+
+    def field(self, current_name: str) -> _CompiledField:
+        for field in self.fields:
+            if field.current_name == current_name:
+                return field
+        msg = f"Compiled projection does not contain current field {current_name!r}"
+        raise SchemaCompilationError(msg)
+
+
+@dataclass(frozen=True)
+class _CompiledVersion:
+    projection: _VersionProjection
+    model: type[BaseModel]
+
+
+@dataclass(frozen=True)
+class _CompiledTransition:
+    source: str
+    target: str
+    upgrade_kind: UpgradeKind
+    upgrade: TransitionFunc | None
+
+
+@dataclass(frozen=True)
+class _CompiledFamily:
+    model: type[BaseModel]
+    name: str
+    versions: tuple[_CompiledVersion, ...]
+    transitions: tuple[_CompiledTransition, ...]
+    version_metadata: VersionMetadata | None
+    missing_version: str | None
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return tuple(version.projection.label for version in self.versions)
+
+    @property
+    def current_version(self) -> str:
+        return self.versions[-1].projection.label
+
+    def index(self, label: str) -> int:
+        for index, version in enumerate(self.versions):
+            if version.projection.label == label:
+                return index
+        msg = f"Unknown schema version {label!r} for {self.name!r}"
+        raise UnknownSchemaVersionError(msg)
+
+    def version(self, label: str) -> _CompiledVersion:
+        return self.versions[self.index(label)]
+
+
+def _ensure_pydantic_v2_model(model_cls: object) -> None:
+    if isinstance(model_cls, type) and issubclass(model_cls, BaseModel):
+        return
+    model_name = getattr(model_cls, "__name__", repr(model_cls))
+    msg = f"{model_name!r} must inherit from pydantic.BaseModel from Pydantic v2"
+    raise SchemaVersionError(msg)
+
+
+def _ensure_unique_versions(versions: tuple[str, ...], *, schema_name: str) -> None:
+    duplicates = {version for version in versions if versions.count(version) > 1}
+    if duplicates:
+        msg = f"Duplicate schema versions for {schema_name!r}: {sorted(duplicates)!r}"
+        raise DuplicateSchemaVersionError(msg)
+
+
+def _validate_family_declarations(
+    *,
+    model: type[BaseModel],
+    name: str,
+    versions: tuple[SchemaVersion, ...],
+    transitions: tuple[VersionTransition, ...],
+    nested: tuple[NestedFamily, ...],
+    missing_version: str | None,
+) -> None:
+    if not versions:
+        msg = f"Schema family {name!r} must declare at least one version"
+        raise SchemaCompilationError(msg)
+    if any(not isinstance(version, SchemaVersion) for version in versions):
+        msg = "SchemaFamily.versions must contain only SchemaVersion values"
+        raise SchemaCompilationError(msg)
+    labels = tuple(
+        _require_label(version.label, parameter="SchemaVersion.label") for version in versions
+    )
+    _ensure_unique_versions(labels, schema_name=name)
+    current = versions[-1]
+    if current.patches or current.wire_model is not None:
+        msg = f"Current schema version {current.label!r} for {name!r} cannot be patched"
+        raise SchemaCompilationError(msg)
+    if missing_version is not None and missing_version not in labels:
+        msg = f"Missing-version fallback {missing_version!r} is not in versions for {name!r}"
+        raise UnknownSchemaVersionError(msg)
+    for declaration in versions:
+        if declaration.patches and declaration.wire_model is not None:
+            msg = (
+                f"Schema version {declaration.label!r} for {name!r} cannot "
+                "combine patches with an explicit wire model"
+            )
+            raise SchemaCompilationError(msg)
+        if declaration.wire_model is not None:
+            _ensure_pydantic_v2_model(declaration.wire_model)
+        _validate_patches(model, declaration.label, declaration.patches)
+    if any(not isinstance(transition, VersionTransition) for transition in transitions):
+        msg = "SchemaFamily.transitions must contain only VersionTransition values"
+        raise SchemaCompilationError(msg)
+    if any(not isinstance(declaration, NestedFamily) for declaration in nested):
+        msg = "SchemaFamily.nested must contain only NestedFamily values"
+        raise SchemaCompilationError(msg)
+    _validate_transition_declarations(name, labels, transitions)
+
+
+def _validate_compilation_boundary(
+    *,
+    name: str,
+    versions: tuple[SchemaVersion, ...],
+    transitions: tuple[VersionTransition, ...],
+    nested: tuple[NestedFamily, ...],
+) -> None:
+    explicit = [version.label for version in versions if version.wire_model is not None]
+    if explicit:
+        msg = (
+            f"Explicit wire models are not supported by the foundation compiler for "
+            f"{name!r}: {explicit!r}"
+        )
+        raise SchemaCompilationError(msg)
+    if nested:
+        msg = f"Explicit nested family compilation is not supported yet for {name!r}"
+        raise SchemaCompilationError(msg)
+    if any(transition.downgrade is not None for transition in transitions):
+        msg = f"Downgrade execution is not supported yet for {name!r}"
+        raise SchemaCompilationError(msg)
+
+
+def _validate_required_field_introductions(
+    *,
+    model: type[BaseModel],
+    name: str,
+    projections: tuple[_VersionProjection, ...],
+    transitions: tuple[VersionTransition, ...],
+) -> None:
+    transitions_by_edge = {
+        (transition.source, transition.target): transition for transition in transitions
+    }
+    for current_name, field_info in model.model_fields.items():
+        if not field_info.is_required():
+            continue
+        for source, target in zip(projections, projections[1:], strict=False):
+            absent_before = source.field(current_name).version_name is None
+            present_after = target.field(current_name).version_name is not None
+            transition = transitions_by_edge.get((source.label, target.label))
+            if (
+                absent_before
+                and present_after
+                and (transition is None or transition.upgrade is None)
+            ):
+                msg = (
+                    f"Required field {current_name!r} is introduced on "
+                    f"{source.label!r} -> {target.label!r} for {name!r} "
+                    "without an upgrade"
+                )
+                raise SchemaCompilationError(msg)
+
+
+def _validate_transition_declarations(
+    family_name: str,
+    labels: tuple[str, ...],
+    transitions: tuple[VersionTransition, ...],
+) -> None:
+    seen: set[tuple[str, str]] = set()
+    for transition in transitions:
+        source = _require_label(transition.source, parameter="transition source")
+        target = _require_label(transition.target, parameter="transition target")
+        if source not in labels or target not in labels:
+            msg = (
+                f"Transition {source!r} -> {target!r} references an unknown version "
+                f"for {family_name!r}"
+            )
+            raise SchemaCompilationError(msg)
+        source_index = labels.index(source)
+        target_index = labels.index(target)
+        if target_index != source_index + 1:
+            msg = (
+                f"Transition {source!r} -> {target!r} for {family_name!r} must connect "
+                "adjacent forward labels"
+            )
+            raise SchemaCompilationError(msg)
+        key = (source, target)
+        if key in seen:
+            msg = f"Transition {source!r} -> {target!r} is declared more than once"
+            raise DuplicateSchemaVersionError(msg)
+        seen.add(key)
+        if transition.upgrade is None and transition.downgrade is None:
+            msg = f"Transition {source!r} -> {target!r} must provide at least one callable"
+            raise SchemaCompilationError(msg)
+        if transition.upgrade is not None and not callable(transition.upgrade):
+            msg = f"Upgrade for {source!r} -> {target!r} must be callable"
+            raise SchemaCompilationError(msg)
+        if transition.downgrade is not None and not callable(transition.downgrade):
+            msg = f"Downgrade for {source!r} -> {target!r} must be callable"
+            raise SchemaCompilationError(msg)
+        if transition.downgrade is None and transition.downgrade_semantics is not None:
+            msg = "downgrade_semantics is forbidden when no downgrade is declared"
+            raise SchemaCompilationError(msg)
+        if transition.downgrade is not None and transition.downgrade_semantics not in (
+            "exact",
+            "lossy",
+        ):
+            msg = "downgrade_semantics must be 'exact' or 'lossy' when a downgrade is declared"
+            raise SchemaCompilationError(msg)
+
+
+def _validate_patches(
+    model_cls: type[BaseModel],
+    version: str,
+    patches: tuple[VersionPatch, ...],
+) -> None:
+    field_names = set(model_cls.model_fields)
+    touched: set[str] = set()
+    removed: set[str] = set()
+    renames: dict[str, str] = {}
+    for patch in patches:
+        if not isinstance(patch, FieldDefault | FieldRemoved | FieldRenamed):
+            msg = f"Unsupported patch declaration for version {version!r}: {patch!r}"
+            raise SchemaCompilationError(msg)
+        current_name = patch.current_name if isinstance(patch, FieldRenamed) else patch.name
+        if not isinstance(current_name, str) or not current_name:
+            msg = f"Patch field names for version {version!r} must be non-empty strings"
+            raise SchemaCompilationError(msg)
+        if current_name not in field_names:
+            msg = f"Patch for version {version!r} references unknown field {current_name!r}"
+            raise SchemaVersionError(msg)
+        if current_name in touched:
+            msg = f"Field {current_name!r} has conflicting patches in version {version!r}"
+            raise SchemaCompilationError(msg)
+        touched.add(current_name)
+        if isinstance(patch, FieldDefault):
+            _validate_field_default(patch, version=version)
+        elif isinstance(patch, FieldRemoved):
+            removed.add(current_name)
+        if isinstance(patch, FieldRenamed):
+            version_name = _require_label(
+                patch.version_name,
+                parameter="rename target",
+            )
+            renames[current_name] = version_name
+
+    output_owners: dict[str, str] = {}
+    for current_name in model_cls.model_fields:
+        if current_name in removed:
+            continue
+        output_name = renames.get(current_name, current_name)
+        existing = output_owners.get(output_name)
+        if existing is not None:
+            msg = (
+                f"Rename target {output_name!r} conflicts in version {version!r}: "
+                f"fields {existing!r} and {current_name!r} share one output name"
+            )
+            raise SchemaVersionError(msg)
+        output_owners[output_name] = current_name
+
+
+def _validate_field_default(patch: FieldDefault, *, version: str) -> None:
+    if not isinstance(patch.has_default, bool):
+        msg = f"Field default for {patch.name!r} in version {version!r} has invalid state"
+        raise SchemaCompilationError(msg)
+    if patch.has_default:
+        if patch.default_factory is not None:
+            msg = (
+                f"Field default for {patch.name!r} in version {version!r} cannot "
+                "combine a value with default_factory"
+            )
+            raise SchemaCompilationError(msg)
+        return
+    if patch.default is not None or not callable(patch.default_factory):
+        msg = (
+            f"Field default factory for {patch.name!r} in version {version!r} "
+            "must be callable and cannot include a direct default"
+        )
+        raise SchemaCompilationError(msg)
+
+
+def _snapshot_field_default(patch: FieldDefault, *, version: str) -> FieldDefault:
+    if not patch.has_default:
+        return patch
+    try:
+        value = deepcopy(patch.default)
+    except Exception as exc:
+        msg = (
+            f"Field default for {patch.name!r} in version {version!r} "
+            "cannot be copied into the compiled plan"
+        )
+        raise SchemaCompilationError(msg) from exc
+    return FieldDefault(name=patch.name, default=value)
+
+
+def _compile_projection(
+    model_cls: type[BaseModel],
+    declaration: SchemaVersion,
+) -> _VersionProjection:
+    removed = {patch.name for patch in declaration.patches if isinstance(patch, FieldRemoved)}
+    defaults = {
+        patch.name: _snapshot_field_default(patch, version=declaration.label)
+        for patch in declaration.patches
+        if isinstance(patch, FieldDefault)
+    }
+    renames = {
+        patch.current_name: patch.version_name
+        for patch in declaration.patches
+        if isinstance(patch, FieldRenamed)
+    }
+    fields = tuple(
+        _CompiledField(
+            current_name=current_name,
+            version_name=None
+            if current_name in removed
+            else renames.get(current_name, current_name),
+            default=defaults.get(current_name),
+        )
+        for current_name in model_cls.model_fields
+    )
+    return _VersionProjection(label=declaration.label, fields=fields)
+
+
+def _compile_transition(
+    source: str,
+    target: str,
+    declaration: VersionTransition | None,
+) -> _CompiledTransition:
+    upgrade = None if declaration is None else declaration.upgrade
+    return _CompiledTransition(
+        source=source,
+        target=target,
+        upgrade_kind="implicit_identity" if upgrade is None else "custom_transition",
+        upgrade=upgrade,
+    )
+
+
+def _generated_model_name(
+    model: type[BaseModel],
+    family_name: str,
+    label: str,
+) -> str:
+    components = (
+        model.__module__,
+        model.__qualname__,
+        family_name,
+        label,
+    )
+    digest = hashlib.sha256()
+    for component in components:
+        encoded = component.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, byteorder="big", signed=False))
+        digest.update(encoded)
+    suffix = digest.hexdigest()[:12]
+    return (
+        f"{_identifier_component(model.__name__)}"
+        f"_{_identifier_component(family_name)}"
+        f"_{_identifier_component(label)}_{suffix}"
+    )
+
+
+def _identifier_component(value: str) -> str:
+    component = "".join(character if character.isalnum() else "_" for character in value)
+    component = component.strip("_") or "value"
+    if component[0].isdigit():
+        component = f"v_{component}"
+    return component

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from functools import reduce
+from operator import or_
+from types import GenericAlias, UnionType
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_args, get_origin
+
+from pydantic import BaseModel, ConfigDict, Field, create_model
+from pydantic_core import PydanticUndefined
+
+from pydantic_versions._compiler import (
+    _CompiledFamily,
+    _CompiledVersion,
+    _generated_model_name,
+    _VersionProjection,
+)
+from pydantic_versions.declarations import VersionedValidation, VersionPath
+from pydantic_versions.exceptions import (
+    InvalidMigrationError,
+    MissingSchemaVersionError,
+    SchemaCompilationError,
+    UnknownSchemaVersionError,
+)
+
+if TYPE_CHECKING:
+    from pydantic_versions.family import SchemaFamily
+
+
+def _runtime_label(value: object, *, family_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        msg = f"Schema version for {family_name!r} must be a non-empty string"
+        raise UnknownSchemaVersionError(msg)
+    return value
+
+
+def _validate_family[T: BaseModel](
+    family: SchemaFamily[T],
+    data: Any,
+    *,
+    version: str | None,
+) -> VersionedValidation[T]:
+    compiled = family._compiled_family()
+    source_version = _detect_version(compiled, data, explicit_version=version)
+    source = compiled.version(source_version)
+    source_model = source.model.model_validate(_source_validation_input(compiled, data))
+    payload = _to_current_names(compiled, source, source_model.model_dump())
+
+    migrations_applied: list[tuple[str, str]] = []
+    source_index = compiled.index(source_version)
+    for transition in compiled.transitions[source_index:]:
+        if transition.upgrade is None:
+            continue
+        migrated = transition.upgrade(dict(payload))
+        if not isinstance(migrated, dict):
+            msg = f"Migration {transition.source!r} -> {transition.target!r} must return a dict"
+            raise InvalidMigrationError(msg)
+        payload = migrated
+        migrations_applied.append((transition.source, transition.target))
+
+    current_model = family.model.model_validate(_current_validation_input(family.model, payload))
+    return VersionedValidation(
+        source_version=source_version,
+        current_version=compiled.current_version,
+        source_model=source_model,
+        current_model=current_model,
+        migrations_applied=tuple(migrations_applied),
+    )
+
+
+def _dump_family[T: BaseModel](
+    family: SchemaFamily[T],
+    *,
+    version: str,
+    data: T | Mapping[str, Any] | None,
+    include_version: bool,
+    dump_kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    compiled = family._compiled_family()
+    requested = _runtime_label(version, family_name=family.name)
+    target = compiled.version(requested)
+
+    if data is None:
+        target_model = target.model()
+    elif isinstance(data, BaseModel):
+        target_model = target.model.model_validate(_to_version_names(target, data.model_dump()))
+    else:
+        target_model = target.model.model_validate(_to_version_names(target, data))
+
+    dumped = target_model.model_dump(**dump_kwargs)
+    if compiled.version_metadata is not None:
+        if include_version:
+            _set_version_field(dumped, compiled.version_metadata.path, requested)
+        else:
+            _remove_version_field(dumped, compiled.version_metadata.path)
+    return dumped
+
+
+def _infer_metadata_owner(
+    model_cls: type[BaseModel],
+    version_path: VersionPath,
+) -> Literal["family", "model"]:
+    if not isinstance(version_path, str):
+        return "family"
+    if version_path in model_cls.model_fields:
+        return "model"
+    if any(field.alias == version_path for field in model_cls.model_fields.values()):
+        return "model"
+    return "family"
+
+
+def _detect_version(
+    compiled: _CompiledFamily,
+    data: Any,
+    *,
+    explicit_version: str | None,
+) -> str:
+    if explicit_version is not None:
+        version = _runtime_label(explicit_version, family_name=compiled.name)
+        compiled.index(version)
+        return version
+    if isinstance(data, Mapping) and compiled.version_metadata is not None:
+        version_value = _get_version_field(data, compiled.version_metadata.path)
+        if version_value is not None:
+            version = _runtime_label(version_value, family_name=compiled.name)
+            compiled.index(version)
+            return version
+    if compiled.missing_version is not None:
+        return compiled.missing_version
+    field_display = (
+        "explicit version"
+        if compiled.version_metadata is None
+        else _version_field_display(compiled.version_metadata.path)
+    )
+    msg = f"Input data for {compiled.name!r} does not include {field_display!r}"
+    raise MissingSchemaVersionError(msg)
+
+
+def _source_validation_input(compiled: _CompiledFamily, data: Any) -> Any:
+    metadata = compiled.version_metadata
+    if (
+        metadata is None
+        or metadata.owner == "model"
+        or isinstance(metadata.path, str)
+        or not isinstance(data, Mapping)
+    ):
+        return data
+    source_data = dict(data)
+    _remove_version_field(source_data, metadata.path)
+    return source_data
+
+
+def _get_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
+    if isinstance(version_field, str):
+        return data.get(version_field)
+    current: Any = data
+    for part in version_field:
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _set_version_field(data: dict[str, Any], version_field: VersionPath, value: str) -> None:
+    if isinstance(version_field, str):
+        data[version_field] = value
+        return
+    current = data
+    for part in version_field[:-1]:
+        next_value = current.get(part)
+        if not isinstance(next_value, dict):
+            next_value = {}
+            current[part] = next_value
+        current = next_value
+    current[version_field[-1]] = value
+
+
+def _remove_version_field(data: dict[str, Any], version_field: VersionPath) -> None:
+    if isinstance(version_field, str):
+        data.pop(version_field, None)
+        return
+    current: Any = data
+    parents: list[tuple[dict[str, Any], str]] = []
+    for part in version_field[:-1]:
+        if not isinstance(current, dict) or not isinstance(current.get(part), dict):
+            return
+        parents.append((current, part))
+        current = current[part]
+    if isinstance(current, dict):
+        current.pop(version_field[-1], None)
+    for parent, part in reversed(parents):
+        child = parent.get(part)
+        if isinstance(child, dict) and not child:
+            parent.pop(part, None)
+
+
+def _version_field_display(version_field: VersionPath) -> str:
+    if isinstance(version_field, str):
+        return version_field
+    return ".".join(version_field)
+
+
+def _version_field_default(
+    family: SchemaFamily[Any],
+    version: str,
+) -> tuple[str, Any] | None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "family" or not isinstance(metadata.path, str):
+        return None
+    if metadata.path in family.model.model_fields:
+        return None
+    return metadata.path, Annotated[str, Field(default=version)]
+
+
+def _build_model_for_projection(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+) -> type[BaseModel]:
+    fields: dict[str, Any] = {}
+    for compiled_field in projection.fields:
+        if compiled_field.version_name is None:
+            continue
+        field_info = family.model.model_fields[compiled_field.current_name]
+        field_dict = field_info.asdict()
+        annotation = _rewrite_annotation(field_dict["annotation"], projection.label, family)
+        attributes = dict(field_dict["attributes"])
+        if compiled_field.version_name != compiled_field.current_name:
+            attributes["alias"] = None
+            attributes["alias_priority"] = None
+            attributes["validation_alias"] = None
+            attributes["serialization_alias"] = None
+        _rewrite_nested_default(
+            attributes,
+            field_dict["annotation"],
+            annotation,
+            family,
+        )
+        if compiled_field.default is not None:
+            if compiled_field.default.has_default:
+                attributes["default"] = deepcopy(compiled_field.default.default)
+                attributes["default_factory"] = None
+            else:
+                attributes["default"] = PydanticUndefined
+                attributes["default_factory"] = compiled_field.default.default_factory
+        fields[compiled_field.version_name] = Annotated[
+            annotation,
+            *field_dict["metadata"],
+            Field(**attributes),
+        ]
+
+    version_field_default = _version_field_default(family, projection.label)
+    if version_field_default is not None:
+        field_name, field_definition = version_field_default
+        if field_name not in fields:
+            fields[field_name] = field_definition
+
+    return create_model(
+        _generated_model_name(family.model, family.name, projection.label),
+        __config__=ConfigDict(**family.model.model_config),
+        __module__=family.model.__module__,
+        **fields,
+    )
+
+
+def _compat_child_family(
+    owner: SchemaFamily[Any],
+    annotation: Any,
+) -> SchemaFamily[Any] | None:
+    if not owner._decorator_created:
+        return None
+    if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+        return None
+    from pydantic_versions.family import _default_family_for_model
+
+    child = _default_family_for_model(annotation)
+    if child is None or not child._decorator_created:
+        return None
+    owner_labels = tuple(version.label for version in owner.versions)
+    child_labels = tuple(version.label for version in child.versions)
+    if child_labels != owner_labels:
+        msg = (
+            f"Decorator child family {child.name!r} must use the exact labels of "
+            f"parent {owner.name!r}; declare an explicit nested mapping instead"
+        )
+        raise SchemaCompilationError(msg)
+    return child
+
+
+def _rewrite_annotation(annotation: Any, version: str, family: SchemaFamily[Any]) -> Any:
+    child = _compat_child_family(family, annotation)
+    if child is not None:
+        return child.model_for(version)
+
+    origin = get_origin(annotation)
+    if origin in (list, tuple, set, frozenset):
+        args = tuple(_rewrite_annotation(arg, version, family) for arg in get_args(annotation))
+        return GenericAlias(origin, args)
+    if origin is dict:
+        args = tuple(_rewrite_annotation(arg, version, family) for arg in get_args(annotation))
+        return GenericAlias(dict, args)
+    if origin in (Union, UnionType):
+        args = tuple(_rewrite_annotation(arg, version, family) for arg in get_args(annotation))
+        return reduce(or_, args)
+    return annotation
+
+
+def _rewrite_nested_default(
+    attributes: dict[str, Any],
+    original_annotation: Any,
+    version_annotation: Any,
+    family: SchemaFamily[Any],
+) -> None:
+    if original_annotation == version_annotation:
+        return
+    child = _compat_child_family(family, original_annotation)
+    if child is None or not (
+        isinstance(version_annotation, type) and issubclass(version_annotation, BaseModel)
+    ):
+        return
+    if attributes.get("default_factory") is original_annotation:
+        attributes["default_factory"] = version_annotation
+        return
+    default = attributes.get("default", PydanticUndefined)
+    if isinstance(default, original_annotation):
+        attributes["default"] = version_annotation.model_validate(
+            default.model_dump(exclude_defaults=True)
+        )
+
+
+def _to_current_names(
+    compiled: _CompiledFamily,
+    version: _CompiledVersion,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(payload)
+    metadata = compiled.version_metadata
+    if metadata is not None:
+        if metadata.owner == "family":
+            _remove_version_field(normalized, metadata.path)
+        else:
+            _set_version_field(normalized, metadata.path, compiled.current_version)
+    renamed = tuple(
+        field
+        for field in version.projection.fields
+        if field.version_name is not None and field.version_name != field.current_name
+    )
+    original = dict(normalized)
+    renamed_values: dict[str, Any] = {}
+    for field in renamed:
+        if field.version_name is None:  # pragma: no cover - narrowed by renamed
+            continue
+        if field.version_name in original:
+            renamed_values[field.current_name] = original[field.version_name]
+    for field in renamed:
+        normalized.pop(field.version_name, None)
+    normalized.update(renamed_values)
+    return normalized
+
+
+def _current_validation_input(
+    model_cls: type[BaseModel], payload: dict[str, Any]
+) -> dict[str, Any]:
+    current_payload = dict(payload)
+    for name, field_info in model_cls.model_fields.items():
+        alias = field_info.alias
+        if alias is not None and name in current_payload and alias not in current_payload:
+            current_payload[alias] = current_payload[name]
+    return current_payload
+
+
+def _to_version_names(version: _CompiledVersion, payload: Any) -> Any:
+    if not isinstance(payload, Mapping):
+        return payload
+    original = dict(payload)
+    versioned = dict(original)
+    renamed = tuple(
+        field
+        for field in version.projection.fields
+        if field.version_name is not None and field.version_name != field.current_name
+    )
+    for field in version.projection.fields:
+        if field.version_name is None:
+            versioned.pop(field.current_name, None)
+    renamed_values: dict[str, Any] = {}
+    for field in renamed:
+        if field.version_name is None:  # pragma: no cover - narrowed by renamed
+            continue
+        if field.current_name in original:
+            renamed_values[field.version_name] = original[field.current_name]
+    for field in renamed:
+        versioned.pop(field.current_name, None)
+    versioned.update(renamed_values)
+    return versioned

--- a/src/pydantic_versions/core.py
+++ b/src/pydantic_versions/core.py
@@ -1,87 +1,76 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field
-from functools import reduce
-from operator import or_
-from types import GenericAlias, UnionType
-from typing import Annotated, Any, Union, get_args, get_origin
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, create_model
-from pydantic_core import PydanticUndefined
+from pydantic import BaseModel
 
+from pydantic_versions._compiler import (
+    _ensure_pydantic_v2_model,
+    _ensure_unique_versions,
+)
+from pydantic_versions._runtime import _infer_metadata_owner, _runtime_label
+from pydantic_versions.declarations import (
+    JsonValue as JsonValue,
+)
+from pydantic_versions.declarations import (
+    MatchingLabels as MatchingLabels,
+)
+from pydantic_versions.declarations import (
+    NestedFamily,
+    SchemaVersion,
+    TransitionFunc,
+    VersionedValidation,
+    VersionMetadata,
+    VersionPath,
+    VersionTransition,
+    _freeze_sequence,
+    _freeze_version_path,
+    _require_label,
+)
+from pydantic_versions.declarations import (
+    TransitionData as TransitionData,
+)
+from pydantic_versions.declarations import (
+    matching_labels as matching_labels,
+)
 from pydantic_versions.exceptions import (
     DuplicateSchemaVersionError,
-    InvalidMigrationError,
-    MissingSchemaVersionError,
-    SchemaVersionError,
+    SchemaCompilationError,
     UnknownSchemaVersionError,
 )
-from pydantic_versions.patches import FieldDefault, FieldRemoved, FieldRenamed, VersionPatch
+from pydantic_versions.family import SchemaFamily, _family_for
+from pydantic_versions.patches import VersionPatch
 
-MigrationFunc = Callable[[dict[str, Any]], dict[str, Any]]
-VersionField = str | tuple[str, ...]
+MigrationFunc = TransitionFunc
+VersionField = VersionPath
 
-
-@dataclass(frozen=True)
-class VersionedValidation[T: BaseModel]:
-    source_version: str
-    current_version: str
-    source_model: BaseModel
-    current_model: T
-    migrations_applied: tuple[tuple[str, str], ...]
+_PENDING_ATTR = "__pydantic_versions_pending__"
 
 
 @dataclass(frozen=True)
 class _VersionSpec:
-    version: str
+    label: str
     patches: tuple[VersionPatch, ...] = ()
 
 
-@dataclass
-class _VersionedSchema:
-    model_cls: type[BaseModel]
-    name: str
-    versions: tuple[str, ...]
-    current: str
-    version_field: VersionField
-    missing_version: str | None
-    patches: dict[str, tuple[VersionPatch, ...]]
-    migrations: dict[tuple[str, str], MigrationFunc] = field(default_factory=dict)
-    generated_models: dict[str, type[BaseModel]] = field(default_factory=dict)
-
-    def index(self, version: str) -> int:
-        try:
-            return self.versions.index(version)
-        except ValueError as exc:
-            msg = f"Unknown schema version {version!r} for {self.name!r}"
-            raise UnknownSchemaVersionError(msg) from exc
-
-
-_REGISTRY: dict[type[BaseModel], _VersionedSchema] = {}
-_PENDING_ATTR = "__pydantic_versions_pending__"
-
-
-def _ensure_pydantic_v2_model(model_cls: object) -> None:
-    if isinstance(model_cls, type) and issubclass(model_cls, BaseModel):
-        return
-    model_name = getattr(model_cls, "__name__", repr(model_cls))
-    msg = f"{model_name!r} must inherit from pydantic.BaseModel from Pydantic v2"
-    raise SchemaVersionError(msg)
-
-
 def schema_version(version: str, *, patches: Sequence[VersionPatch] = ()):
-    return schema_versions([version], patches=patches)
+    return schema_versions((version,), patches=patches)
 
 
 def schema_versions(versions: Sequence[str], *, patches: Sequence[VersionPatch] = ()):
+    version_order = _freeze_sequence(versions, parameter="schema_versions.versions")
+    patch_order = _freeze_sequence(patches, parameter="schema_versions.patches")
+    labels = tuple(
+        _require_label(version, parameter="schema version label") for version in version_order
+    )
+    _ensure_unique_versions(labels, schema_name="pending schema declaration")
+
     def decorator[T: BaseModel](model_cls: type[T]) -> type[T]:
         _ensure_pydantic_v2_model(model_cls)
-        pending: list[_VersionSpec] = list(getattr(model_cls, _PENDING_ATTR, ()))
-        version_order = tuple(str(version) for version in versions)
-        _ensure_unique_versions(version_order, schema_name=model_cls.__name__)
-        for version in version_order:
-            pending.append(_VersionSpec(version=version, patches=tuple(patches)))
+        pending: list[_VersionSpec] = list(model_cls.__dict__.get(_PENDING_ATTR, ()))
+        pending.extend(_VersionSpec(label=label, patches=patch_order) for label in labels)
         setattr(model_cls, _PENDING_ATTR, tuple(pending))
         return model_cls
 
@@ -93,419 +82,114 @@ def versioned_schema(
     name: str,
     versions: Sequence[str],
     current: str,
-    version_field: VersionField = "schema_version",
+    version_field: VersionPath = "schema_version",
     missing_version: str | None = None,
+    metadata_owner: Literal["family", "model"] | None = None,
+    transitions: Sequence[VersionTransition] = (),
+    nested: Sequence[NestedFamily] = (),
 ):
+    version_order = _freeze_sequence(versions, parameter="versioned_schema.versions")
+    labels = tuple(
+        _require_label(version, parameter="schema version label") for version in version_order
+    )
+    _ensure_unique_versions(labels, schema_name=name)
+    current_version = _require_label(current, parameter="current")
+    if current_version not in labels:
+        msg = f"Current schema version {current_version!r} is not in versions for {name!r}"
+        raise UnknownSchemaVersionError(msg)
+    if not labels or current_version != labels[-1]:
+        msg = f"Current schema version for {name!r} must be the final declared label"
+        raise SchemaCompilationError(msg)
+    normalized_path = _freeze_version_path(version_field, parameter="version_field")
+    transition_order = _freeze_sequence(
+        transitions,
+        parameter="versioned_schema.transitions",
+    )
+    nested_order = _freeze_sequence(nested, parameter="versioned_schema.nested")
+
     def decorator[T: BaseModel](model_cls: type[T]) -> type[T]:
         _ensure_pydantic_v2_model(model_cls)
-        version_order = tuple(str(version) for version in versions)
-        _ensure_unique_versions(version_order, schema_name=name)
-        normalized_version_field = _normalize_version_field(version_field)
-        current_version = str(current)
-        if current_version not in version_order:
-            msg = f"Current schema version {current_version!r} is not in versions for {name!r}"
-            raise UnknownSchemaVersionError(msg)
-        if missing_version is not None and str(missing_version) not in version_order:
-            msg = f"Missing-version fallback {missing_version!r} is not in versions for {name!r}"
-            raise UnknownSchemaVersionError(msg)
-
-        pending = tuple(getattr(model_cls, _PENDING_ATTR, ()))
-        patch_map: dict[str, tuple[VersionPatch, ...]] = dict.fromkeys(version_order, ())
+        pending = tuple(model_cls.__dict__.get(_PENDING_ATTR, ()))
+        patches_by_label: dict[str, tuple[VersionPatch, ...]] = dict.fromkeys(labels, ())
+        declared_patch_labels: set[str] = set()
         for spec in pending:
-            if spec.version not in version_order:
-                msg = f"Patch schema version {spec.version!r} is not in versions for {name!r}"
+            if spec.label not in labels:
+                msg = f"Patch schema version {spec.label!r} is not in versions for {name!r}"
                 raise UnknownSchemaVersionError(msg)
-            if patch_map[spec.version]:
-                msg = f"Schema version {spec.version!r} is declared more than once for {name!r}"
+            if spec.label in declared_patch_labels:
+                msg = f"Schema version {spec.label!r} is declared more than once for {name!r}"
                 raise DuplicateSchemaVersionError(msg)
-            _validate_patches(model_cls, spec.version, spec.patches)
-            patch_map[spec.version] = spec.patches
+            declared_patch_labels.add(spec.label)
+            patches_by_label[spec.label] = spec.patches
 
-        _REGISTRY[model_cls] = _VersionedSchema(
-            model_cls=model_cls,
-            name=name,
-            versions=version_order,
-            current=current_version,
-            version_field=normalized_version_field,
-            missing_version=None if missing_version is None else str(missing_version),
-            patches=patch_map,
+        owner = metadata_owner
+        if owner is None:
+            owner = _infer_metadata_owner(model_cls, normalized_path)
+        declarations = tuple(
+            SchemaVersion(label=label, patches=patches_by_label[label]) for label in labels
         )
+        family = SchemaFamily(
+            model=model_cls,
+            name=name,
+            versions=declarations,
+            transitions=transition_order,
+            nested=nested_order,
+            version_metadata=VersionMetadata(path=normalized_path, owner=owner),
+            missing_version=missing_version,
+        )
+        family._decorator_created = True
+        family.as_default()
+        if _PENDING_ATTR in model_cls.__dict__:
+            delattr(model_cls, _PENDING_ATTR)
         return model_cls
 
     return decorator
 
 
-def migration(model_cls: type[BaseModel], from_version: str, to_version: str):
-    schema = _schema_for(model_cls)
-    source = str(from_version)
-    target = str(to_version)
-    source_index = schema.index(source)
-    target_index = schema.index(target)
-    if source_index >= target_index:
-        msg = f"Migration {source!r} -> {target!r} must move forward for {schema.name!r}"
-        raise InvalidMigrationError(msg)
+def migration[T: BaseModel](
+    subject: type[T] | SchemaFamily[T],
+    from_version: str,
+    to_version: str,
+):
+    family = _family_for(subject)
+    source = _runtime_label(from_version, family_name=family.name)
+    target = _runtime_label(to_version, family_name=family.name)
+    family._ensure_legacy_transition_allowed(source, target)
 
-    def decorator(func: MigrationFunc) -> MigrationFunc:
-        key = (source, target)
-        if key in schema.migrations:
-            msg = f"Migration {source!r} -> {target!r} is already registered for {schema.name!r}"
-            raise DuplicateSchemaVersionError(msg)
-        schema.migrations[key] = func
+    def decorator(func: TransitionFunc) -> TransitionFunc:
+        family._register_legacy_transition(source, target, func)
         return func
 
     return decorator
 
 
-def model_for_version[T: BaseModel](model_cls: type[T], version: str) -> type[BaseModel]:
-    schema = _schema_for(model_cls)
-    requested = str(version)
-    schema.index(requested)
-    if requested not in schema.generated_models:
-        schema.generated_models[requested] = _build_model_for_version(schema, requested)
-    return schema.generated_models[requested]
+def model_for_version[T: BaseModel](
+    subject: type[T] | SchemaFamily[T],
+    version: str,
+) -> type[BaseModel]:
+    return _family_for(subject).model_for(version)
 
 
 def validate_versioned[T: BaseModel](
-    model_cls: type[T],
+    subject: type[T] | SchemaFamily[T],
     data: Any,
     *,
     version: str | None = None,
 ) -> VersionedValidation[T]:
-    schema = _schema_for(model_cls)
-    source_version = _detect_version(schema, data, explicit_version=version)
-    source_model_cls = model_for_version(model_cls, source_version)
-    source_model = source_model_cls.model_validate(_source_validation_input(schema, data))
-    payload = _to_current_names(schema, source_version, source_model.model_dump())
-
-    migrations_applied: list[tuple[str, str]] = []
-    source_index = schema.index(source_version)
-    current_index = schema.index(schema.current)
-    for index in range(source_index, current_index):
-        step = (schema.versions[index], schema.versions[index + 1])
-        migrate = schema.migrations.get(step)
-        if migrate is None:
-            continue
-        migrated = migrate(dict(payload))
-        if not isinstance(migrated, dict):
-            msg = f"Migration {step[0]!r} -> {step[1]!r} must return a dict"
-            raise InvalidMigrationError(msg)
-        payload = migrated
-        migrations_applied.append(step)
-
-    current_model = model_cls.model_validate(_current_validation_input(model_cls, payload))
-    return VersionedValidation(
-        source_version=source_version,
-        current_version=schema.current,
-        source_model=source_model,
-        current_model=current_model,
-        migrations_applied=tuple(migrations_applied),
-    )
+    return _family_for(subject).validate(data, version=version)
 
 
 def dump_versioned[T: BaseModel](
-    model_cls: type[T],
+    subject: type[T] | SchemaFamily[T],
     *,
     version: str,
-    data: Any = None,
+    data: T | Mapping[str, Any] | None = None,
     include_version: bool = True,
     **dump_kwargs: Any,
 ) -> dict[str, Any]:
-    schema = _schema_for(model_cls)
-    requested = str(version)
-    schema.index(requested)
-    target_model_cls = model_for_version(model_cls, requested)
-
-    if data is None:
-        target_model = target_model_cls()
-    elif isinstance(data, BaseModel):
-        target_model = target_model_cls.model_validate(
-            _to_version_names(schema, requested, data.model_dump())
-        )
-    else:
-        target_model = target_model_cls.model_validate(_to_version_names(schema, requested, data))
-
-    dumped = target_model.model_dump(**dump_kwargs)
-    if include_version:
-        _set_version_field(dumped, schema.version_field, requested)
-    else:
-        _remove_version_field(dumped, schema.version_field)
-    return dumped
-
-
-def _schema_for(model_cls: type[BaseModel]) -> _VersionedSchema:
-    try:
-        return _REGISTRY[model_cls]
-    except KeyError as exc:
-        msg = f"{model_cls.__name__!r} is not registered with @versioned_schema"
-        raise SchemaVersionError(msg) from exc
-
-
-def _ensure_unique_versions(versions: tuple[str, ...], *, schema_name: str) -> None:
-    duplicates = {version for version in versions if versions.count(version) > 1}
-    if duplicates:
-        msg = f"Duplicate schema versions for {schema_name!r}: {sorted(duplicates)!r}"
-        raise DuplicateSchemaVersionError(msg)
-
-
-def _validate_patches(
-    model_cls: type[BaseModel],
-    version: str,
-    patches: tuple[VersionPatch, ...],
-) -> None:
-    field_names = set(model_cls.model_fields)
-    output_names = set(field_names)
-    for patch in patches:
-        if isinstance(patch, FieldDefault | FieldRemoved):
-            if patch.name not in field_names:
-                msg = f"Patch for version {version!r} references unknown field {patch.name!r}"
-                raise SchemaVersionError(msg)
-        if isinstance(patch, FieldRenamed):
-            if patch.current_name not in field_names:
-                msg = f"Rename for version {version!r} references unknown field {patch.current_name!r}"
-                raise SchemaVersionError(msg)
-            output_names.discard(patch.current_name)
-            if patch.version_name in output_names:
-                msg = f"Rename target {patch.version_name!r} conflicts in version {version!r}"
-                raise SchemaVersionError(msg)
-            output_names.add(patch.version_name)
-
-
-def _detect_version(
-    schema: _VersionedSchema,
-    data: Any,
-    *,
-    explicit_version: str | None,
-) -> str:
-    if explicit_version is not None:
-        version = str(explicit_version)
-        schema.index(version)
-        return version
-    if isinstance(data, Mapping):
-        version_value = _get_version_field(data, schema.version_field)
-        if version_value is not None:
-            version = str(version_value)
-            schema.index(version)
-            return version
-    if schema.missing_version is not None:
-        return schema.missing_version
-    msg = f"Input data for {schema.name!r} does not include {_version_field_display(schema.version_field)!r}"
-    raise MissingSchemaVersionError(msg)
-
-
-def _source_validation_input(schema: _VersionedSchema, data: Any) -> Any:
-    if isinstance(schema.version_field, str) or not isinstance(data, Mapping):
-        return data
-    source_data = dict(data)
-    _remove_version_field(source_data, schema.version_field)
-    return source_data
-
-
-def _normalize_version_field(version_field: VersionField) -> VersionField:
-    if isinstance(version_field, str):
-        if not version_field:
-            msg = "version_field cannot be empty"
-            raise SchemaVersionError(msg)
-        return version_field
-    if not version_field or any(not part for part in version_field):
-        msg = "version_field path must contain non-empty field names"
-        raise SchemaVersionError(msg)
-    return tuple(str(part) for part in version_field)
-
-
-def _get_version_field(data: Mapping[str, Any], version_field: VersionField) -> Any:
-    if isinstance(version_field, str):
-        return data.get(version_field)
-    current: Any = data
-    for part in version_field:
-        if not isinstance(current, Mapping) or part not in current:
-            return None
-        current = current[part]
-    return current
-
-
-def _set_version_field(data: dict[str, Any], version_field: VersionField, value: str) -> None:
-    if isinstance(version_field, str):
-        data[version_field] = value
-        return
-    current = data
-    for part in version_field[:-1]:
-        next_value = current.get(part)
-        if not isinstance(next_value, dict):
-            next_value = {}
-            current[part] = next_value
-        current = next_value
-    current[version_field[-1]] = value
-
-
-def _remove_version_field(data: dict[str, Any], version_field: VersionField) -> None:
-    if isinstance(version_field, str):
-        data.pop(version_field, None)
-        return
-    current: Any = data
-    parents: list[tuple[dict[str, Any], str]] = []
-    for part in version_field[:-1]:
-        if not isinstance(current, dict) or not isinstance(current.get(part), dict):
-            return
-        parents.append((current, part))
-        current = current[part]
-    if isinstance(current, dict):
-        current.pop(version_field[-1], None)
-    for parent, part in reversed(parents):
-        child = parent.get(part)
-        if isinstance(child, dict) and not child:
-            parent.pop(part, None)
-
-
-def _version_field_display(version_field: VersionField) -> str:
-    if isinstance(version_field, str):
-        return version_field
-    return ".".join(version_field)
-
-
-def _version_field_default(schema: _VersionedSchema, version: str) -> tuple[str, Any] | None:
-    if not isinstance(schema.version_field, str):
-        return None
-    version_field = schema.version_field
-    if version_field in schema.model_cls.model_fields:
-        return None
-    return version_field, Annotated[str, Field(default=version)]
-
-
-def _build_model_for_version(schema: _VersionedSchema, version: str) -> type[BaseModel]:
-    removed = {patch.name for patch in schema.patches[version] if isinstance(patch, FieldRemoved)}
-    defaults = {
-        patch.name: patch for patch in schema.patches[version] if isinstance(patch, FieldDefault)
-    }
-    renames = {
-        patch.current_name: patch.version_name
-        for patch in schema.patches[version]
-        if isinstance(patch, FieldRenamed)
-    }
-
-    fields: dict[str, Any] = {}
-    for current_name, field_info in schema.model_cls.model_fields.items():
-        if current_name in removed:
-            continue
-        version_name = renames.get(current_name, current_name)
-        field_dict = field_info.asdict()
-        annotation = _rewrite_annotation(field_dict["annotation"], version)
-        attributes = dict(field_dict["attributes"])
-        if current_name in renames:
-            attributes["alias"] = None
-            attributes["alias_priority"] = None
-            attributes["validation_alias"] = None
-            attributes["serialization_alias"] = None
-        _rewrite_nested_default(attributes, field_dict["annotation"], annotation)
-        if current_name in defaults:
-            default_patch = defaults[current_name]
-            if default_patch.has_default:
-                attributes["default"] = default_patch.default
-                attributes["default_factory"] = None
-            else:
-                attributes["default"] = PydanticUndefined
-                attributes["default_factory"] = default_patch.default_factory
-        fields[version_name] = Annotated[
-            annotation,
-            *field_dict["metadata"],
-            Field(**attributes),
-        ]
-
-    version_field_default = _version_field_default(schema, version)
-    if version_field_default is not None:
-        field_name, field_definition = version_field_default
-        if field_name not in fields:
-            fields[field_name] = field_definition
-
-    model_name = f"{schema.model_cls.__name__}Schema{_safe_model_suffix(version)}"
-    return create_model(
-        model_name,
-        __config__=ConfigDict(**schema.model_cls.model_config),
-        __module__=schema.model_cls.__module__,
-        **fields,
+    return _family_for(subject).dump(
+        version=version,
+        data=data,
+        include_version=include_version,
+        **dump_kwargs,
     )
-
-
-def _rewrite_annotation(annotation: Any, version: str) -> Any:
-    if (
-        isinstance(annotation, type)
-        and issubclass(annotation, BaseModel)
-        and annotation in _REGISTRY
-    ):
-        return model_for_version(annotation, version)
-
-    origin = get_origin(annotation)
-    if origin in (list, tuple, set, frozenset):
-        args = tuple(_rewrite_annotation(arg, version) for arg in get_args(annotation))
-        return GenericAlias(origin, args)
-    if origin is dict:
-        args = tuple(_rewrite_annotation(arg, version) for arg in get_args(annotation))
-        return GenericAlias(dict, args)
-    if origin in (Union, UnionType):
-        args = tuple(_rewrite_annotation(arg, version) for arg in get_args(annotation))
-        return reduce(or_, args)
-    return annotation
-
-
-def _rewrite_nested_default(
-    attributes: dict[str, Any],
-    original_annotation: Any,
-    version_annotation: Any,
-) -> None:
-    if original_annotation == version_annotation:
-        return
-    if not (
-        isinstance(original_annotation, type)
-        and issubclass(original_annotation, BaseModel)
-        and original_annotation in _REGISTRY
-        and isinstance(version_annotation, type)
-        and issubclass(version_annotation, BaseModel)
-    ):
-        return
-    if attributes.get("default_factory") is original_annotation:
-        attributes["default_factory"] = version_annotation
-        return
-    default = attributes.get("default", PydanticUndefined)
-    if isinstance(default, original_annotation):
-        attributes["default"] = version_annotation.model_validate(
-            default.model_dump(exclude_defaults=True)
-        )
-
-
-def _to_current_names(
-    schema: _VersionedSchema,
-    version: str,
-    payload: dict[str, Any],
-) -> dict[str, Any]:
-    normalized = dict(payload)
-    _remove_version_field(normalized, schema.version_field)
-    for patch in schema.patches[version]:
-        if isinstance(patch, FieldRenamed) and patch.version_name in normalized:
-            normalized[patch.current_name] = normalized.pop(patch.version_name)
-    return normalized
-
-
-def _current_validation_input(
-    model_cls: type[BaseModel], payload: dict[str, Any]
-) -> dict[str, Any]:
-    current_payload = dict(payload)
-    for name, field_info in model_cls.model_fields.items():
-        alias = field_info.alias
-        if alias is not None and name in current_payload and alias not in current_payload:
-            current_payload[alias] = current_payload[name]
-    return current_payload
-
-
-def _to_version_names(schema: _VersionedSchema, version: str, payload: Any) -> Any:
-    if not isinstance(payload, Mapping):
-        return payload
-    versioned = dict(payload)
-    for patch in schema.patches[version]:
-        if isinstance(patch, FieldRemoved):
-            versioned.pop(patch.name, None)
-        if isinstance(patch, FieldRenamed) and patch.current_name in versioned:
-            versioned[patch.version_name] = versioned.pop(patch.current_name)
-    return versioned
-
-
-def _safe_model_suffix(version: str) -> str:
-    return "".join(char if char.isalnum() else "_" for char in version).title()

--- a/src/pydantic_versions/declarations.py
+++ b/src/pydantic_versions/declarations.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel
+
+from pydantic_versions.exceptions import SchemaCompilationError
+from pydantic_versions.patches import VersionPatch
+
+if TYPE_CHECKING:
+    from pydantic_versions.family import SchemaFamily
+
+type TransitionData = dict[str, Any]
+type TransitionFunc = Callable[[TransitionData], TransitionData]
+type VersionPath = str | tuple[str, ...]
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+
+type DowngradeSemantics = Literal["exact", "lossy"]
+
+
+def _freeze_sequence[T](value: Sequence[T], *, parameter: str) -> tuple[T, ...]:
+    if isinstance(value, str | bytes) or not isinstance(value, Sequence):
+        msg = f"{parameter} must be a sequence, not {type(value).__name__}"
+        raise SchemaCompilationError(msg)
+    return tuple(value)
+
+
+def _freeze_version_path(path: VersionPath, *, parameter: str) -> VersionPath:
+    if isinstance(path, str):
+        if not path:
+            msg = f"{parameter} cannot be empty"
+            raise SchemaCompilationError(msg)
+        return path
+    if not isinstance(path, tuple) or not path:
+        msg = f"{parameter} must be a non-empty string or tuple of strings"
+        raise SchemaCompilationError(msg)
+    if any(not isinstance(part, str) or not part for part in path):
+        msg = f"{parameter} must contain only non-empty strings"
+        raise SchemaCompilationError(msg)
+    return tuple(path)
+
+
+def _require_label(value: object, *, parameter: str) -> str:
+    if not isinstance(value, str) or not value:
+        msg = f"{parameter} must be a non-empty string"
+        raise SchemaCompilationError(msg)
+    return value
+
+
+@dataclass(frozen=True)
+class VersionedValidation[T: BaseModel]:
+    source_version: str
+    current_version: str
+    source_model: BaseModel
+    current_model: T
+    migrations_applied: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class SchemaVersion:
+    label: str
+    patches: tuple[VersionPatch, ...] = ()
+    wire_model: type[BaseModel] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "patches",
+            _freeze_sequence(self.patches, parameter="SchemaVersion.patches"),
+        )
+
+
+@dataclass(frozen=True)
+class VersionTransition:
+    source: str
+    target: str
+    upgrade: TransitionFunc | None = None
+    downgrade: TransitionFunc | None = None
+    downgrade_semantics: DowngradeSemantics | None = None
+
+
+@dataclass(frozen=True)
+class VersionMetadata:
+    path: VersionPath = "schema_version"
+    owner: Literal["family", "model"] = "family"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "path",
+            _freeze_version_path(self.path, parameter="VersionMetadata.path"),
+        )
+        if self.owner not in ("family", "model"):
+            msg = "VersionMetadata.owner must be 'family' or 'model'"
+            raise SchemaCompilationError(msg)
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        path: JsonValue = self.path if isinstance(self.path, str) else list(self.path)
+        return {"path": path, "owner": self.owner}
+
+
+_DEFAULT_VERSION_METADATA = VersionMetadata()
+
+
+@dataclass(frozen=True)
+class MatchingLabels:
+    pass
+
+
+@dataclass(frozen=True)
+class NestedFamily:
+    path: VersionPath
+    family: SchemaFamily[Any] | Callable[[], SchemaFamily[Any]]
+    versions: Mapping[str, str] | MatchingLabels
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "path",
+            _freeze_version_path(self.path, parameter="NestedFamily.path"),
+        )
+        if isinstance(self.versions, MatchingLabels):
+            return
+        if not isinstance(self.versions, Mapping):
+            msg = "NestedFamily.versions must be a mapping or matching_labels()"
+            raise SchemaCompilationError(msg)
+        copied: dict[str, str] = {}
+        for parent, child in self.versions.items():
+            copied[_require_label(parent, parameter="nested parent label")] = _require_label(
+                child,
+                parameter="nested child label",
+            )
+        object.__setattr__(self, "versions", MappingProxyType(copied))
+
+
+def matching_labels() -> MatchingLabels:
+    return MatchingLabels()

--- a/src/pydantic_versions/exceptions.py
+++ b/src/pydantic_versions/exceptions.py
@@ -5,6 +5,14 @@ class SchemaVersionError(Exception):
     """Base exception for schema version configuration and runtime errors."""
 
 
+class SchemaCompilationError(SchemaVersionError):
+    """Raised when a schema-family declaration cannot be compiled safely."""
+
+
+class SchemaFamilySelectionError(SchemaVersionError):
+    """Raised when a model-only call has no unambiguous explicit default family."""
+
+
 class MissingSchemaVersionError(SchemaVersionError):
     """Raised when a schema version cannot be discovered for input data."""
 

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from threading import RLock
+from typing import Any, Self
+
+from pydantic import BaseModel
+
+from pydantic_versions._compiler import (
+    _compile_projection,
+    _compile_transition,
+    _CompiledFamily,
+    _CompiledVersion,
+    _ensure_pydantic_v2_model,
+    _validate_compilation_boundary,
+    _validate_family_declarations,
+    _validate_required_field_introductions,
+)
+from pydantic_versions._runtime import (
+    _build_model_for_projection,
+    _dump_family,
+    _runtime_label,
+    _validate_family,
+)
+from pydantic_versions.declarations import (
+    _DEFAULT_VERSION_METADATA,
+    NestedFamily,
+    SchemaVersion,
+    TransitionFunc,
+    VersionedValidation,
+    VersionMetadata,
+    VersionTransition,
+    _freeze_sequence,
+    _require_label,
+)
+from pydantic_versions.exceptions import (
+    DuplicateSchemaVersionError,
+    InvalidMigrationError,
+    SchemaCompilationError,
+    SchemaFamilySelectionError,
+    UnknownSchemaVersionError,
+)
+
+_DEFAULT_FAMILIES: dict[type[BaseModel], SchemaFamily[Any]] = {}
+_FAMILY_LOCK = RLock()
+
+
+class SchemaFamily[T: BaseModel]:
+    __slots__ = (
+        "_compiled",
+        "_compiling",
+        "_decorator_created",
+        "_missing_version",
+        "_model",
+        "_name",
+        "_nested",
+        "_transitions",
+        "_version_metadata",
+        "_versions",
+    )
+
+    def __init__(
+        self,
+        *,
+        model: type[T],
+        name: str,
+        versions: Sequence[SchemaVersion],
+        transitions: Sequence[VersionTransition] = (),
+        nested: Sequence[NestedFamily] = (),
+        version_metadata: VersionMetadata | None = _DEFAULT_VERSION_METADATA,
+        missing_version: str | None = None,
+    ) -> None:
+        _ensure_pydantic_v2_model(model)
+        self._model = model
+        self._name = _require_label(name, parameter="SchemaFamily.name")
+        self._versions = _freeze_sequence(versions, parameter="SchemaFamily.versions")
+        self._transitions = _freeze_sequence(
+            transitions,
+            parameter="SchemaFamily.transitions",
+        )
+        self._nested = _freeze_sequence(nested, parameter="SchemaFamily.nested")
+        if version_metadata is not None and not isinstance(version_metadata, VersionMetadata):
+            msg = "version_metadata must be VersionMetadata or None"
+            raise SchemaCompilationError(msg)
+        self._version_metadata = version_metadata
+        if missing_version is not None:
+            missing_version = _require_label(missing_version, parameter="missing_version")
+        self._missing_version = missing_version
+        self._decorator_created = False
+        self._compiled: _CompiledFamily | None = None
+        self._compiling = False
+        self._validate_declarations()
+
+    @property
+    def model(self) -> type[T]:
+        return self._model
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def versions(self) -> tuple[SchemaVersion, ...]:
+        return self._versions
+
+    @property
+    def transitions(self) -> tuple[VersionTransition, ...]:
+        return self._transitions
+
+    @property
+    def nested(self) -> tuple[NestedFamily, ...]:
+        return self._nested
+
+    @property
+    def version_metadata(self) -> VersionMetadata | None:
+        return self._version_metadata
+
+    @property
+    def missing_version(self) -> str | None:
+        return self._missing_version
+
+    @property
+    def current_version(self) -> str:
+        return self._versions[-1].label
+
+    def compile(self) -> Self:
+        with _FAMILY_LOCK:
+            if self._compiled is not None:
+                return self
+            if self._compiling:
+                msg = f"Recursive schema-family compilation is not yet supported for {self.name!r}"
+                raise SchemaCompilationError(msg)
+            self._compiling = True
+            try:
+                self._validate_declarations()
+                _validate_compilation_boundary(
+                    name=self.name,
+                    versions=self.versions,
+                    transitions=self.transitions,
+                    nested=self.nested,
+                )
+                projections = tuple(
+                    _compile_projection(self.model, declaration) for declaration in self.versions
+                )
+                _validate_required_field_introductions(
+                    model=self.model,
+                    name=self.name,
+                    projections=projections,
+                    transitions=self.transitions,
+                )
+                compiled_versions = tuple(
+                    _CompiledVersion(
+                        projection=projection,
+                        model=_build_model_for_projection(self, projection),
+                    )
+                    for projection in projections
+                )
+                explicit = {
+                    (transition.source, transition.target): transition
+                    for transition in self.transitions
+                }
+                compiled_transitions = tuple(
+                    _compile_transition(source, target, explicit.get((source, target)))
+                    for source, target in zip(
+                        (version.label for version in self.versions),
+                        (version.label for version in self.versions[1:]),
+                        strict=False,
+                    )
+                )
+                self._compiled = _CompiledFamily(
+                    model=self.model,
+                    name=self.name,
+                    versions=compiled_versions,
+                    transitions=compiled_transitions,
+                    version_metadata=self.version_metadata,
+                    missing_version=self.missing_version,
+                )
+            finally:
+                self._compiling = False
+        return self
+
+    def as_default(self) -> Self:
+        with _FAMILY_LOCK:
+            existing = _DEFAULT_FAMILIES.get(self.model)
+            if existing is None:
+                _DEFAULT_FAMILIES[self.model] = self
+            elif existing is not self:
+                msg = (
+                    f"{self.model.__name__!r} already has explicit default family "
+                    f"{existing.name!r}; cannot attach {self.name!r}"
+                )
+                raise SchemaFamilySelectionError(msg)
+        return self
+
+    def model_for(self, version: str) -> type[BaseModel]:
+        requested = _runtime_label(version, family_name=self.name)
+        return self._compiled_family().version(requested).model
+
+    def validate(self, data: Any, *, version: str | None = None) -> VersionedValidation[T]:
+        return _validate_family(self, data, version=version)
+
+    def defaults_for(
+        self,
+        *,
+        version: str,
+        include_version: bool = True,
+        **dump_kwargs: Any,
+    ) -> dict[str, Any]:
+        return self.dump(
+            version=version,
+            include_version=include_version,
+            **dump_kwargs,
+        )
+
+    def dump(
+        self,
+        *,
+        version: str,
+        data: T | Mapping[str, Any] | None = None,
+        include_version: bool = True,
+        **dump_kwargs: Any,
+    ) -> dict[str, Any]:
+        return _dump_family(
+            self,
+            version=version,
+            data=data,
+            include_version=include_version,
+            dump_kwargs=dump_kwargs,
+        )
+
+    def _compiled_family(self) -> _CompiledFamily:
+        self.compile()
+        if self._compiled is None:  # pragma: no cover - compile() publishes atomically
+            msg = f"Schema family {self.name!r} did not publish compiled state"
+            raise SchemaCompilationError(msg)
+        return self._compiled
+
+    def _validate_declarations(self) -> None:
+        _validate_family_declarations(
+            model=self.model,
+            name=self.name,
+            versions=self.versions,
+            transitions=self.transitions,
+            nested=self.nested,
+            missing_version=self.missing_version,
+        )
+
+    def _register_legacy_transition(
+        self,
+        source: str,
+        target: str,
+        upgrade: TransitionFunc,
+    ) -> None:
+        with _FAMILY_LOCK:
+            self._ensure_legacy_transition_allowed(source, target)
+            candidate = VersionTransition(source=source, target=target, upgrade=upgrade)
+            self._transitions = (*self.transitions, candidate)
+
+    def _ensure_legacy_transition_allowed(self, source: str, target: str) -> None:
+        with _FAMILY_LOCK:
+            if self._compiled is not None or self._compiling:
+                msg = f"Cannot register migration after {self.name!r} has been compiled"
+                raise InvalidMigrationError(msg)
+            labels = tuple(version.label for version in self.versions)
+            try:
+                source_index = labels.index(source)
+                target_index = labels.index(target)
+            except ValueError as exc:
+                msg = f"Unknown migration edge {source!r} -> {target!r} for {self.name!r}"
+                raise UnknownSchemaVersionError(msg) from exc
+            if target_index != source_index + 1:
+                msg = (
+                    f"Migration {source!r} -> {target!r} must connect adjacent "
+                    f"forward labels for {self.name!r}"
+                )
+                raise InvalidMigrationError(msg)
+            if any(
+                transition.source == source and transition.target == target
+                for transition in self.transitions
+            ):
+                msg = f"Migration {source!r} -> {target!r} is already registered for {self.name!r}"
+                raise DuplicateSchemaVersionError(msg)
+
+
+def _default_family_for_model(model: type[BaseModel]) -> SchemaFamily[Any] | None:
+    return _DEFAULT_FAMILIES.get(model)
+
+
+def _family_for[T: BaseModel](subject: type[T] | SchemaFamily[T]) -> SchemaFamily[T]:
+    if isinstance(subject, SchemaFamily):
+        return subject
+    _ensure_pydantic_v2_model(subject)
+    family = _DEFAULT_FAMILIES.get(subject)
+    if family is None:
+        msg = (
+            f"{subject.__name__!r} has no explicit default schema family; pass a "
+            "SchemaFamily or call family.as_default() during application configuration"
+        )
+        raise SchemaFamilySelectionError(msg)
+    return family

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-module fixtures for public consumer-contract tests."""

--- a/tests/fixtures/external_family/__init__.py
+++ b/tests/fixtures/external_family/__init__.py
@@ -1,0 +1,1 @@
+"""External schema-family fixture package."""

--- a/tests/fixtures/external_family/models.py
+++ b/tests/fixtures/external_family/models.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ExternalConfig(BaseModel):
+    timeout: float = 10.0
+    retries: int = 3

--- a/tests/fixtures/external_family/schema_history.py
+++ b/tests/fixtures/external_family/schema_history.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pydantic_versions import SchemaFamily, SchemaVersion, field_default
+from tests.fixtures.external_family.models import ExternalConfig
+
+EXTERNAL_CONFIG_SCHEMA = SchemaFamily(
+    model=ExternalConfig,
+    name="external_config",
+    versions=(
+        SchemaVersion("1", patches=(field_default("timeout", 5.0),)),
+        SchemaVersion("2"),
+    ),
+)

--- a/tests/typing/schema_family_contract.py
+++ b/tests/typing/schema_family_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, assert_type
+
+from pydantic import BaseModel
+
+from pydantic_versions import (
+    SchemaCompilationError,
+    SchemaFamily,
+    SchemaFamilySelectionError,
+    SchemaVersion,
+    VersionedValidation,
+    VersionPatch,
+    VersionTransition,
+    dump_versioned,
+    field_default,
+    model_for_version,
+    validate_versioned,
+)
+
+
+class AppConfig(BaseModel):
+    timeout: float = 10.0
+
+
+def upgrade_v1(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+patch: VersionPatch = field_default("timeout", 5.0)
+family: SchemaFamily[AppConfig] = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion("1", patches=(patch,)),
+        SchemaVersion("2"),
+    ),
+    transitions=(VersionTransition("1", "2", upgrade=upgrade_v1),),
+)
+
+assert_type(family.compile(), SchemaFamily[AppConfig])
+assert_type(family.as_default(), SchemaFamily[AppConfig])
+assert_type(family.model_for("1"), type[BaseModel])
+assert_type(family.validate({"schema_version": "1"}), VersionedValidation[AppConfig])
+assert_type(model_for_version(family, "1"), type[BaseModel])
+assert_type(
+    validate_versioned(family, {"schema_version": "1"}),
+    VersionedValidation[AppConfig],
+)
+assert_type(family.dump(version="1"), dict[str, Any])
+assert_type(dump_versioned(family, version="1"), dict[str, Any])
+
+compilation_error: type[Exception] = SchemaCompilationError
+selection_error: type[Exception] = SchemaFamilySelectionError

--- a/tests/unit/test_schema_family.py
+++ b/tests/unit/test_schema_family.py
@@ -1,0 +1,850 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from threading import Barrier
+from typing import Any, cast
+
+import pytest
+from pydantic import BaseModel, Field
+
+from pydantic_versions import (
+    DuplicateSchemaVersionError,
+    FieldDefault,
+    InvalidMigrationError,
+    NestedFamily,
+    SchemaCompilationError,
+    SchemaFamily,
+    SchemaFamilySelectionError,
+    SchemaVersion,
+    SchemaVersionError,
+    UnknownSchemaVersionError,
+    VersionMetadata,
+    VersionTransition,
+    dump_versioned,
+    field_default,
+    field_removed,
+    field_renamed,
+    matching_labels,
+    migration,
+    model_for_version,
+    schema_version,
+    schema_versions,
+    validate_versioned,
+    versioned_schema,
+)
+
+
+def _identity(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+def test_external_family_versions_model_from_separate_module() -> None:
+    from tests.fixtures.external_family.models import ExternalConfig
+
+    schema_before = ExternalConfig.model_json_schema()
+
+    from tests.fixtures.external_family.schema_history import EXTERNAL_CONFIG_SCHEMA
+
+    historical = EXTERNAL_CONFIG_SCHEMA.model_for("1")
+    result = EXTERNAL_CONFIG_SCHEMA.validate({"schema_version": "1", "retries": 4})
+
+    assert result.source_model.__class__ is historical
+    assert result.source_model.model_dump() == {
+        "timeout": 5.0,
+        "retries": 4,
+        "schema_version": "1",
+    }
+    assert result.current_model == ExternalConfig(timeout=5.0, retries=4)
+    assert model_for_version(EXTERNAL_CONFIG_SCHEMA, "1") is historical
+    assert (
+        validate_versioned(
+            EXTERNAL_CONFIG_SCHEMA,
+            {"schema_version": "1", "retries": 4},
+        ).current_model
+        == result.current_model
+    )
+    assert dump_versioned(EXTERNAL_CONFIG_SCHEMA, version="1") == {
+        "timeout": 5.0,
+        "retries": 3,
+        "schema_version": "1",
+    }
+    assert ExternalConfig.model_json_schema() == schema_before
+    assert "__pydantic_versions_pending__" not in ExternalConfig.__dict__
+
+
+@pytest.mark.parametrize("history_first", [False, True])
+def test_external_history_import_order_does_not_change_model(history_first: bool) -> None:
+    repository = Path(__file__).resolve().parents[2]
+    if history_first:
+        imports = (
+            "from tests.fixtures.external_family.schema_history "
+            "import EXTERNAL_CONFIG_SCHEMA\n"
+            "from tests.fixtures.external_family.models import ExternalConfig\n"
+            "before = ExternalConfig.model_json_schema()\n"
+        )
+    else:
+        imports = (
+            "from tests.fixtures.external_family.models import ExternalConfig\n"
+            "before = ExternalConfig.model_json_schema()\n"
+            "from tests.fixtures.external_family.schema_history "
+            "import EXTERNAL_CONFIG_SCHEMA\n"
+        )
+    script = (
+        imports
+        + "after = ExternalConfig.model_json_schema()\n"
+        + "assert before == after\n"
+        + "assert EXTERNAL_CONFIG_SCHEMA.validate("
+        + "{'schema_version': '1'}).current_model.timeout == 5.0\n"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_external_family_is_not_an_implicit_default() -> None:
+    class NoDefaultConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=NoDefaultConfig,
+        name="no_default",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    assert family.model_for("1") is model_for_version(family, "1")
+    with pytest.raises(SchemaFamilySelectionError, match="no explicit default"):
+        model_for_version(NoDefaultConfig, "1")
+
+
+def test_explicit_default_enables_model_only_calls() -> None:
+    class DefaultConfig(BaseModel):
+        value: int = 2
+
+    family = SchemaFamily(
+        model=DefaultConfig,
+        name="selected",
+        versions=(
+            SchemaVersion("1", patches=(field_default("value", 1),)),
+            SchemaVersion("2"),
+        ),
+    )
+
+    assert family.as_default() is family
+    assert family.as_default() is family
+    assert model_for_version(DefaultConfig, "1") is family.model_for("1")
+    assert validate_versioned(DefaultConfig, {"schema_version": "1"}).current_model == (
+        DefaultConfig(value=1)
+    )
+
+
+def test_second_default_is_rejected_without_replacing_first() -> None:
+    class SharedDefaultConfig(BaseModel):
+        value: int = 3
+
+    first = SchemaFamily(
+        model=SharedDefaultConfig,
+        name="first",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    ).as_default()
+    second = SchemaFamily(
+        model=SharedDefaultConfig,
+        name="second",
+        versions=(SchemaVersion("legacy"), SchemaVersion("current")),
+    )
+
+    with pytest.raises(SchemaFamilySelectionError, match="already has explicit default"):
+        second.as_default()
+
+    assert model_for_version(SharedDefaultConfig, "1") is first.model_for("1")
+    with pytest.raises(UnknownSchemaVersionError):
+        model_for_version(SharedDefaultConfig, "legacy")
+
+
+def test_two_families_share_a_model_without_sharing_state() -> None:
+    class SharedConfig(BaseModel):
+        value: int = 10
+        selected_by: str = "current"
+
+    def select_public(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "selected_by": "public"}
+
+    def select_internal(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "selected_by": "internal"}
+
+    public = SchemaFamily(
+        model=SharedConfig,
+        name="public",
+        versions=(
+            SchemaVersion("1", patches=(field_default("value", 1),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=select_public),),
+    )
+    internal = SchemaFamily(
+        model=SharedConfig,
+        name="internal",
+        versions=(
+            SchemaVersion("1", patches=(field_default("value", 2),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=select_internal),),
+    )
+
+    public_model = public.model_for("1")
+    internal_model = internal.model_for("1")
+
+    assert public_model is public.model_for("1")
+    assert internal_model is internal.model_for("1")
+    assert public_model is not internal_model
+    assert public_model.__name__ != internal_model.__name__
+    assert public_model().model_dump()["value"] == 1
+    assert internal_model().model_dump()["value"] == 2
+    assert public.validate({"schema_version": "1"}).current_model.selected_by == "public"
+    assert internal.validate({"schema_version": "1"}).current_model.selected_by == "internal"
+
+
+def test_declarations_are_frozen_and_defensively_copied() -> None:
+    class CopiedConfig(BaseModel):
+        value: int = 10
+
+    patch_declarations = [field_default("value", 1)]
+    version_one = SchemaVersion("1", patches=cast(Any, patch_declarations))
+    versions = [version_one, SchemaVersion("2")]
+    transition_declarations = [VersionTransition("1", "2", upgrade=_identity)]
+    family = SchemaFamily(
+        model=CopiedConfig,
+        name="copied",
+        versions=versions,
+        transitions=transition_declarations,
+    )
+
+    patch_declarations.append(field_removed("value"))
+    versions.append(SchemaVersion("3"))
+    transition_declarations.clear()
+
+    assert tuple(version.label for version in family.versions) == ("1", "2")
+    assert len(family.transitions) == 1
+    assert family.model_for("1")().model_dump()["value"] == 1
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, version_one).label = "changed"
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, family.transitions[0]).source = "changed"
+
+
+def test_compilation_snapshots_mutable_field_defaults() -> None:
+    class MutableDefaultConfig(BaseModel):
+        values: list[int] = Field(default_factory=list)
+
+    caller_default: list[int] = []
+    family = SchemaFamily(
+        model=MutableDefaultConfig,
+        name="mutable_default",
+        versions=(
+            SchemaVersion("1", patches=(field_default("values", caller_default),)),
+            SchemaVersion("2"),
+        ),
+    ).compile()
+
+    caller_default.append(9)
+
+    assert family.model_for("1")().model_dump()["values"] == []
+    compiled_default = family._compiled_family().versions[0].projection.fields[0].default
+    assert compiled_default is not None
+    assert compiled_default.default == []
+
+
+def test_nested_mapping_declaration_copies_the_caller_mapping() -> None:
+    class ParentConfig(BaseModel):
+        value: int = 1
+
+    class ChildConfig(BaseModel):
+        value: int = 1
+
+    child = SchemaFamily(
+        model=ChildConfig,
+        name="child",
+        versions=(SchemaVersion("legacy"), SchemaVersion("current")),
+    )
+    mapping = {"1": "legacy", "2": "current"}
+    declaration = NestedFamily(path="child", family=child, versions=mapping)
+
+    mapping["2"] = "legacy"
+
+    assert dict(cast(Any, declaration.versions)) == {
+        "1": "legacy",
+        "2": "current",
+    }
+    assert isinstance(matching_labels(), type(matching_labels()))
+    assert VersionMetadata(("meta", "version")).to_dict() == {
+        "path": ["meta", "version"],
+        "owner": "family",
+    }
+
+
+def test_compile_is_lazy_idempotent_and_cache_stable() -> None:
+    class LazyConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=LazyConfig,
+        name="lazy",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    assert family._compiled is None
+    assert family.compile() is family
+    first = family.model_for("1")
+
+    assert family.compile() is family
+    assert family.model_for("1") is first
+
+
+def test_lazy_compilation_allows_a_later_forward_reference_rebuild() -> None:
+    class ForwardConfig(BaseModel):
+        child: ForwardValue
+
+    family = SchemaFamily(
+        model=ForwardConfig,
+        name="forward_reference",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    assert family._compiled is None
+
+    class ForwardValue(BaseModel):
+        value: int
+
+    ForwardConfig.model_rebuild(_types_namespace={"ForwardValue": ForwardValue})
+
+    result = family.validate(
+        {"schema_version": "1", "child": {"value": 3}},
+    )
+
+    assert result.current_model.child == ForwardValue(value=3)
+
+
+def test_compile_is_thread_safe_and_publishes_one_model_identity() -> None:
+    class ConcurrentConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=ConcurrentConfig,
+        name="concurrent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    workers = 8
+    barrier = Barrier(workers)
+
+    def compile_model() -> type[BaseModel]:
+        barrier.wait()
+        return family.compile().model_for("1")
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        models = tuple(executor.map(lambda _: compile_model(), range(workers)))
+
+    assert len({id(model) for model in models}) == 1
+
+
+def test_private_compiled_state_is_frozen() -> None:
+    class FrozenConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=FrozenConfig,
+        name="frozen",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    compiled = family._compiled_family()
+
+    assert isinstance(compiled.versions, tuple)
+    assert isinstance(compiled.transitions, tuple)
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, compiled).name = "changed"
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, compiled.versions[0]).model = FrozenConfig
+
+
+def test_sanitized_label_collisions_have_distinct_generated_identities() -> None:
+    class CollisionConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=CollisionConfig,
+        name="collision",
+        versions=(
+            SchemaVersion("1.0"),
+            SchemaVersion("1-0"),
+            SchemaVersion("2"),
+        ),
+    )
+
+    dotted = family.model_for("1.0")
+    dashed = family.model_for("1-0")
+
+    assert dotted is not dashed
+    assert dotted.__name__ != dashed.__name__
+    assert dotted().model_dump()["schema_version"] == "1.0"
+    assert dashed().model_dump()["schema_version"] == "1-0"
+
+
+def test_schema_family_rejects_malformed_names_labels_and_sequences() -> None:
+    class StrictConfig(BaseModel):
+        value: int = 1
+
+    versions = (SchemaVersion("1"), SchemaVersion("2"))
+
+    with pytest.raises(SchemaCompilationError, match="at least one version"):
+        SchemaFamily(model=StrictConfig, name="strict", versions=())
+    with pytest.raises(SchemaCompilationError, match="non-empty string"):
+        SchemaFamily(model=StrictConfig, name="", versions=versions)
+    with pytest.raises(SchemaCompilationError, match="must be a sequence"):
+        SchemaFamily(model=StrictConfig, name="strict", versions=cast(Any, "12"))
+    with pytest.raises(SchemaCompilationError, match="non-empty string"):
+        SchemaFamily(
+            model=StrictConfig,
+            name="strict",
+            versions=(SchemaVersion(cast(Any, 1)), SchemaVersion("2")),
+        )
+    with pytest.raises(DuplicateSchemaVersionError):
+        SchemaFamily(
+            model=StrictConfig,
+            name="strict",
+            versions=(SchemaVersion("1"), SchemaVersion("1")),
+        )
+    with pytest.raises(UnknownSchemaVersionError):
+        SchemaFamily(
+            model=StrictConfig,
+            name="strict",
+            versions=versions,
+            missing_version="legacy",
+        )
+    with pytest.raises(SchemaCompilationError, match="non-empty string"):
+        SchemaFamily(
+            model=StrictConfig,
+            name="strict",
+            versions=versions,
+            missing_version=cast(Any, 1),
+        )
+
+
+def test_compatibility_declarations_reject_coercion_and_nonterminal_current() -> None:
+    with pytest.raises(SchemaCompilationError, match="must be a sequence"):
+        versioned_schema(name="string", versions=cast(Any, "12"), current="2")
+    with pytest.raises(SchemaCompilationError, match="must be a sequence"):
+        schema_versions(cast(Any, "12"))
+    with pytest.raises(SchemaCompilationError, match="non-empty string"):
+        schema_version(cast(Any, 1))
+    with pytest.raises(SchemaCompilationError, match="final declared label"):
+        versioned_schema(name="nonterminal", versions=("1", "2"), current="1")
+
+
+@pytest.mark.parametrize(
+    "transition, error",
+    [
+        (VersionTransition("0", "1", upgrade=_identity), SchemaCompilationError),
+        (VersionTransition("2", "1", upgrade=_identity), SchemaCompilationError),
+        (VersionTransition("1", "3", upgrade=_identity), SchemaCompilationError),
+        (VersionTransition("1", "2"), SchemaCompilationError),
+        (
+            VersionTransition("1", "2", upgrade=cast(Any, "not-callable")),
+            SchemaCompilationError,
+        ),
+        (
+            VersionTransition("1", "2", upgrade=_identity, downgrade_semantics="exact"),
+            SchemaCompilationError,
+        ),
+        (
+            VersionTransition("1", "2", downgrade=_identity),
+            SchemaCompilationError,
+        ),
+    ],
+)
+def test_transition_topology_is_validated(
+    transition: VersionTransition,
+    error: type[Exception],
+) -> None:
+    class TransitionConfig(BaseModel):
+        value: int = 1
+
+    with pytest.raises(error):
+        SchemaFamily(
+            model=TransitionConfig,
+            name="transitions",
+            versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+            transitions=(transition,),
+        )
+
+
+def test_duplicate_transition_edge_is_rejected() -> None:
+    class DuplicateTransitionConfig(BaseModel):
+        value: int = 1
+
+    with pytest.raises(DuplicateSchemaVersionError):
+        SchemaFamily(
+            model=DuplicateTransitionConfig,
+            name="duplicate_transitions",
+            versions=(SchemaVersion("1"), SchemaVersion("2")),
+            transitions=(
+                VersionTransition("1", "2", upgrade=_identity),
+                VersionTransition("1", "2", upgrade=_identity),
+            ),
+        )
+
+
+def test_future_declarations_are_rejected_instead_of_ignored() -> None:
+    class FutureConfig(BaseModel):
+        value: int = 1
+
+    class HistoricalConfig(BaseModel):
+        value: str
+
+    wire_family = SchemaFamily(
+        model=FutureConfig,
+        name="wire_future",
+        versions=(SchemaVersion("1", wire_model=HistoricalConfig), SchemaVersion("2")),
+    )
+    nested_family = SchemaFamily(
+        model=FutureConfig,
+        name="nested_future",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(
+            NestedFamily(
+                path="value",
+                family=wire_family,
+                versions={"1": "1", "2": "2"},
+            ),
+        ),
+    )
+    downgrade_family = SchemaFamily(
+        model=FutureConfig,
+        name="downgrade_future",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=_identity,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    with pytest.raises(SchemaCompilationError, match="Explicit wire models"):
+        wire_family.compile()
+    with pytest.raises(SchemaCompilationError, match="nested family"):
+        nested_family.compile()
+    with pytest.raises(SchemaCompilationError, match="Downgrade execution"):
+        downgrade_family.compile()
+
+
+def test_current_and_mutually_exclusive_wire_declarations_are_rejected() -> None:
+    class CurrentConfig(BaseModel):
+        value: int = 1
+
+    class HistoricalConfig(BaseModel):
+        value: int = 1
+
+    with pytest.raises(SchemaCompilationError, match="cannot be patched"):
+        SchemaFamily(
+            model=CurrentConfig,
+            name="patched_current",
+            versions=(SchemaVersion("1", patches=(field_default("value", 2),)),),
+        )
+    with pytest.raises(SchemaCompilationError, match="cannot be patched"):
+        SchemaFamily(
+            model=CurrentConfig,
+            name="wire_current",
+            versions=(SchemaVersion("1", wire_model=HistoricalConfig),),
+        )
+    with pytest.raises(SchemaCompilationError, match="combine patches"):
+        SchemaFamily(
+            model=CurrentConfig,
+            name="mixed_wire",
+            versions=(
+                SchemaVersion(
+                    "1",
+                    patches=(field_default("value", 2),),
+                    wire_model=HistoricalConfig,
+                ),
+                SchemaVersion("2"),
+            ),
+        )
+
+
+def test_conflicting_patch_declarations_are_rejected() -> None:
+    class PatchedConfig(BaseModel):
+        value: int = 1
+        other: int = 2
+
+    with pytest.raises(SchemaCompilationError, match="conflicting patches"):
+        SchemaFamily(
+            model=PatchedConfig,
+            name="conflicting",
+            versions=(
+                SchemaVersion(
+                    "1",
+                    patches=(field_default("value", 3), field_removed("value")),
+                ),
+                SchemaVersion("2"),
+            ),
+        )
+    with pytest.raises(SchemaVersionError, match="Rename target"):
+        SchemaFamily(
+            model=PatchedConfig,
+            name="rename_collision",
+            versions=(
+                SchemaVersion("1", patches=(field_renamed("value", "other"),)),
+                SchemaVersion("2"),
+            ),
+        )
+    with pytest.raises(SchemaVersionError, match="unknown field"):
+        SchemaFamily(
+            model=PatchedConfig,
+            name="unknown_field",
+            versions=(
+                SchemaVersion("1", patches=(field_removed("missing"),)),
+                SchemaVersion("2"),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "patches",
+    [
+        (field_renamed("a", "c"), field_renamed("b", "a")),
+        (field_renamed("b", "a"), field_renamed("a", "c")),
+    ],
+)
+def test_snapshot_renames_are_order_independent(
+    patches: tuple[Any, ...],
+) -> None:
+    class RenamedConfig(BaseModel):
+        a: int
+        b: int
+
+    family = SchemaFamily(
+        model=RenamedConfig,
+        name="rename_snapshot",
+        versions=(SchemaVersion("1", patches=patches), SchemaVersion("2")),
+    )
+
+    result = family.validate({"schema_version": "1", "c": 10, "a": 20})
+
+    assert result.current_model == RenamedConfig(a=10, b=20)
+    assert family.dump(
+        version="1",
+        data=RenamedConfig(a=30, b=40),
+    ) == {"c": 30, "a": 40, "schema_version": "1"}
+
+
+def test_rename_can_reuse_a_removed_field_name() -> None:
+    class ReusedNameConfig(BaseModel):
+        a: int
+        b: int = 2
+
+    family = SchemaFamily(
+        model=ReusedNameConfig,
+        name="reuse_removed_name",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_removed("b"), field_renamed("a", "b")),
+            ),
+            SchemaVersion("2"),
+        ),
+    )
+
+    assert family.validate({"schema_version": "1", "b": 5}).current_model == (
+        ReusedNameConfig(a=5, b=2)
+    )
+    assert family.dump(
+        version="1",
+        data=ReusedNameConfig(a=7, b=9),
+    ) == {"b": 7, "schema_version": "1"}
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        FieldDefault("values", default_factory=cast(Any, 42), has_default=False),
+        FieldDefault("values", default=[1], default_factory=list),
+        FieldDefault("values", default=[1], default_factory=list, has_default=False),
+        FieldDefault("values", has_default=cast(Any, 1)),
+    ],
+)
+def test_malformed_field_default_records_fail_during_declaration(
+    patch: FieldDefault,
+) -> None:
+    class DefaultRecordConfig(BaseModel):
+        values: list[int] = Field(default_factory=list)
+
+    with pytest.raises(SchemaCompilationError, match="Field default"):
+        SchemaFamily(
+            model=DefaultRecordConfig,
+            name="invalid_default_record",
+            versions=(SchemaVersion("1", patches=(patch,)), SchemaVersion("2")),
+        )
+
+
+def test_required_field_introduction_requires_upgrade_on_that_edge() -> None:
+    class RequiredConfig(BaseModel):
+        required: str
+
+    invalid = SchemaFamily(
+        model=RequiredConfig,
+        name="required_invalid",
+        versions=(
+            SchemaVersion("1", patches=(field_removed("required"),)),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(SchemaCompilationError, match="without an upgrade"):
+        invalid.compile()
+
+    def add_required(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "required": "created"}
+
+    valid = SchemaFamily(
+        model=RequiredConfig,
+        name="required_valid",
+        versions=(
+            SchemaVersion("1", patches=(field_removed("required"),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=add_required),),
+    )
+
+    assert valid.validate({"schema_version": "1"}).current_model.required == "created"
+
+
+def test_every_accepted_upgrade_executes_once_and_in_order() -> None:
+    class OrderedConfig(BaseModel):
+        events: list[str] = Field(default_factory=list)
+
+    def first(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "events": [*data["events"], "1-2"]}
+
+    def second(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "events": [*data["events"], "2-3"]}
+
+    family = SchemaFamily(
+        model=OrderedConfig,
+        name="ordered",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition("1", "2", upgrade=first),
+            VersionTransition("2", "3", upgrade=second),
+        ),
+    )
+
+    result = family.validate({"schema_version": "1", "events": []})
+
+    assert result.current_model.events == ["1-2", "2-3"]
+    assert result.migrations_applied == (("1", "2"), ("2", "3"))
+
+
+def test_decorator_transitions_delegate_to_the_family_compiler() -> None:
+    class DecoratedConfig(BaseModel):
+        value: int = 1
+
+    def double(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] * 2}
+
+    decorator = versioned_schema(
+        name="decorated_transition",
+        versions=("1", "2"),
+        current="2",
+        transitions=(VersionTransition("1", "2", upgrade=double),),
+    )
+    returned = decorator(DecoratedConfig)
+
+    assert returned is DecoratedConfig
+    assert (
+        validate_versioned(
+            DecoratedConfig,
+            {"schema_version": "1", "value": 3},
+        ).current_model.value
+        == 6
+    )
+
+
+def test_legacy_migration_must_be_adjacent_and_registered_before_compilation() -> None:
+    @versioned_schema(name="legacy_builder", versions=("1", "2", "3"), current="3")
+    class LegacyBuilderConfig(BaseModel):
+        value: int = 1
+
+    with pytest.raises(InvalidMigrationError, match="adjacent"):
+        migration(LegacyBuilderConfig, "1", "3")
+
+    @migration(LegacyBuilderConfig, "1", "2")
+    def first(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 1}
+
+    assert (
+        validate_versioned(
+            LegacyBuilderConfig,
+            {"schema_version": "1", "value": 1},
+        ).current_model.value
+        == 2
+    )
+
+    with pytest.raises(InvalidMigrationError, match="after.*compiled"):
+        migration(LegacyBuilderConfig, "2", "3")
+
+
+def test_decorator_and_external_flat_declarations_are_equivalent() -> None:
+    @versioned_schema(name="decorator_equivalent", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_default("value", 1),))
+    class EquivalentConfig(BaseModel):
+        value: int = 2
+
+    external = SchemaFamily(
+        model=EquivalentConfig,
+        name="external_equivalent",
+        versions=(
+            SchemaVersion("1", patches=(field_default("value", 1),)),
+            SchemaVersion("2"),
+        ),
+    )
+
+    decorated_result = validate_versioned(EquivalentConfig, {"schema_version": "1"})
+    external_result = external.validate({"schema_version": "1"})
+
+    assert decorated_result.current_model == external_result.current_model
+    assert model_for_version(EquivalentConfig, "1")().model_dump() == (
+        external.model_for("1")().model_dump()
+    )
+
+
+def test_runtime_version_arguments_are_not_coerced() -> None:
+    class RuntimeLabelConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=RuntimeLabelConfig,
+        name="runtime_labels",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    with pytest.raises(UnknownSchemaVersionError, match="non-empty string"):
+        family.model_for(cast(Any, 1))
+    with pytest.raises(UnknownSchemaVersionError, match="non-empty string"):
+        family.validate({"schema_version": 1})
+
+
+def test_public_patch_records_are_exported() -> None:
+    patch = field_default("value", 1)
+
+    assert isinstance(patch, FieldDefault)

--- a/tests/unit/test_versioned_schema.py
+++ b/tests/unit/test_versioned_schema.py
@@ -175,7 +175,11 @@ def test_dump_versioned_accepts_mapping_data_for_historical_schema() -> None:
 
 def test_dump_versioned_rejects_non_mapping_data() -> None:
     with pytest.raises(ValidationError):
-        dump_versioned(AppConfig, version="1", data=["not", "a", "mapping"])
+        dump_versioned(
+            AppConfig,
+            version="1",
+            data=cast(Any, ["not", "a", "mapping"]),
+        )
 
 
 def test_dump_versioned_removes_historical_fields_before_validation() -> None:
@@ -366,7 +370,7 @@ def test_patch_helpers_validate_default_arguments() -> None:
 
 
 def test_field_default_supports_default_factory() -> None:
-    @versioned_schema(name="factory_default", versions=["1"], current="1")
+    @versioned_schema(name="factory_default", versions=["1", "2"], current="2")
     @schema_version("1", patches=[field_default("items", default_factory=list)])
     class FactoryDefault(BaseModel):
         items: list[str]

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
   { "User Guide" = [
     { "Getting Started" = "guide/getting-started.md" },
     { "Concepts" = "guide/concepts.md" },
+    { "External Schema Families" = "guide/external-families.md" },
     { "Complex Config Example" = "guide/complex-config-example.md" },
     { "Django Ninja" = "guide/django-ninja.md" },
     { "Version Discovery" = "guide/version-discovery.md" },


### PR DESCRIPTION
## Summary

- add typed external `SchemaFamily`, `SchemaVersion`, and `VersionTransition` declarations so schema history can live outside the current Pydantic model
- compile family-owned immutable projections, adjacent transition steps, generated-model identities, and caches as the runtime authority
- keep decorators and model-first helpers as explicit-default compatibility adapters to that same compiler/runtime
- document family isolation, explicit defaults, migration visibility, and the staged boundaries for later 0.2.0 work
- type-check and execute the installed wheel from an isolated consumer environment

## Why

The 0.1 decorator stack made version configuration larger than the model it wrapped, coupled history to model declaration/import order, and used mutable process-global state as the source of truth. Consumers that need separate histories or more than one interpretation of a model could not use the package cleanly as a dependency.

This foundation moves configuration to a dedicated external object while preserving the compact decorator style for existing flat schemas.

## Compatibility and migration impact

Existing flat decorator examples continue through the new family compiler. External family construction has no global side effect; callers can pass the family directly or deliberately select one compatibility default with `as_default()`.

The compiler now rejects malformed/non-string labels, non-terminal current versions, unreachable or duplicate transition edges, late migration registration, and future declarations that this foundation cannot execute safely. Explicit historical models, explicit nested mappings, public plans, downgrade execution, full rendering semantics, and traces remain in their owning 0.2.0 issues rather than being silently approximated here.

No package version, release tag, upload, or publishing configuration changed.

## Validation

- `uv run make ci` — 108 tests passed; 95.26% coverage; Ruff and ty passed
- `uv run make docs-build-strict`
- `uv lock --check`
- `uv build`
- isolated installed-wheel ty check, runtime execution, and `py.typed` verification
- 26 Python fences parsed across the changed README/docs
- workflow YAML parsing and `git diff --check`
- independent architecture, docs, compiler, regression-fix, and CI-isolation reviews

Closes #4
Refs #2