### PR TITLE
feat: expose deterministic conversion plans

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added frozen schema inventories and deterministic validation/render plans with
+  stable step IDs, visible implicit migrations, JSON-safe serialization, lossy
+  projection semantics, and payload-free irreversible-route preflight.
 - Added immutable external `SchemaFamily`, `SchemaVersion`, and
   `VersionTransition` declarations so schema history can live outside the
   current model and two isolated families can safely reuse one model.

--- a/docs/decisions/0001-schema-family-and-conversion-contract.md
+++ b/docs/decisions/0001-schema-family-and-conversion-contract.md
@@ -804,7 +804,12 @@ qualified name, the exact family name, and the exact label. Labels `1.0` and
 `1-0` therefore cannot collide. A family name is a non-empty stable identifier;
 two different declarations with the same model and family identity may not be
 combined in one schema graph. Plan-step IDs use the same encoding plus the
-operation, kind, source, target, schema path, and declaration ordinal.
+operation, direction, kind, source, target, schema path, semantics, and
+declaration ordinal, together with safe step-specific declaration details such
+as projection, wire-model, and metadata kind. They use a versioned `pv1-`
+prefix and the full 64-character SHA-256 digest because they are durable
+correlation identifiers; unlike generated Python class-name suffixes, they are
+not truncated. Default values, factories, and callable identities are excluded.
 
 ## Version metadata ownership
 

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -2,7 +2,8 @@
 
 Migrations upgrade already-validated historical data toward the current model.
 They are optional: if adjacent versions are compatible, the compiler records an
-identity edge.
+identity edge. The compiled inventory and operation-specific plans make both
+custom and identity edges visible without running a payload.
 
 ## Declare transitions with the family
 
@@ -49,8 +50,10 @@ def migrate_v1_to_v2(data: dict) -> dict:
 
 Legacy registrations must finish before the family's first compilation.
 Registering another migration after `compile()`, `model_for_version()`,
-`validate_versioned()`, or `dump_versioned()` has compiled that family raises
-`InvalidMigrationError` instead of mutating live plans.
+`describe()`, `plan_validation()`, `plan_render()`, `validate_versioned()`, or
+`dump_versioned()` has compiled that family raises `InvalidMigrationError`
+instead of mutating live plans. Put legacy decorators before any inspection or
+runtime call; new code should prefer constructor transitions.
 
 ## Direction and topology
 
@@ -80,14 +83,119 @@ topology is:
 ```
 
 Custom upgrades run in that order. An edge with no upgrade callable remains an
-explicit internal identity step, which is useful when a version changed only
-field defaults or when its historical projection is already current-compatible.
+explicit identity step, which is useful when a version changed only field
+defaults or when its historical projection is already current-compatible.
 
 `SchemaFamily.transitions` exposes the frozen custom declarations for tooling
 and review. After validation, `VersionedValidation.migrations_applied` reports
-the custom upgrade edges that actually ran. Compiler-added identity steps are
-not presented as user migrations; the public compiled-plan API will provide the
-complete topology.
+the custom upgrade edges that actually ran. Use the inventory or a validation
+plan when tooling needs the complete topology, including compiler-added
+identity steps.
+
+## Inspect the migration inventory
+
+`describe()` returns the family-owned compiled inventory:
+
+```python
+inventory = APP_CONFIG_SCHEMA.describe()
+
+transition = inventory.transitions[0]
+assert transition.source == "1"
+assert transition.target == "2"
+assert transition.upgrade == "custom"
+assert transition.downgrade == "unavailable"
+assert transition.downgrade_semantics == "unavailable"
+```
+
+That record can drive a migration table without inspecting decorator state or
+Python callables:
+
+| Edge | Upgrade | Downgrade | Downgrade semantics |
+| --- | --- | --- | --- |
+| `1 -> 2` | `custom` | `unavailable` | `unavailable` |
+
+Every adjacent pair appears in declared version order. An omitted transition is
+reported as `implicit_identity` in both directions with exact downgrade
+semantics. Version descriptions also list generated/current wire-model kinds
+and version-specific default, removed, and renamed field projections.
+
+The inventory and its nested records are frozen values. `to_dict()` returns a
+fresh deterministic JSON-safe representation and deliberately omits model
+classes, callable objects, default values and factories, and payload data.
+
+## Plan validation
+
+`plan_validation()` describes the selected source-to-current route without
+executing a migration:
+
+```python
+plan = APP_CONFIG_SCHEMA.plan_validation("1")
+
+assert plan.operation == "validate"
+assert plan.source_version == "1"
+assert plan.target_version == "2"
+assert [step.kind for step in plan.steps] == [
+    "metadata",
+    "wire_validation",
+    "custom_transition",
+    "current_validation",
+]
+```
+
+Validation plans contain source metadata and wire-validation boundaries,
+version-specific projections, every adjacent upgrade or identity edge, and the
+final current-model validation boundary. Their overall semantics are
+`not_applicable`; individual identity steps are marked `exact`.
+
+Each step has a deterministic `pv1-` ID followed by the full 64-character
+SHA-256 digest of safe schema identity. IDs never depend on Python's
+process-randomized hash, callable `repr()`, object identity, or payload values.
+
+## Preflight rendering
+
+`plan_render()` describes a current-to-target route. It is conservative: a
+custom upgrade with no declared downgrade makes the complete reverse route
+unavailable.
+
+```python
+import pytest
+
+from pydantic_versions import IrreversibleTransitionError
+
+
+with pytest.raises(IrreversibleTransitionError):
+    APP_CONFIG_SCHEMA.plan_render("1")
+```
+
+The method takes no payload and raises before any user transition can run.
+Structural rename and default projections are exact. A target projection that
+removes a current field is available but marks its step and the complete render
+plan as `lossy`.
+
+Custom downgrade declarations are still rejected by the current compiler and
+are not executed yet. Consequently, the only available reverse transition in
+this implementation slice is an implicit identity. Downgrade execution lands
+in its dedicated conversion work.
+
+Planning is intentionally ahead of runtime routing during this implementation
+stage. `validate()` and the dictionary-returning `dump()` compatibility path do
+not yet execute these public plans. In particular, a failed `plan_render()`
+means no safe reverse route is declared even if legacy `dump()` can still
+project a target-shaped dictionary; do not treat that dictionary as execution
+of a custom downgrade.
+
+## Plans are not traces
+
+A plan is a static, payload-free description of what an operation would need to
+do. It contains safe schema paths and conditional templates, never actual list
+indices, mapping keys, values, exception messages, or timing data. Creating or
+serializing a plan does not emit logs.
+
+An execution trace records what actually happened for one payload. Structured
+per-step traces are separate later work. Until then,
+`VersionedValidation.migrations_applied` remains the compatibility view of
+top-level custom upgrades that completed; it intentionally excludes implicit
+identity steps.
 
 ## Return values
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -27,6 +27,9 @@ declaration sequence and has no default-selection side effect.
 - `current_version`: the final declared version label.
 - `compile()`: lazily and atomically compile the immutable family state; returns the family.
 - `as_default()`: deliberately select this family for model-only compatibility calls; returns the family.
+- `describe()`: return the frozen compiled `SchemaInventory`.
+- `plan_validation(source_version)`: return the cached source-to-current `ConversionPlan`.
+- `plan_render(target_version)`: return the cached current-to-target `ConversionPlan`, or raise `IrreversibleTransitionError` if no complete reverse route exists.
 - `model_for(version)`: return the family-local generated wire model.
 - `validate(data, *, version=None)`: validate historical input and upgrade it to the current model.
 - `defaults_for(*, version, include_version=True, **dump_kwargs)`: render target defaults.
@@ -89,6 +92,147 @@ the later top-level conversion work.
 declaration types so the final constructor remains stable. Non-empty explicit
 nested mappings currently fail compilation instead of being ignored; graph
 compilation and nested execution land in their dedicated 0.2 changes.
+
+## Compiled inventory and plans
+
+The public inspection records are frozen value objects. Their `to_dict()`
+methods return fresh deterministic dictionaries containing JSON-safe
+primitives.
+
+### Inventory records
+
+```python
+@dataclass(frozen=True)
+class ProjectionDescription:
+    kind: Literal["default", "removed", "renamed"]
+    current_field: str
+    historical_field: str | None
+    has_default: bool
+
+
+@dataclass(frozen=True)
+class VersionDescription:
+    label: str
+    wire_model: Literal["current", "generated", "explicit"]
+    projections: tuple[ProjectionDescription, ...]
+
+
+@dataclass(frozen=True)
+class TransitionDescription:
+    source: str
+    target: str
+    upgrade: Literal["implicit_identity", "custom"]
+    downgrade: Literal["implicit_identity", "custom", "unavailable"]
+    downgrade_semantics: StepSemantics
+
+
+@dataclass(frozen=True)
+class NestedFamilyDescription:
+    schema_path: str
+    family: str
+    versions: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class SchemaInventory:
+    family: str
+    model: str
+    current_version: str
+    versions: tuple[VersionDescription, ...]
+    transitions: tuple[TransitionDescription, ...]
+    nested: tuple[NestedFamilyDescription, ...]
+    version_metadata: VersionMetadata | None
+```
+
+`SchemaFamily.describe()` compiles the family if necessary and returns its
+cached inventory. Versions and transitions retain canonical declared order, and
+every adjacent edge is present even when its upgrade is an implicit identity.
+Projection descriptions reveal whether a historical version changes a default,
+removes a field, or renames it, but never reveal a default value or factory.
+
+The model is represented by its qualified name rather than a class object.
+`NestedFamilyDescription` is part of the stable output contract, but inventories
+remain flat while explicit nested compilation is unsupported.
+
+### Plan records
+
+```python
+type StepKind = Literal[
+    "wire_validation",
+    "projection",
+    "implicit_identity",
+    "custom_transition",
+    "nested",
+    "current_validation",
+    "serialization",
+    "metadata",
+]
+type StepSemantics = Literal[
+    "not_applicable",
+    "exact",
+    "lossy",
+    "unavailable",
+]
+
+
+@dataclass(frozen=True)
+class PlanStep:
+    id: str
+    family: str
+    source_version: str
+    target_version: str
+    operation: Literal["validate", "render"]
+    direction: Literal["upgrade", "downgrade"]
+    kind: StepKind
+    schema_path: str
+    semantics: StepSemantics
+    conditional: bool
+
+
+@dataclass(frozen=True)
+class ConversionPlan:
+    family: str
+    source_version: str
+    target_version: str
+    operation: Literal["validate", "render"]
+    semantics: StepSemantics
+    steps: tuple[PlanStep, ...]
+```
+
+`plan_validation(source_version)` exposes source metadata and wire validation,
+field projections, each adjacent upgrade or identity edge, and current-model
+validation. Its overall semantics are `not_applicable`.
+
+`plan_render(target_version)` exposes current validation, reverse edges, target
+projections and metadata, target wire validation, and serialization. Exact
+structural changes produce an `exact` plan; removing a current field produces a
+`lossy` plan. A custom upgrade without a declared downgrade makes the route
+unavailable, so the method raises `IrreversibleTransitionError` instead of
+returning that candidate.
+
+Plan construction is data-independent and does not execute transition
+callables or default factories. Step IDs use `pv1-` plus a full 64-character
+SHA-256 digest and do not depend on object identity, callable representations,
+or Python's randomized hash. Root-level steps use `$`; a plain metadata field
+uses its field name, while tuple paths use an unambiguous `$.*` schema pattern
+and literal special characters use JSON-style bracket quoting. Paths never
+contain payload-derived indices or keys.
+
+Inventories and plans never contain payloads, model objects, callable objects,
+default values, exception messages, tracebacks, timing, or host/user
+identifiers, and creating them does not log. A plan describes a possible
+operation; it is not an execution trace. Structured per-payload traces are a
+separate API.
+
+Calling `describe()`, `plan_validation()`, or `plan_render()` performs the
+family's first compilation when needed. A later legacy `@migration`
+registration therefore fails instead of mutating the published inventory and
+plans.
+
+The current validation and dictionary-dump compatibility paths are not yet
+driven by these public plans. In particular, a rejected render plan means that
+no safe reverse transition is declared even if legacy dumping can still apply a
+structural target projection.
 
 ## Decorator compatibility
 
@@ -167,12 +311,15 @@ class VersionedValidation[T: BaseModel]:
 - `TransitionFunc`: `Callable[[TransitionData], TransitionData]`
 - `VersionPath`: `str | tuple[str, ...]`
 - `JsonValue`: recursive JSON-safe primitive type
+- `StepKind`: supported inventory/plan operation-step kinds
+- `StepSemantics`: `not_applicable`, `exact`, `lossy`, or `unavailable`
 
 ## Exceptions
 
 - `SchemaVersionError`
   - `SchemaCompilationError`
   - `SchemaFamilySelectionError`
+  - `IrreversibleTransitionError`
   - `MissingSchemaVersionError`
   - `UnknownSchemaVersionError`
   - `DuplicateSchemaVersionError`

--- a/src/pydantic_versions/__init__.py
+++ b/src/pydantic_versions/__init__.py
@@ -27,6 +27,7 @@ from pydantic_versions.declarations import (
 from pydantic_versions.exceptions import (
     DuplicateSchemaVersionError,
     InvalidMigrationError,
+    IrreversibleTransitionError,
     MissingSchemaVersionError,
     SchemaCompilationError,
     SchemaFamilySelectionError,
@@ -35,6 +36,17 @@ from pydantic_versions.exceptions import (
     VersionedValidationError,
 )
 from pydantic_versions.family import SchemaFamily
+from pydantic_versions.inspection import (
+    ConversionPlan,
+    NestedFamilyDescription,
+    PlanStep,
+    ProjectionDescription,
+    SchemaInventory,
+    StepKind,
+    StepSemantics,
+    TransitionDescription,
+    VersionDescription,
+)
 from pydantic_versions.patches import (
     FieldDefault,
     FieldRemoved,
@@ -56,22 +68,31 @@ def _package_version(distribution: str = "pydantic-versions") -> str:
 __version__ = _package_version()
 
 __all__ = [
+    "ConversionPlan",
     "DuplicateSchemaVersionError",
     "FieldDefault",
     "FieldRemoved",
     "FieldRenamed",
     "InvalidMigrationError",
+    "IrreversibleTransitionError",
     "JsonValue",
     "MatchingLabels",
     "MissingSchemaVersionError",
     "NestedFamily",
+    "NestedFamilyDescription",
+    "PlanStep",
+    "ProjectionDescription",
     "SchemaCompilationError",
     "SchemaFamily",
     "SchemaFamilySelectionError",
+    "SchemaInventory",
     "SchemaVersion",
     "SchemaVersionError",
+    "StepKind",
+    "StepSemantics",
     "TransitionData",
     "TransitionFunc",
+    "TransitionDescription",
     "UnknownSchemaVersionError",
     "VersionMetadata",
     "VersionPatch",
@@ -79,6 +100,7 @@ __all__ = [
     "VersionTransition",
     "VersionedValidation",
     "VersionedValidationError",
+    "VersionDescription",
     "__version__",
     "dump_versioned",
     "field_default",

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel
 
@@ -23,7 +23,12 @@ from pydantic_versions.exceptions import (
 )
 from pydantic_versions.patches import FieldDefault, FieldRemoved, FieldRenamed, VersionPatch
 
+if TYPE_CHECKING:
+    from pydantic_versions._planning import _PlanningCatalog
+
 type UpgradeKind = Literal["implicit_identity", "custom_transition"]
+type DowngradeKind = Literal["implicit_identity", "custom_transition", "unavailable"]
+type WireModelKind = Literal["current", "generated", "explicit"]
 
 
 @dataclass(frozen=True)
@@ -31,6 +36,7 @@ class _CompiledField:
     current_name: str
     version_name: str | None
     default: FieldDefault | None
+    patch_ordinal: int | None
 
 
 @dataclass(frozen=True)
@@ -50,6 +56,7 @@ class _VersionProjection:
 class _CompiledVersion:
     projection: _VersionProjection
     model: type[BaseModel]
+    wire_model_kind: WireModelKind
 
 
 @dataclass(frozen=True)
@@ -58,6 +65,8 @@ class _CompiledTransition:
     target: str
     upgrade_kind: UpgradeKind
     upgrade: TransitionFunc | None
+    downgrade_kind: DowngradeKind
+    downgrade_semantics: Literal["exact", "lossy", "unavailable"]
 
 
 @dataclass(frozen=True)
@@ -68,6 +77,7 @@ class _CompiledFamily:
     transitions: tuple[_CompiledTransition, ...]
     version_metadata: VersionMetadata | None
     missing_version: str | None
+    catalog: _PlanningCatalog
 
     @property
     def labels(self) -> tuple[str, ...]:
@@ -347,6 +357,10 @@ def _compile_projection(
         for patch in declaration.patches
         if isinstance(patch, FieldRenamed)
     }
+    patch_ordinals = {
+        patch.current_name if isinstance(patch, FieldRenamed) else patch.name: ordinal
+        for ordinal, patch in enumerate(declaration.patches)
+    }
     fields = tuple(
         _CompiledField(
             current_name=current_name,
@@ -354,6 +368,7 @@ def _compile_projection(
             if current_name in removed
             else renames.get(current_name, current_name),
             default=defaults.get(current_name),
+            patch_ordinal=patch_ordinals.get(current_name),
         )
         for current_name in model_cls.model_fields
     )
@@ -366,11 +381,29 @@ def _compile_transition(
     declaration: VersionTransition | None,
 ) -> _CompiledTransition:
     upgrade = None if declaration is None else declaration.upgrade
+    downgrade = None if declaration is None else declaration.downgrade
+    if downgrade is not None:
+        if declaration is None:  # pragma: no cover - derived from declaration
+            msg = f"Downgrade {source!r} -> {target!r} has no declaration"
+            raise SchemaCompilationError(msg)
+        downgrade_kind: DowngradeKind = "custom_transition"
+        downgrade_semantics = declaration.downgrade_semantics
+        if downgrade_semantics not in ("exact", "lossy"):  # pragma: no cover - validated
+            msg = f"Downgrade {source!r} -> {target!r} has no declared semantics"
+            raise SchemaCompilationError(msg)
+    elif upgrade is None:
+        downgrade_kind = "implicit_identity"
+        downgrade_semantics = "exact"
+    else:
+        downgrade_kind = "unavailable"
+        downgrade_semantics = "unavailable"
     return _CompiledTransition(
         source=source,
         target=target,
         upgrade_kind="implicit_identity" if upgrade is None else "custom_transition",
         upgrade=upgrade,
+        downgrade_kind=downgrade_kind,
+        downgrade_semantics=downgrade_semantics,
     )
 
 
@@ -385,17 +418,21 @@ def _generated_model_name(
         family_name,
         label,
     )
-    digest = hashlib.sha256()
-    for component in components:
-        encoded = component.encode("utf-8")
-        digest.update(len(encoded).to_bytes(8, byteorder="big", signed=False))
-        digest.update(encoded)
-    suffix = digest.hexdigest()[:12]
+    suffix = _stable_digest(components)[:12]
     return (
         f"{_identifier_component(model.__name__)}"
         f"_{_identifier_component(family_name)}"
         f"_{_identifier_component(label)}_{suffix}"
     )
+
+
+def _stable_digest(components: tuple[str, ...]) -> str:
+    digest = hashlib.sha256()
+    for component in components:
+        encoded = component.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, byteorder="big", signed=False))
+        digest.update(encoded)
+    return digest.hexdigest()
 
 
 def _identifier_component(value: str) -> str:

--- a/src/pydantic_versions/_planning.py
+++ b/src/pydantic_versions/_planning.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic_versions._compiler import (
+    _CompiledField,
+    _CompiledTransition,
+    _CompiledVersion,
+    _stable_digest,
+)
+from pydantic_versions.declarations import VersionPath
+from pydantic_versions.exceptions import SchemaCompilationError
+from pydantic_versions.inspection import (
+    ConversionPlan,
+    PlanStep,
+    ProjectionDescription,
+    SchemaInventory,
+    StepKind,
+    StepSemantics,
+    TransitionDescription,
+    VersionDescription,
+)
+
+if TYPE_CHECKING:
+    from pydantic_versions.family import SchemaFamily
+
+_ROOT_PATH = "$"
+
+
+@dataclass(frozen=True)
+class _PlanningCatalog:
+    inventory: SchemaInventory
+    validation_plans: tuple[ConversionPlan, ...]
+    render_plans: tuple[ConversionPlan, ...]
+
+
+def _build_planning_catalog(
+    family: SchemaFamily[Any],
+    versions: tuple[_CompiledVersion, ...],
+    transitions: tuple[_CompiledTransition, ...],
+) -> _PlanningCatalog:
+    version_descriptions = tuple(_describe_version(version) for version in versions)
+    transition_descriptions = tuple(_describe_transition(transition) for transition in transitions)
+    inventory = SchemaInventory(
+        family=family.name,
+        model=f"{family.model.__module__}.{family.model.__qualname__}",
+        current_version=family.current_version,
+        versions=version_descriptions,
+        transitions=transition_descriptions,
+        nested=(),
+        version_metadata=family.version_metadata,
+    )
+    validation_plans = tuple(
+        _build_validation_plan(
+            family,
+            versions,
+            transitions,
+            source_index=source_index,
+        )
+        for source_index in range(len(versions))
+    )
+    render_plans = tuple(
+        _build_render_plan(
+            family,
+            versions,
+            transitions,
+            target_index=target_index,
+        )
+        for target_index in range(len(versions))
+    )
+    return _PlanningCatalog(
+        inventory=inventory,
+        validation_plans=validation_plans,
+        render_plans=render_plans,
+    )
+
+
+def _describe_version(version: _CompiledVersion) -> VersionDescription:
+    ordered: list[tuple[int, ProjectionDescription]] = []
+    for field in version.projection.fields:
+        description = _describe_projection(field)
+        if description is None:
+            continue
+        if field.patch_ordinal is None:  # pragma: no cover - compiled invariant
+            msg = (
+                f"Compiled projection {version.projection.label!r} has no declaration "
+                f"ordinal for field {field.current_name!r}"
+            )
+            raise SchemaCompilationError(msg)
+        ordered.append((field.patch_ordinal, description))
+    ordered.sort(key=lambda item: item[0])
+    return VersionDescription(
+        label=version.projection.label,
+        wire_model=version.wire_model_kind,
+        projections=tuple(description for _, description in ordered),
+    )
+
+
+def _describe_projection(field: _CompiledField) -> ProjectionDescription | None:
+    if field.version_name is None:
+        return ProjectionDescription(
+            kind="removed",
+            current_field=field.current_name,
+            historical_field=None,
+            has_default=False,
+        )
+    if field.version_name != field.current_name:
+        return ProjectionDescription(
+            kind="renamed",
+            current_field=field.current_name,
+            historical_field=field.version_name,
+            has_default=False,
+        )
+    if field.default is not None:
+        return ProjectionDescription(
+            kind="default",
+            current_field=field.current_name,
+            historical_field=field.version_name,
+            has_default=True,
+        )
+    return None
+
+
+def _describe_transition(transition: _CompiledTransition) -> TransitionDescription:
+    upgrade: Literal["implicit_identity", "custom"] = (
+        "implicit_identity" if transition.upgrade_kind == "implicit_identity" else "custom"
+    )
+    if transition.downgrade_kind == "custom_transition":
+        downgrade: Literal["implicit_identity", "custom", "unavailable"] = "custom"
+    else:
+        downgrade = transition.downgrade_kind
+    return TransitionDescription(
+        source=transition.source,
+        target=transition.target,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        downgrade_semantics=transition.downgrade_semantics,
+    )
+
+
+def _build_validation_plan(
+    family: SchemaFamily[Any],
+    versions: tuple[_CompiledVersion, ...],
+    transitions: tuple[_CompiledTransition, ...],
+    *,
+    source_index: int,
+) -> ConversionPlan:
+    source = versions[source_index]
+    source_label = source.projection.label
+    current_label = versions[-1].projection.label
+    steps: list[PlanStep] = []
+
+    if family.version_metadata is not None:
+        metadata_identity = _version_path_identity(family.version_metadata.path)
+        steps.append(
+            _step(
+                family,
+                operation="validate",
+                direction="upgrade",
+                kind="metadata",
+                source_version=source_label,
+                target_version=source_label,
+                schema_path=_schema_path(family.version_metadata.path),
+                semantics="not_applicable",
+                ordinal=0,
+                identity_details=(family.version_metadata.owner, *metadata_identity),
+            )
+        )
+    steps.append(
+        _step(
+            family,
+            operation="validate",
+            direction="upgrade",
+            kind="wire_validation",
+            source_version=source_label,
+            target_version=source_label,
+            schema_path=_ROOT_PATH,
+            semantics="not_applicable",
+            ordinal=source_index,
+            identity_details=(source.wire_model_kind,),
+        )
+    )
+    steps.extend(
+        _projection_steps(
+            family,
+            operation="validate",
+            direction="upgrade",
+            source_version=source_label,
+            target_version=source_label,
+            descriptions=_describe_version(source).projections,
+            render=False,
+        )
+    )
+    for edge_index, transition in enumerate(transitions[source_index:], start=source_index):
+        kind: StepKind = transition.upgrade_kind
+        semantics: StepSemantics = "exact" if kind == "implicit_identity" else "not_applicable"
+        steps.append(
+            _step(
+                family,
+                operation="validate",
+                direction="upgrade",
+                kind=kind,
+                source_version=transition.source,
+                target_version=transition.target,
+                schema_path=_ROOT_PATH,
+                semantics=semantics,
+                ordinal=edge_index,
+                identity_details=(transition.upgrade_kind,),
+            )
+        )
+    steps.append(
+        _step(
+            family,
+            operation="validate",
+            direction="upgrade",
+            kind="current_validation",
+            source_version=current_label,
+            target_version=current_label,
+            schema_path=_ROOT_PATH,
+            semantics="not_applicable",
+            ordinal=0,
+        )
+    )
+    return ConversionPlan(
+        family=family.name,
+        source_version=source_label,
+        target_version=current_label,
+        operation="validate",
+        semantics="not_applicable",
+        steps=tuple(steps),
+    )
+
+
+def _build_render_plan(
+    family: SchemaFamily[Any],
+    versions: tuple[_CompiledVersion, ...],
+    transitions: tuple[_CompiledTransition, ...],
+    *,
+    target_index: int,
+) -> ConversionPlan:
+    current_label = versions[-1].projection.label
+    target = versions[target_index]
+    target_label = target.projection.label
+    steps: list[PlanStep] = [
+        _step(
+            family,
+            operation="render",
+            direction="downgrade",
+            kind="current_validation",
+            source_version=current_label,
+            target_version=current_label,
+            schema_path=_ROOT_PATH,
+            semantics="not_applicable",
+            ordinal=0,
+        )
+    ]
+
+    route = tuple(enumerate(transitions[target_index:], start=target_index))
+    for edge_index, transition in reversed(route):
+        kind: StepKind = (
+            "custom_transition"
+            if transition.downgrade_kind == "unavailable"
+            else transition.downgrade_kind
+        )
+        steps.append(
+            _step(
+                family,
+                operation="render",
+                direction="downgrade",
+                kind=kind,
+                source_version=transition.target,
+                target_version=transition.source,
+                schema_path=_ROOT_PATH,
+                semantics=transition.downgrade_semantics,
+                ordinal=edge_index,
+                identity_details=(
+                    transition.downgrade_kind,
+                    transition.downgrade_semantics,
+                ),
+            )
+        )
+    steps.extend(
+        _projection_steps(
+            family,
+            operation="render",
+            direction="downgrade",
+            source_version=target_label,
+            target_version=target_label,
+            descriptions=_describe_version(target).projections,
+            render=True,
+        )
+    )
+    if family.version_metadata is not None:
+        metadata_identity = _version_path_identity(family.version_metadata.path)
+        steps.append(
+            _step(
+                family,
+                operation="render",
+                direction="downgrade",
+                kind="metadata",
+                source_version=target_label,
+                target_version=target_label,
+                schema_path=_schema_path(family.version_metadata.path),
+                semantics="not_applicable",
+                ordinal=0,
+                identity_details=(family.version_metadata.owner, *metadata_identity),
+            )
+        )
+    steps.extend(
+        (
+            _step(
+                family,
+                operation="render",
+                direction="downgrade",
+                kind="wire_validation",
+                source_version=target_label,
+                target_version=target_label,
+                schema_path=_ROOT_PATH,
+                semantics="not_applicable",
+                ordinal=target_index,
+                identity_details=(target.wire_model_kind,),
+            ),
+            _step(
+                family,
+                operation="render",
+                direction="downgrade",
+                kind="serialization",
+                source_version=target_label,
+                target_version=target_label,
+                schema_path=_ROOT_PATH,
+                semantics="not_applicable",
+                ordinal=0,
+            ),
+        )
+    )
+    semantics: StepSemantics = "exact"
+    if any(step.semantics == "unavailable" for step in steps):
+        semantics = "unavailable"
+    elif any(step.semantics == "lossy" for step in steps):
+        semantics = "lossy"
+    return ConversionPlan(
+        family=family.name,
+        source_version=current_label,
+        target_version=target_label,
+        operation="render",
+        semantics=semantics,
+        steps=tuple(steps),
+    )
+
+
+def _projection_steps(
+    family: SchemaFamily[Any],
+    *,
+    operation: Literal["validate", "render"],
+    direction: Literal["upgrade", "downgrade"],
+    source_version: str,
+    target_version: str,
+    descriptions: tuple[ProjectionDescription, ...],
+    render: bool,
+) -> tuple[PlanStep, ...]:
+    steps: list[PlanStep] = []
+    for ordinal, description in enumerate(descriptions):
+        semantics: StepSemantics = "not_applicable"
+        if render:
+            semantics = "lossy" if description.kind == "removed" else "exact"
+        steps.append(
+            _step(
+                family,
+                operation=operation,
+                direction=direction,
+                kind="projection",
+                source_version=source_version,
+                target_version=target_version,
+                schema_path=description.current_field,
+                semantics=semantics,
+                ordinal=ordinal,
+                identity_details=(
+                    description.kind,
+                    description.historical_field or "",
+                    "default" if description.has_default else "required",
+                ),
+            )
+        )
+    return tuple(steps)
+
+
+def _step(
+    family: SchemaFamily[Any],
+    *,
+    operation: Literal["validate", "render"],
+    direction: Literal["upgrade", "downgrade"],
+    kind: StepKind,
+    source_version: str,
+    target_version: str,
+    schema_path: str,
+    semantics: StepSemantics,
+    ordinal: int,
+    identity_details: tuple[str, ...] = (),
+) -> PlanStep:
+    components = (
+        family.model.__module__,
+        family.model.__qualname__,
+        family.name,
+        operation,
+        direction,
+        kind,
+        source_version,
+        target_version,
+        schema_path,
+        semantics,
+        str(ordinal),
+        *identity_details,
+    )
+    return PlanStep(
+        id=f"pv1-{_stable_digest(components)}",
+        family=family.name,
+        source_version=source_version,
+        target_version=target_version,
+        operation=operation,
+        direction=direction,
+        kind=kind,
+        schema_path=schema_path,
+        semantics=semantics,
+        conditional=False,
+    )
+
+
+def _schema_path(path: VersionPath) -> str:
+    if isinstance(path, str):
+        return path if path.isidentifier() else f"$[{json.dumps(path, ensure_ascii=False)}]"
+    return "$" + "".join(
+        f".{part}" if part.isidentifier() else f"[{json.dumps(part, ensure_ascii=False)}]"
+        for part in path
+    )
+
+
+def _version_path_identity(path: VersionPath) -> tuple[str, ...]:
+    if isinstance(path, str):
+        return ("field", path)
+    return ("nested", *path)

--- a/src/pydantic_versions/exceptions.py
+++ b/src/pydantic_versions/exceptions.py
@@ -13,6 +13,10 @@ class SchemaFamilySelectionError(SchemaVersionError):
     """Raised when a model-only call has no unambiguous explicit default family."""
 
 
+class IrreversibleTransitionError(SchemaVersionError):
+    """Raised when a complete render route cannot be planned safely."""
+
+
 class MissingSchemaVersionError(SchemaVersionError):
     """Raised when a schema version cannot be discovered for input data."""
 

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -16,6 +16,7 @@ from pydantic_versions._compiler import (
     _validate_family_declarations,
     _validate_required_field_introductions,
 )
+from pydantic_versions._planning import _build_planning_catalog
 from pydantic_versions._runtime import (
     _build_model_for_projection,
     _dump_family,
@@ -36,10 +37,12 @@ from pydantic_versions.declarations import (
 from pydantic_versions.exceptions import (
     DuplicateSchemaVersionError,
     InvalidMigrationError,
+    IrreversibleTransitionError,
     SchemaCompilationError,
     SchemaFamilySelectionError,
     UnknownSchemaVersionError,
 )
+from pydantic_versions.inspection import ConversionPlan, SchemaInventory
 
 _DEFAULT_FAMILIES: dict[type[BaseModel], SchemaFamily[Any]] = {}
 _FAMILY_LOCK = RLock()
@@ -152,8 +155,17 @@ class SchemaFamily[T: BaseModel]:
                     _CompiledVersion(
                         projection=projection,
                         model=_build_model_for_projection(self, projection),
+                        wire_model_kind=(
+                            "current"
+                            if index == len(projections) - 1
+                            else "explicit"
+                            if declaration.wire_model is not None
+                            else "generated"
+                        ),
                     )
-                    for projection in projections
+                    for index, (projection, declaration) in enumerate(
+                        zip(projections, self.versions, strict=True)
+                    )
                 )
                 explicit = {
                     (transition.source, transition.target): transition
@@ -167,6 +179,11 @@ class SchemaFamily[T: BaseModel]:
                         strict=False,
                     )
                 )
+                catalog = _build_planning_catalog(
+                    self,
+                    compiled_versions,
+                    compiled_transitions,
+                )
                 self._compiled = _CompiledFamily(
                     model=self.model,
                     name=self.name,
@@ -174,6 +191,7 @@ class SchemaFamily[T: BaseModel]:
                     transitions=compiled_transitions,
                     version_metadata=self.version_metadata,
                     missing_version=self.missing_version,
+                    catalog=catalog,
                 )
             finally:
                 self._compiling = False
@@ -191,6 +209,30 @@ class SchemaFamily[T: BaseModel]:
                 )
                 raise SchemaFamilySelectionError(msg)
         return self
+
+    def describe(self) -> SchemaInventory:
+        return self._compiled_family().catalog.inventory
+
+    def plan_validation(self, source_version: str) -> ConversionPlan:
+        requested = _runtime_label(source_version, family_name=self.name)
+        compiled = self._compiled_family()
+        return compiled.catalog.validation_plans[compiled.index(requested)]
+
+    def plan_render(self, target_version: str) -> ConversionPlan:
+        requested = _runtime_label(target_version, family_name=self.name)
+        compiled = self._compiled_family()
+        candidate = compiled.catalog.render_plans[compiled.index(requested)]
+        if candidate.semantics == "unavailable":
+            blocked = next(step for step in candidate.steps if step.semantics == "unavailable")
+            msg = (
+                f"Schema family {self.name!r} cannot render "
+                f"{candidate.source_version!r} -> {candidate.target_version!r}: "
+                f"transition {blocked.target_version!r} -> "
+                f"{blocked.source_version!r} has no declared downgrade for render step "
+                f"{blocked.source_version!r} -> {blocked.target_version!r}"
+            )
+            raise IrreversibleTransitionError(msg)
+        return candidate
 
     def model_for(self, version: str) -> type[BaseModel]:
         requested = _runtime_label(version, family_name=self.name)

--- a/src/pydantic_versions/inspection.py
+++ b/src/pydantic_versions/inspection.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic_versions.declarations import JsonValue, VersionMetadata
+
+__all__ = [
+    "ConversionPlan",
+    "NestedFamilyDescription",
+    "PlanStep",
+    "ProjectionDescription",
+    "SchemaInventory",
+    "StepKind",
+    "StepSemantics",
+    "TransitionDescription",
+    "VersionDescription",
+]
+
+type StepKind = Literal[
+    "wire_validation",
+    "projection",
+    "implicit_identity",
+    "custom_transition",
+    "nested",
+    "current_validation",
+    "serialization",
+    "metadata",
+]
+type StepSemantics = Literal[
+    "not_applicable",
+    "exact",
+    "lossy",
+    "unavailable",
+]
+
+
+class _SerializableRecord:
+    def to_dict(self) -> dict[str, JsonValue]:
+        raise NotImplementedError
+
+
+def _record_list(records: tuple[_SerializableRecord, ...]) -> list[JsonValue]:
+    return [record.to_dict() for record in records]
+
+
+@dataclass(frozen=True)
+class ProjectionDescription(_SerializableRecord):
+    kind: Literal["default", "removed", "renamed"]
+    current_field: str
+    historical_field: str | None
+    has_default: bool
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return {
+            "kind": self.kind,
+            "current_field": self.current_field,
+            "historical_field": self.historical_field,
+            "has_default": self.has_default,
+        }
+
+
+@dataclass(frozen=True)
+class VersionDescription(_SerializableRecord):
+    label: str
+    wire_model: Literal["current", "generated", "explicit"]
+    projections: tuple[ProjectionDescription, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "projections", tuple(self.projections))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return {
+            "label": self.label,
+            "wire_model": self.wire_model,
+            "projections": _record_list(self.projections),
+        }
+
+
+@dataclass(frozen=True)
+class TransitionDescription(_SerializableRecord):
+    source: str
+    target: str
+    upgrade: Literal["implicit_identity", "custom"]
+    downgrade: Literal["implicit_identity", "custom", "unavailable"]
+    downgrade_semantics: StepSemantics
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return {
+            "source": self.source,
+            "target": self.target,
+            "upgrade": self.upgrade,
+            "downgrade": self.downgrade,
+            "downgrade_semantics": self.downgrade_semantics,
+        }
+
+
+@dataclass(frozen=True)
+class NestedFamilyDescription(_SerializableRecord):
+    schema_path: str
+    family: str
+    versions: tuple[tuple[str, str], ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "versions",
+            tuple((parent, child) for parent, child in self.versions),
+        )
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        versions: list[JsonValue] = []
+        for parent, child in self.versions:
+            pair: list[JsonValue] = [parent, child]
+            versions.append(pair)
+        return {
+            "schema_path": self.schema_path,
+            "family": self.family,
+            "versions": versions,
+        }
+
+
+@dataclass(frozen=True)
+class SchemaInventory(_SerializableRecord):
+    family: str
+    model: str
+    current_version: str
+    versions: tuple[VersionDescription, ...]
+    transitions: tuple[TransitionDescription, ...]
+    nested: tuple[NestedFamilyDescription, ...]
+    version_metadata: VersionMetadata | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "versions", tuple(self.versions))
+        object.__setattr__(self, "transitions", tuple(self.transitions))
+        object.__setattr__(self, "nested", tuple(self.nested))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        metadata: JsonValue = (
+            None if self.version_metadata is None else self.version_metadata.to_dict()
+        )
+        return {
+            "family": self.family,
+            "model": self.model,
+            "current_version": self.current_version,
+            "versions": _record_list(self.versions),
+            "transitions": _record_list(self.transitions),
+            "nested": _record_list(self.nested),
+            "version_metadata": metadata,
+        }
+
+
+@dataclass(frozen=True)
+class PlanStep(_SerializableRecord):
+    id: str
+    family: str
+    source_version: str
+    target_version: str
+    operation: Literal["validate", "render"]
+    direction: Literal["upgrade", "downgrade"]
+    kind: StepKind
+    schema_path: str
+    semantics: StepSemantics
+    conditional: bool
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return {
+            "id": self.id,
+            "family": self.family,
+            "source_version": self.source_version,
+            "target_version": self.target_version,
+            "operation": self.operation,
+            "direction": self.direction,
+            "kind": self.kind,
+            "schema_path": self.schema_path,
+            "semantics": self.semantics,
+            "conditional": self.conditional,
+        }
+
+
+@dataclass(frozen=True)
+class ConversionPlan(_SerializableRecord):
+    family: str
+    source_version: str
+    target_version: str
+    operation: Literal["validate", "render"]
+    semantics: StepSemantics
+    steps: tuple[PlanStep, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "steps", tuple(self.steps))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        return {
+            "family": self.family,
+            "source_version": self.source_version,
+            "target_version": self.target_version,
+            "operation": self.operation,
+            "semantics": self.semantics,
+            "steps": _record_list(self.steps),
+        }

--- a/tests/typing/schema_family_contract.py
+++ b/tests/typing/schema_family_contract.py
@@ -5,10 +5,20 @@ from typing import Any, assert_type
 from pydantic import BaseModel
 
 from pydantic_versions import (
+    ConversionPlan,
+    IrreversibleTransitionError,
+    NestedFamilyDescription,
+    PlanStep,
+    ProjectionDescription,
     SchemaCompilationError,
     SchemaFamily,
     SchemaFamilySelectionError,
+    SchemaInventory,
     SchemaVersion,
+    StepKind,
+    StepSemantics,
+    TransitionDescription,
+    VersionDescription,
     VersionedValidation,
     VersionPatch,
     VersionTransition,
@@ -40,6 +50,21 @@ family: SchemaFamily[AppConfig] = SchemaFamily(
 
 assert_type(family.compile(), SchemaFamily[AppConfig])
 assert_type(family.as_default(), SchemaFamily[AppConfig])
+inventory: SchemaInventory = family.describe()
+assert_type(inventory, SchemaInventory)
+assert_type(inventory.versions, tuple[VersionDescription, ...])
+assert_type(inventory.versions[0].projections, tuple[ProjectionDescription, ...])
+assert_type(inventory.transitions, tuple[TransitionDescription, ...])
+assert_type(inventory.nested, tuple[NestedFamilyDescription, ...])
+validation_plan: ConversionPlan = family.plan_validation("1")
+render_plan: ConversionPlan = family.plan_render("2")
+assert_type(validation_plan, ConversionPlan)
+assert_type(render_plan, ConversionPlan)
+assert_type(validation_plan.steps, tuple[PlanStep, ...])
+step_kind: StepKind = validation_plan.steps[0].kind
+step_semantics: StepSemantics = validation_plan.steps[0].semantics
+assert_type(step_kind, StepKind)
+assert_type(step_semantics, StepSemantics)
 assert_type(family.model_for("1"), type[BaseModel])
 assert_type(family.validate({"schema_version": "1"}), VersionedValidation[AppConfig])
 assert_type(model_for_version(family, "1"), type[BaseModel])
@@ -52,3 +77,4 @@ assert_type(dump_versioned(family, version="1"), dict[str, Any])
 
 compilation_error: type[Exception] = SchemaCompilationError
 selection_error: type[Exception] = SchemaFamilySelectionError
+irreversible_error: type[Exception] = IrreversibleTransitionError

--- a/tests/unit/test_inventory_and_plans.py
+++ b/tests/unit/test_inventory_and_plans.py
@@ -1,0 +1,686 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from threading import Barrier
+from typing import Any, cast
+
+import pytest
+from pydantic import BaseModel, Field
+
+from pydantic_versions import (
+    ConversionPlan,
+    InvalidMigrationError,
+    IrreversibleTransitionError,
+    NestedFamilyDescription,
+    PlanStep,
+    ProjectionDescription,
+    SchemaFamily,
+    SchemaFamilySelectionError,
+    SchemaInventory,
+    SchemaVersion,
+    TransitionDescription,
+    UnknownSchemaVersionError,
+    VersionDescription,
+    VersionMetadata,
+    VersionTransition,
+    field_default,
+    field_removed,
+    field_renamed,
+    migration,
+    validate_versioned,
+)
+
+
+class InventoryConfig(BaseModel):
+    timeout: float = 10.0
+    retries: int = 3
+    feature: bool = False
+
+
+class RenderConfig(BaseModel):
+    renamed: int = 1
+    removed: str = "current"
+
+
+class PrivacyConfig(BaseModel):
+    token: str = "current"
+    values: list[str] = Field(default_factory=list)
+
+
+class CollisionConfig(BaseModel):
+    value: int = 1
+
+
+def _identity(data: dict[str, Any]) -> dict[str, Any]:
+    return data
+
+
+class _CallableProbe:
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+        self.calls = 0
+
+    def __call__(self, data: dict[str, Any]) -> dict[str, Any]:
+        self.calls += 1
+        return data
+
+    def __repr__(self) -> str:
+        return f"<callable:{self.marker}>"
+
+
+class _FactoryProbe:
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+        self.calls = 0
+
+    def __call__(self) -> list[str]:
+        self.calls += 1
+        return [self.marker]
+
+    def __repr__(self) -> str:
+        return f"<factory:{self.marker}>"
+
+
+def _inventory_family(
+    *,
+    upgrade: Any = _identity,
+    name: str = "inventory",
+) -> SchemaFamily[InventoryConfig]:
+    return SchemaFamily(
+        model=InventoryConfig,
+        name=name,
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(
+                    field_default("timeout", 5.0),
+                    field_renamed("retries", "attempts"),
+                    field_removed("feature"),
+                ),
+            ),
+            SchemaVersion("2"),
+            SchemaVersion("3"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=upgrade),),
+    )
+
+
+def _structural_family(
+    *,
+    name: str = "structural",
+    remove_field: bool = True,
+) -> SchemaFamily[RenderConfig]:
+    patches = [field_renamed("renamed", "legacy_name")]
+    if remove_field:
+        patches.append(field_removed("removed"))
+    return SchemaFamily(
+        model=RenderConfig,
+        name=name,
+        versions=(
+            SchemaVersion("1", patches=tuple(patches)),
+            SchemaVersion("2"),
+        ),
+    )
+
+
+def _step_signature(
+    step: PlanStep,
+) -> tuple[str, str, str, str, str]:
+    return (
+        step.kind,
+        step.source_version,
+        step.target_version,
+        step.schema_path,
+        step.semantics,
+    )
+
+
+def _assert_json_safe(value: object) -> None:
+    if value is None or isinstance(value, bool | int | float | str):
+        return
+    if isinstance(value, list):
+        for item in value:
+            _assert_json_safe(item)
+        return
+    if isinstance(value, dict):
+        assert all(isinstance(key, str) for key in value)
+        for item in value.values():
+            _assert_json_safe(item)
+        return
+    pytest.fail(f"Non-JSON-safe value: {type(value).__name__}")
+
+
+def test_describe_returns_a_complete_frozen_inventory() -> None:
+    family = _inventory_family()
+
+    inventory = family.describe()
+
+    assert inventory == SchemaInventory(
+        family="inventory",
+        model=f"{InventoryConfig.__module__}.{InventoryConfig.__qualname__}",
+        current_version="3",
+        versions=(
+            VersionDescription(
+                label="1",
+                wire_model="generated",
+                projections=(
+                    ProjectionDescription(
+                        kind="default",
+                        current_field="timeout",
+                        historical_field="timeout",
+                        has_default=True,
+                    ),
+                    ProjectionDescription(
+                        kind="renamed",
+                        current_field="retries",
+                        historical_field="attempts",
+                        has_default=False,
+                    ),
+                    ProjectionDescription(
+                        kind="removed",
+                        current_field="feature",
+                        historical_field=None,
+                        has_default=False,
+                    ),
+                ),
+            ),
+            VersionDescription(label="2", wire_model="generated", projections=()),
+            VersionDescription(label="3", wire_model="current", projections=()),
+        ),
+        transitions=(
+            TransitionDescription(
+                source="1",
+                target="2",
+                upgrade="custom",
+                downgrade="unavailable",
+                downgrade_semantics="unavailable",
+            ),
+            TransitionDescription(
+                source="2",
+                target="3",
+                upgrade="implicit_identity",
+                downgrade="implicit_identity",
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(),
+        version_metadata=VersionMetadata(),
+    )
+    assert family.describe() is inventory
+    assert tuple(
+        (
+            f"{transition.source} -> {transition.target}",
+            transition.upgrade,
+            transition.downgrade,
+            transition.downgrade_semantics,
+        )
+        for transition in inventory.transitions
+    ) == (
+        ("1 -> 2", "custom", "unavailable", "unavailable"),
+        ("2 -> 3", "implicit_identity", "implicit_identity", "exact"),
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, inventory).family = "changed"
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, inventory.versions[0].projections[0]).kind = "removed"
+
+
+def test_public_nested_description_serializes_pairs_as_json_arrays() -> None:
+    description = NestedFamilyDescription(
+        schema_path="workers[*].retry",
+        family="retry",
+        versions=(("1", "legacy"), ("2", "current")),
+    )
+
+    assert description.to_dict() == {
+        "schema_path": "workers[*].retry",
+        "family": "retry",
+        "versions": [["1", "legacy"], ["2", "current"]],
+    }
+
+
+def test_public_records_defensively_freeze_caller_owned_sequences() -> None:
+    projections = [ProjectionDescription("removed", "value", None, False)]
+    versions = [VersionDescription("1", "generated", cast(Any, projections))]
+    transitions = [
+        TransitionDescription("1", "2", "implicit_identity", "implicit_identity", "exact")
+    ]
+    nested_versions = [["1", "legacy"]]
+    nested = [
+        NestedFamilyDescription(
+            "child",
+            "child_family",
+            cast(Any, nested_versions),
+        )
+    ]
+    inventory = SchemaInventory(
+        family="frozen",
+        model="tests.Config",
+        current_version="2",
+        versions=cast(Any, versions),
+        transitions=cast(Any, transitions),
+        nested=cast(Any, nested),
+        version_metadata=None,
+    )
+    steps = [
+        PlanStep(
+            id="pv1-test",
+            family="frozen",
+            source_version="1",
+            target_version="2",
+            operation="validate",
+            direction="upgrade",
+            kind="implicit_identity",
+            schema_path="$",
+            semantics="exact",
+            conditional=False,
+        )
+    ]
+    plan = ConversionPlan(
+        family="frozen",
+        source_version="1",
+        target_version="2",
+        operation="validate",
+        semantics="not_applicable",
+        steps=cast(Any, steps),
+    )
+
+    projections.clear()
+    versions.clear()
+    transitions.clear()
+    nested_versions[0][1] = "mutated"
+    nested.clear()
+    steps.clear()
+
+    assert inventory.versions[0].projections[0].current_field == "value"
+    assert inventory.transitions[0].source == "1"
+    assert inventory.nested[0].versions == (("1", "legacy"),)
+    assert plan.steps[0].kind == "implicit_identity"
+
+
+def test_projection_inventory_and_plan_order_follow_patch_declarations() -> None:
+    class OrderedProjectionConfig(BaseModel):
+        first: int = 1
+        second: int = 2
+
+    family = SchemaFamily(
+        model=OrderedProjectionConfig,
+        name="ordered_projections",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_removed("second"), field_removed("first")),
+            ),
+            SchemaVersion("2"),
+        ),
+    )
+
+    assert tuple(
+        projection.current_field for projection in family.describe().versions[0].projections
+    ) == ("second", "first")
+    assert tuple(
+        step.schema_path for step in family.plan_validation("1").steps if step.kind == "projection"
+    ) == ("second", "first")
+
+
+def test_validation_plan_exposes_structural_custom_and_identity_steps_in_order() -> None:
+    family = _inventory_family()
+
+    plan = family.plan_validation("1")
+
+    assert plan == ConversionPlan(
+        family="inventory",
+        source_version="1",
+        target_version="3",
+        operation="validate",
+        semantics="not_applicable",
+        steps=plan.steps,
+    )
+    assert tuple(map(_step_signature, plan.steps)) == (
+        ("metadata", "1", "1", "schema_version", "not_applicable"),
+        ("wire_validation", "1", "1", "$", "not_applicable"),
+        ("projection", "1", "1", "timeout", "not_applicable"),
+        ("projection", "1", "1", "retries", "not_applicable"),
+        ("projection", "1", "1", "feature", "not_applicable"),
+        ("custom_transition", "1", "2", "$", "not_applicable"),
+        ("implicit_identity", "2", "3", "$", "exact"),
+        ("current_validation", "3", "3", "$", "not_applicable"),
+    )
+    assert all(step.operation == "validate" for step in plan.steps)
+    assert all(step.direction == "upgrade" for step in plan.steps)
+    assert all(not step.conditional for step in plan.steps)
+    assert len({step.id for step in plan.steps}) == len(plan.steps)
+    assert all(re.fullmatch(r"pv1-[0-9a-f]{64}", step.id) for step in plan.steps)
+    assert family.plan_validation("1") is plan
+
+
+def test_validation_plans_are_scoped_to_the_requested_source() -> None:
+    family = _inventory_family()
+
+    middle = family.plan_validation("2")
+    current = family.plan_validation("3")
+
+    assert tuple(step.kind for step in middle.steps) == (
+        "metadata",
+        "wire_validation",
+        "implicit_identity",
+        "current_validation",
+    )
+    assert tuple(step.kind for step in current.steps) == (
+        "metadata",
+        "wire_validation",
+        "current_validation",
+    )
+    assert all(
+        not (step.source_version == "1" and step.target_version == "2")
+        for step in (*middle.steps, *current.steps)
+    )
+
+
+def test_family_without_version_metadata_omits_metadata_plan_steps() -> None:
+    family = SchemaFamily(
+        model=CollisionConfig,
+        name="unversioned_body",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    assert family.describe().version_metadata is None
+    assert tuple(step.kind for step in family.plan_validation("1").steps) == (
+        "wire_validation",
+        "implicit_identity",
+        "current_validation",
+    )
+    assert tuple(step.kind for step in family.plan_render("1").steps) == (
+        "current_validation",
+        "implicit_identity",
+        "wire_validation",
+        "serialization",
+    )
+
+
+def test_render_plan_reverses_edges_then_projects_and_marks_removal_lossy() -> None:
+    family = _structural_family()
+
+    plan = family.plan_render("1")
+
+    assert plan.source_version == "2"
+    assert plan.target_version == "1"
+    assert plan.operation == "render"
+    assert plan.semantics == "lossy"
+    assert tuple(map(_step_signature, plan.steps)) == (
+        ("current_validation", "2", "2", "$", "not_applicable"),
+        ("implicit_identity", "2", "1", "$", "exact"),
+        ("projection", "1", "1", "renamed", "exact"),
+        ("projection", "1", "1", "removed", "lossy"),
+        ("metadata", "1", "1", "schema_version", "not_applicable"),
+        ("wire_validation", "1", "1", "$", "not_applicable"),
+        ("serialization", "1", "1", "$", "not_applicable"),
+    )
+    assert all(step.operation == "render" for step in plan.steps)
+    assert all(step.direction == "downgrade" for step in plan.steps)
+    assert all(not step.conditional for step in plan.steps)
+
+
+def test_render_plan_is_exact_for_rename_only_and_current_targets() -> None:
+    family = _structural_family(name="exact_structural", remove_field=False)
+
+    historical = family.plan_render("1")
+    current = family.plan_render("2")
+
+    assert historical.semantics == "exact"
+    assert tuple(step.kind for step in historical.steps) == (
+        "current_validation",
+        "implicit_identity",
+        "projection",
+        "metadata",
+        "wire_validation",
+        "serialization",
+    )
+    assert current.semantics == "exact"
+    assert tuple(step.kind for step in current.steps) == (
+        "current_validation",
+        "metadata",
+        "wire_validation",
+        "serialization",
+    )
+    assert {step.id for step in family.plan_validation("1").steps}.isdisjoint(
+        step.id for step in historical.steps
+    )
+
+
+def test_impossible_render_route_fails_only_when_it_crosses_the_one_way_edge() -> None:
+    upgrade = _CallableProbe("private-upgrade")
+    family = _inventory_family(upgrade=upgrade, name="one_way")
+
+    inventory = family.describe()
+    validation = family.plan_validation("1")
+    reachable_render = family.plan_render("2")
+
+    assert inventory.transitions[0].downgrade == "unavailable"
+    assert "custom_transition" in {step.kind for step in validation.steps}
+    assert tuple(step.kind for step in reachable_render.steps) == (
+        "current_validation",
+        "implicit_identity",
+        "metadata",
+        "wire_validation",
+        "serialization",
+    )
+    with pytest.raises(IrreversibleTransitionError) as error:
+        family.plan_render("1")
+
+    message = str(error.value)
+    assert "one_way" in message
+    assert "'2' -> '1'" in message
+    assert "private-upgrade" not in message
+    assert upgrade.calls == 0
+
+
+@pytest.mark.parametrize("method", ["plan_validation", "plan_render"])
+def test_plan_version_arguments_remain_strict_and_typed(method: str) -> None:
+    family = _structural_family(name=f"strict_{method}")
+    planner = getattr(family, method)
+
+    with pytest.raises(UnknownSchemaVersionError):
+        planner(cast(Any, 1))
+    with pytest.raises(UnknownSchemaVersionError):
+        planner("unknown")
+
+
+def test_inventory_and_plans_are_json_safe_and_do_not_leak_private_objects() -> None:
+    upgrade = _CallableProbe("CALLABLE_SECRET")
+    factory = _FactoryProbe("FACTORY_SECRET")
+    family = SchemaFamily(
+        model=PrivacyConfig,
+        name="privacy",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(
+                    field_default("token", "DEFAULT_SECRET"),
+                    field_default("values", default_factory=factory),
+                ),
+            ),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=upgrade),),
+        version_metadata=VersionMetadata(("private", "version")),
+    )
+
+    inventory = family.describe()
+    plan = family.plan_validation("1")
+    serialized_records = (
+        json.dumps(inventory.to_dict(), allow_nan=False),
+        json.dumps(plan.to_dict(), allow_nan=False),
+        repr(inventory),
+        repr(plan),
+    )
+
+    _assert_json_safe(inventory.to_dict())
+    _assert_json_safe(plan.to_dict())
+    assert all(
+        marker not in rendered
+        for rendered in serialized_records
+        for marker in ("DEFAULT_SECRET", "FACTORY_SECRET", "CALLABLE_SECRET", "0x")
+    )
+    assert upgrade.calls == 0
+    assert factory.calls == 0
+    assert inventory.versions[0].projections == (
+        ProjectionDescription("default", "token", "token", True),
+        ProjectionDescription("default", "values", "values", True),
+    )
+
+    mutable_copy = inventory.to_dict()
+    versions = cast(list[dict[str, Any]], mutable_copy["versions"])
+    versions[0]["label"] = "mutated"
+    fresh_versions = cast(list[dict[str, Any]], inventory.to_dict()["versions"])
+    assert fresh_versions[0]["label"] == "1"
+
+
+def test_equivalent_declarations_have_stable_ids_without_callable_identity() -> None:
+    first_callable = _CallableProbe("first")
+    second_callable = _CallableProbe("second")
+    first = _inventory_family(upgrade=first_callable)
+    second = _inventory_family(upgrade=second_callable)
+
+    first_plan = first.plan_validation("1")
+    second_plan = second.plan_validation("1")
+
+    assert first.describe() == second.describe()
+    assert first_plan == second_plan
+    assert tuple(step.id for step in first_plan.steps) == tuple(
+        step.id for step in second_plan.steps
+    )
+    assert (
+        first_plan.steps[5].id
+        == "pv1-debe514195ae9a040548007eaea33abcd83a7c84ec8a9b24653bdfb28b15740d"
+    )
+    assert first_callable.calls == 0
+    assert second_callable.calls == 0
+
+
+def test_plan_json_is_deterministic_across_processes() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    local = json.dumps(
+        _inventory_family().plan_validation("1").to_dict(),
+        separators=(",", ":"),
+    )
+    script = (
+        "import json\n"
+        "from tests.unit.test_inventory_and_plans import _inventory_family\n"
+        "print(json.dumps("
+        "_inventory_family().plan_validation('1').to_dict(),"
+        "separators=(',', ':')))\n"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == local
+
+
+def test_step_ids_resist_sanitized_family_and_label_collisions() -> None:
+    dotted = SchemaFamily(
+        model=CollisionConfig,
+        name="plan.family",
+        versions=(SchemaVersion("1.0"), SchemaVersion("1-0")),
+    )
+    dashed = SchemaFamily(
+        model=CollisionConfig,
+        name="plan-family",
+        versions=(SchemaVersion("1.0"), SchemaVersion("1-0")),
+    )
+
+    dotted_ids = tuple(step.id for step in dotted.plan_validation("1.0").steps)
+    dashed_ids = tuple(step.id for step in dashed.plan_validation("1.0").steps)
+
+    assert len(set(dotted_ids)) == len(dotted_ids)
+    assert len(set(dashed_ids)) == len(dashed_ids)
+    assert set(dotted_ids).isdisjoint(dashed_ids)
+
+
+def test_metadata_schema_paths_distinguish_literal_and_nested_fields() -> None:
+    literal = SchemaFamily(
+        model=CollisionConfig,
+        name="metadata_path",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata("meta.version", owner="family"),
+    )
+    nested = SchemaFamily(
+        model=CollisionConfig,
+        name="metadata_path",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata(("meta", "version"), owner="family"),
+    )
+
+    literal_step = literal.plan_validation("1").steps[0]
+    nested_step = nested.plan_validation("1").steps[0]
+
+    assert literal_step.schema_path == '$["meta.version"]'
+    assert nested_step.schema_path == "$.meta.version"
+    assert literal_step.id != nested_step.id
+
+
+def test_inspection_freezes_legacy_migration_registration() -> None:
+    family = SchemaFamily(
+        model=CollisionConfig,
+        name="legacy_inspection",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+    )
+    first_upgrade = _CallableProbe("first-upgrade")
+    migration(family, "1", "2")(first_upgrade)
+
+    assert family.describe().transitions[0].upgrade == "custom"
+    assert first_upgrade.calls == 0
+
+    with pytest.raises(InvalidMigrationError, match="after.*compiled"):
+        migration(family, "2", "3")
+
+
+def test_concurrent_inspection_publishes_one_cached_side_effect_free_catalog() -> None:
+    class ConcurrentConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=ConcurrentConfig,
+        name="concurrent_inspection",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    schema_before = ConcurrentConfig.model_json_schema()
+    barrier = Barrier(8)
+
+    with pytest.raises(SchemaFamilySelectionError):
+        validate_versioned(ConcurrentConfig, {"schema_version": "1"})
+
+    def inspect_family(_: int) -> tuple[SchemaInventory, ConversionPlan, ConversionPlan]:
+        barrier.wait()
+        return (
+            family.describe(),
+            family.plan_validation("1"),
+            family.plan_render("1"),
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(inspect_family, range(8)))
+
+    first = results[0]
+    assert all(
+        inventory is first[0] and validation is first[1] and render is first[2]
+        for inventory, validation, render in results
+    )
+    assert ConcurrentConfig.model_json_schema() == schema_before
+    with pytest.raises(SchemaFamilySelectionError):
+        validate_versioned(ConcurrentConfig, {"schema_version": "1"})


### PR DESCRIPTION
## Summary

- Add frozen public inventory and plan records with deterministic JSON-safe `to_dict()` output.
- Add cached `SchemaFamily.describe()`, `plan_validation()`, and `plan_render()` APIs.
- Preserve declared projection order and expose structural, implicit-identity, custom, one-way, and lossy steps with unambiguous directions.
- Assign versioned full SHA-256 step IDs that exclude payloads, defaults, factories, callables, and unstable object representations.
- Reject render plans that cross an upgrade-only edge before payload execution.
- Document inventory-driven migration tables, plan semantics, privacy, and the plan-versus-trace boundary.

## Release rationale

This is the static-introspection foundation for 0.2.0. Applications can inspect migration topology and preflight a requested operation without reaching into decorator state or processing user data, while later runtime traces will have stable step identities to reference.

## Compatibility and migration impact

- Existing decorator and free-function APIs remain available.
- Inspection lazily compiles the family, so a later legacy `@migration` registration fails instead of mutating published plans. Constructor `transitions=` remains the deterministic declaration path.
- Validation and dictionary dumping are not yet driven by these public plans. Custom downgrade execution, explicit historical wire models, nested graph execution, and traces remain in their focused 0.2.0 issues.
- A render plan can now report structural lossiness or raise `IrreversibleTransitionError` for a route with no declared reverse transition.
- No package version, tag, upload, TestPyPI, PyPI, or release state changes are included.

## Contract details

- Projection steps follow the declared patch sequence.
- Metadata paths distinguish literal dotted fields from tuple-based nested paths.
- Step IDs use `pv1-` plus the full 64-character SHA-256 digest over length-prefixed safe declaration identity.
- Inventory and plan serialization contains no model objects, callable objects, default values/factories, payload values, exception text, timing, or host/user identifiers.

## Validation

- `uv run make ci`: 127 tests passed with 96.09% coverage; Ruff and ty passed.
- `uv run make docs-build-strict`: passed with no issues.
- `uv lock --check`: passed.
- `uv build`: wheel and source distribution built successfully.
- A fresh wheel installed outside the checkout passed the copied typing contract, runtime smoke, and `py.typed` check.
- `git diff --check`: no whitespace errors.
- All nine GitHub Actions jobs passed: lint/format, typing, docs, package build, Python 3.12/3.13/3.14 locked tests, exact-minimum Pydantic, and latest-Pydantic coverage.

Closes #5