### PR TITLE
feat: enforce generated models as wire contracts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Defined generated current and historical models as object-shaped Pydantic v2
+  wire contracts, with explicit preservation and behavior boundaries, exact
+  `Literal` version discriminators, deterministic identities, and contextual
+  `UnsupportedWireModelError` failures for unsafe automatic projections.
 - Added frozen schema inventories and deterministic validation/render plans with
   stable step IDs, visible implicit migrations, JSON-safe serialization, lossy
   projection semantics, and payload-free irreversible-route preflight.

--- a/docs/guide/complex-config-example.md
+++ b/docs/guide/complex-config-example.md
@@ -250,9 +250,10 @@ class PipelineDocument(BaseModel):
     spec: PipelineConfig
 ```
 
-For nested paths, the metadata wrapper does not have to be part of the Pydantic
-model. The version field is read before validation and removed before the source
-model is validated.
+For nested paths, the metadata wrapper does not have to be part of the
+authoritative application model. The generated wire model validates the
+complete wrapper, and family-owned metadata is removed only from the private
+transition value before final application-model validation.
 
 ## Rendering Older Configs
 

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -32,11 +32,13 @@ result = APP_CONFIG_SCHEMA.validate({"schema_version": "2"})
 config = result.current_model
 ```
 
-## Historical schemas
+## Generated wire schemas
 
-Historical schemas are independently derived from the current model with
-patches. This keeps simple default-only versions compact while still allowing
-validation against the older shape:
+Current and historical wire schemas are object-shaped Pydantic models generated
+from the current model's supported declarative field contract. They are not
+behavioral subclasses of the current model. Historical patches keep
+default-only versions compact while still allowing validation against an older
+shape:
 
 ```python
 from pydantic_versions import SchemaFamily, SchemaVersion, field_default
@@ -55,6 +57,14 @@ APP_CONFIG_SCHEMA = SchemaFamily(
     ),
 )
 ```
+
+Generated models preserve supported field constraints, defaults, factories,
+aliases, and declarative model configuration. Application validators, methods,
+computed fields, private attributes, and lifecycle configuration are not copied.
+The authoritative current model still performs final application validation.
+
+See [generated wire contracts](generated-wire-contracts.md) for the supported
+preserve, omit, and reject boundary.
 
 For a larger nested example that shows why this matters in practice, see the
 [complex config example](complex-config-example.md).

--- a/docs/guide/django-ninja.md
+++ b/docs/guide/django-ninja.md
@@ -13,6 +13,7 @@ The compatibility tests cover both schema-level behavior and a minimal real
 
 - generated historical schemas work as request body types;
 - current generated schemas work as request body types;
+- generated historical schemas work as response body types;
 - route handlers can upgrade historical payloads into the current schema;
 - generated historical models appear in the OpenAPI schema with historical field names.
 - `ModelSchema` classes preserve Django-derived field metadata such as string length constraints.
@@ -59,10 +60,10 @@ assert result.current_model == TaskPayload(
 )
 ```
 
-## Generated Historical Schemas
+## Generated Wire Schemas
 
-`model_for_version()` returns a generated Pydantic model that Django Ninja can
-inspect for JSON Schema/OpenAPI generation:
+`model_for_version()` returns an object-shaped Pydantic wire contract that
+Django Ninja can inspect for JSON Schema/OpenAPI generation:
 
 ```python
 from pydantic_versions import model_for_version
@@ -74,6 +75,13 @@ schema = TaskPayloadV1.model_json_schema()
 assert "is_completed" in schema["properties"]
 assert "completed" not in schema["properties"]
 ```
+
+The generated model preserves supported fields, constraints, defaults, and
+aliases, but it is not a behavioral subclass of `TaskPayload`. Model validators,
+methods, computed fields, and private attributes are not copied. Family
+validation still finishes with the authoritative current `TaskPayload` model.
+See [generated wire contracts](generated-wire-contracts.md) for the supported
+boundary.
 
 This supports explicit route-level schemas:
 
@@ -136,7 +144,9 @@ class TaskPayload(ModelSchema):
 
 The generated v1 schema exposes `completed`, keeps the historical timeout
 default, and preserves the `maxLength` constraint derived from the Django model's
-`CharField`.
+`CharField`. A model that uses an unsupported automatic-projection feature
+raises `UnsupportedWireModelError` during family compilation instead of
+producing a misleading OpenAPI schema.
 
 ## What To Test In Applications
 

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -1,0 +1,107 @@
+# Generated Wire Contracts
+
+`SchemaFamily.model_for()` and `model_for_version()` return Pydantic v2 models
+for declared schema versions. These generated models describe the data on the
+wire: they are suitable for direct Pydantic validation and serialization, JSON
+Schema generation, and framework inspection.
+
+Generated current and historical models are object-shaped wire contracts. They
+are not behavioral subclasses or complete copies of the authoritative current
+application model.
+
+## What Generation Preserves
+
+The compiler preserves declarations that define the supported wire shape and
+Pydantic's declarative handling of that shape:
+
+| Result | Current-model declaration | Generated wire contract |
+| --- | --- | --- |
+| Preserved | Field annotations, `Annotated` metadata, `Field` constraints, and JSON-serializable static field schema metadata | The generated field keeps the supported validation and JSON Schema contract. Pydantic's declarative built-in annotation types remain supported. |
+| Preserved | Required fields, direct defaults, and zero-argument default factories on unchanged annotations | Each version keeps its projected required/default/factory state. Compilation does not call default factories. |
+| Preserved | `alias`, `validation_alias`, `serialization_alias`, and alias generators | Unrenamed fields keep supported validation and serialization aliases. A historical rename defines a new Python field name instead of attaching the current field's explicit aliases to that different name. |
+| Preserved | Declarative model configuration | `extra`, `strict`, `populate_by_name`, `validate_by_alias`, `validate_by_name`, `serialize_by_alias`, `loc_by_alias`, `use_enum_values`, alias generators, supported string/number/temporal/bytes settings, a static title, and non-structural mapping-based JSON Schema metadata remain part of the wire contract. |
+| Omitted | Field and model validators, and field serializers | They remain behavior of the authoritative current model and are not copied onto generated models. Constraints carried by field annotations and metadata are still preserved. |
+| Omitted | Computed fields, private attributes, methods, and `model_post_init` | These application behaviors are not part of the wire contract. |
+| Omitted | Lifecycle-only configuration such as assignment validation and frozen instances | Generated models describe documents rather than application-object lifecycle behavior. |
+| Rejected | `RootModel`, an incomplete or unresolved generic model, or another non-object validation or serialization shape | Compilation raises `UnsupportedWireModelError`; resolve and rebuild an incomplete model, or wrap a root or scalar value in a named object field. |
+| Rejected | A model-level serializer, application-defined annotation or model schema hooks, behavioral dataclasses, callable schema/title mutation, non-JSON schema metadata, model schema metadata that replaces generated structure, legacy `json_encoders`, or arbitrary-type escape hatches | Automatic projection cannot safely reproduce that custom behavior and raises `UnsupportedWireModelError`. |
+| Rejected | Serialization exclusions such as `exclude`/`exclude_if`, callable discriminators, and unknown behavior-changing model or field settings | The automatic compiler fails closed instead of silently changing the wire document. |
+| Rejected at registration | Pydantic v1 compatibility models | The family raises `SchemaVersionError` before automatic projection; wire models must inherit from Pydantic v2's `BaseModel`. |
+
+Historical patches are applied to this preserved declaration state. A removed
+field is absent, a renamed field uses its historical Python name, and a default
+patch replaces the projected field's required/default/factory state.
+
+Zero-argument factories remain safe when the field annotation is unchanged. A
+decorator-owned child annotation can replace the child class itself as a
+factory, and a direct child instance is projected without running its
+serializers. Opaque factories for a projected child are rejected because they
+could construct the authoritative child and run its behavior on historical
+input. Any factory that consumes already validated field data is also rejected:
+automatic wire models intentionally omit current-model validators, so copying
+its materialized result could prevent the authoritative current factory from
+seeing the final values. Typed `__pydantic_extra__` values and schema or runtime
+behavior hidden inside either standard-library or `typing_extensions` type
+aliases are likewise rejected instead of being weakened or executed. Untyped
+`extra` behavior and JSON-serializable static schema metadata declared directly
+on a field remain supported.
+
+## Version Discriminators
+
+When a family declares version metadata, the generated document contract uses
+the exact version label rather than an unrestricted string:
+
+- With family-owned metadata, `model_for()` returns a complete document adapter
+  for every version, including the current version. The discriminator at the
+  configured path has annotation `Literal[label]` and default `label`.
+- With a supported validation-capable direct model-owned metadata field or
+  alias, every automatically
+  generated version, including the current version, is a distinct document
+  projection. Its declared metadata field has annotation `Literal[label]` and
+  default `label`. Output-only serialization aliases and validation locations
+  disabled by model configuration are rejected. The field or direct alias must
+  resolve unambiguously and keep one invariant location; nested model-owned
+  paths are not projected by this top-level wire compiler. The exact label
+  replaces other validation constraints on the generated discriminator while
+  keeping its aliases and descriptive field metadata; the authoritative current
+  field still validates the current label at the final application boundary.
+- With `version_metadata=None`, generation does not add a discriminator.
+
+This is a statement about the generated Pydantic and JSON Schema shape.
+Conversion-time version discovery, conflict handling, and metadata mutation are
+separate runtime concerns.
+
+## Current-Model Validation
+
+The current application model remains authoritative. Its validators, methods,
+and other application behavior can run during final current-model validation
+without being copied into a historical or current wire projection.
+
+Directly validating a generated model exercises only that wire contract and
+raises Pydantic's native `ValidationError` on invalid input. Use the family
+validation API when the desired result is an instance of the authoritative
+current model.
+
+## Unsupported Models
+
+`UnsupportedWireModelError` is a `SchemaCompilationError`. It is raised during
+family compilation when automatic generation cannot guarantee an object-shaped
+wire contract. The error identifies the family, model, and unsupported reason,
+plus the version when a failure is projection-specific, without rendering
+payloads, defaults, or callable representations.
+
+If Pydantic reports the underlying generation failure, that exception remains
+available as the chained cause.
+
+## Stable Generated Identities
+
+Generated classes have deterministic, collision-resistant names. The readable
+prefix contains sanitized current-model, family, and version-label components.
+The suffix is the first 12 hexadecimal characters of SHA-256 over
+length-prefixed UTF-8 values for the model module and qualified name, exact
+family name, and exact label.
+
+Consequently, labels whose readable forms sanitize to the same text, such as
+`1.0` and `1-0`, still receive distinct Python class names and JSON Schema
+components. Repeated compilation of one family reuses its cached generated
+model objects, while separate family identities do not share them.

--- a/docs/guide/version-discovery.md
+++ b/docs/guide/version-discovery.md
@@ -9,12 +9,13 @@
 
 ## Explicit version
 
-An explicit version wins over anything in the payload:
+An explicit version selects the expected wire contract when the version is
+known outside the payload:
 
 ```python
 result = validate_versioned(
     AppConfig,
-    {"schema_version": "2"},
+    {"timeout": 5.0},
     version="1",
 )
 
@@ -22,7 +23,9 @@ assert result.source_version == "1"
 ```
 
 Use this when the version is known from a filename, database column, API route,
-or another source outside the config body.
+or another source outside the config body. If the payload also carries version
+metadata, that discriminator must match the selected contract; the package does
+not overwrite a conflicting value.
 
 ## Top-level version fields
 
@@ -76,9 +79,10 @@ metadata:
 timeout: 5
 ```
 
-The metadata wrapper does not have to be part of the Pydantic model. The version
-field is removed before source-model validation, so strict models can still
-reject unrelated extra fields.
+The metadata wrapper does not have to be part of the authoritative application
+model. The generated wire model includes and validates the complete wrapper,
+then family-owned metadata is removed only from the private transition value.
+Strict application models can therefore still reject unrelated extra fields.
 
 ## Legacy unversioned configs
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -30,7 +30,8 @@ declaration sequence and has no default-selection side effect.
 - `describe()`: return the frozen compiled `SchemaInventory`.
 - `plan_validation(source_version)`: return the cached source-to-current `ConversionPlan`.
 - `plan_render(target_version)`: return the cached current-to-target `ConversionPlan`, or raise `IrreversibleTransitionError` if no complete reverse route exists.
-- `model_for(version)`: return the family-local generated wire model.
+- `model_for(version)`: return the family-local, object-shaped generated wire
+  contract for that declared version.
 - `validate(data, *, version=None)`: validate historical input and upgrade it to the current model.
 - `defaults_for(*, version, include_version=True, **dump_kwargs)`: render target defaults.
 - `dump(*, version, data=None, include_version=True, **dump_kwargs)`: return a target-version dictionary.
@@ -85,6 +86,41 @@ class VersionMetadata:
 Describes the version-discriminator path and its ownership. Full collision and
 alias semantics are defined by the 0.2 architecture decision and implemented by
 the later top-level conversion work.
+
+### Generated wire models
+
+`SchemaFamily.model_for()` and `model_for_version()` return generated Pydantic
+v2 wire contracts, not behavioral subclasses of the current model. Generated
+current and historical projections are object-shaped and preserve supported
+field annotations, constraints, defaults, factories, aliases, declarative model
+configuration, and static non-structural model schema metadata. Model metadata
+cannot replace generated object properties, requirements, or composition.
+
+They do not copy model or field validators, field serializers, computed fields,
+private attributes, methods, `model_post_init`, or lifecycle-only configuration.
+The authoritative current model remains responsible for final application
+validation.
+
+When version metadata is family-owned, the complete generated document adapter
+has an exact `Literal[label]` discriminator for every version, including
+current, with default `label`. With a supported validation-capable direct
+model-owned field or alias, every generated document projection, including
+current, declares its metadata field with exact annotation `Literal[label]` and
+default `label`. Output-only or disabled validation locations are rejected.
+That location must remain invariant; nested model-owned paths are rejected
+until the top-level conversion compiler can resolve them safely. No
+discriminator is added when `version_metadata=None`.
+
+Automatic projection raises `UnsupportedWireModelError` for a `RootModel`,
+unresolved generic, model-level serializer, overridden model core/JSON Schema
+hook, application-defined annotation hook, behavioral dataclass, callable or
+non-JSON schema mutation, structural model schema override, validated-data
+factory, legacy `json_encoders`, arbitrary-type escape hatch, serialization
+exclusion, or non-object validation or serialization shape. Pydantic v1 models
+instead fail registration with `SchemaVersionError`.
+See
+[generated wire contracts](../guide/generated-wire-contracts.md) for the full
+supported preserve, omit, and reject boundary.
 
 ### Reserved nested declarations
 
@@ -147,6 +183,9 @@ class SchemaInventory:
 `SchemaFamily.describe()` compiles the family if necessary and returns its
 cached inventory. Versions and transitions retain canonical declared order, and
 every adjacent edge is present even when its upgrade is an implicit identity.
+The inventory value `wire_model="current"` identifies the current version's
+semantic role; `model_for(current_version)` still returns a generated wire
+projection rather than the authoritative application class.
 Projection descriptions reveal whether a historical version changes a default,
 removes a field, or renames it, but never reveal a default value or factory.
 
@@ -277,8 +316,8 @@ during upgrade validation. Returns `FieldRenamed`.
 
 `model_for_version(subject, version)`
 
-Returns the generated Pydantic model for a declared version. `subject` may be a
-family or a model with an explicit default family.
+Returns the generated object-shaped Pydantic wire contract for a declared
+version. `subject` may be a family or a model with an explicit default family.
 
 `validate_versioned(subject, data, *, version=None)`
 
@@ -318,6 +357,7 @@ class VersionedValidation[T: BaseModel]:
 
 - `SchemaVersionError`
   - `SchemaCompilationError`
+    - `UnsupportedWireModelError`
   - `SchemaFamilySelectionError`
   - `IrreversibleTransitionError`
   - `MissingSchemaVersionError`
@@ -325,3 +365,10 @@ class VersionedValidation[T: BaseModel]:
   - `DuplicateSchemaVersionError`
   - `InvalidMigrationError`
   - `VersionedValidationError`
+
+`UnsupportedWireModelError` reports that automatic projection cannot safely
+produce the required object-shaped Pydantic v2 wire contract. It is raised
+during compilation and includes safe family, model, and unsupported-reason
+context, plus the version for projection-specific failures. Direct validation
+of a successfully generated wire model still raises Pydantic's native
+`ValidationError`.

--- a/src/pydantic_versions/__init__.py
+++ b/src/pydantic_versions/__init__.py
@@ -33,6 +33,7 @@ from pydantic_versions.exceptions import (
     SchemaFamilySelectionError,
     SchemaVersionError,
     UnknownSchemaVersionError,
+    UnsupportedWireModelError,
     VersionedValidationError,
 )
 from pydantic_versions.family import SchemaFamily
@@ -93,6 +94,7 @@ __all__ = [
     "TransitionData",
     "TransitionFunc",
     "TransitionDescription",
+    "UnsupportedWireModelError",
     "UnknownSchemaVersionError",
     "VersionMetadata",
     "VersionPatch",

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -1,20 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from copy import deepcopy
-from functools import reduce
-from operator import or_
-from types import GenericAlias, UnionType
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, create_model
-from pydantic_core import PydanticUndefined
+from pydantic import BaseModel
 
 from pydantic_versions._compiler import (
     _CompiledFamily,
     _CompiledVersion,
-    _generated_model_name,
-    _VersionProjection,
 )
 from pydantic_versions.declarations import VersionedValidation, VersionPath
 from pydantic_versions.exceptions import (
@@ -44,8 +37,8 @@ def _validate_family[T: BaseModel](
     compiled = family._compiled_family()
     source_version = _detect_version(compiled, data, explicit_version=version)
     source = compiled.version(source_version)
-    source_model = source.model.model_validate(_source_validation_input(compiled, data))
-    payload = _to_current_names(compiled, source, source_model.model_dump())
+    source_model = source.model.model_validate(data)
+    payload = _to_current_names(compiled, source, source_model.model_dump(by_alias=False))
 
     migrations_applied: list[tuple[str, str]] = []
     source_index = compiled.index(source_version)
@@ -59,7 +52,10 @@ def _validate_family[T: BaseModel](
         payload = migrated
         migrations_applied.append((transition.source, transition.target))
 
-    current_model = family.model.model_validate(_current_validation_input(family.model, payload))
+    current_model = family.model.model_validate(
+        _current_validation_input(family.model, payload),
+        by_name=True,
+    )
     return VersionedValidation(
         source_version=source_version,
         current_version=compiled.current_version,
@@ -84,9 +80,12 @@ def _dump_family[T: BaseModel](
     if data is None:
         target_model = target.model()
     elif isinstance(data, BaseModel):
-        target_model = target.model.model_validate(_to_version_names(target, data.model_dump()))
+        target_model = target.model.model_validate(
+            _to_version_names(target, data.model_dump(by_alias=False)),
+            by_name=True,
+        )
     else:
-        target_model = target.model.model_validate(_to_version_names(target, data))
+        target_model = target.model.model_validate(_to_version_names(target, data), by_name=True)
 
     dumped = target_model.model_dump(**dump_kwargs)
     if compiled.version_metadata is not None:
@@ -135,20 +134,6 @@ def _detect_version(
     )
     msg = f"Input data for {compiled.name!r} does not include {field_display!r}"
     raise MissingSchemaVersionError(msg)
-
-
-def _source_validation_input(compiled: _CompiledFamily, data: Any) -> Any:
-    metadata = compiled.version_metadata
-    if (
-        metadata is None
-        or metadata.owner == "model"
-        or isinstance(metadata.path, str)
-        or not isinstance(data, Mapping)
-    ):
-        return data
-    source_data = dict(data)
-    _remove_version_field(source_data, metadata.path)
-    return source_data
 
 
 def _get_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
@@ -201,133 +186,6 @@ def _version_field_display(version_field: VersionPath) -> str:
     return ".".join(version_field)
 
 
-def _version_field_default(
-    family: SchemaFamily[Any],
-    version: str,
-) -> tuple[str, Any] | None:
-    metadata = family.version_metadata
-    if metadata is None or metadata.owner != "family" or not isinstance(metadata.path, str):
-        return None
-    if metadata.path in family.model.model_fields:
-        return None
-    return metadata.path, Annotated[str, Field(default=version)]
-
-
-def _build_model_for_projection(
-    family: SchemaFamily[Any],
-    projection: _VersionProjection,
-) -> type[BaseModel]:
-    fields: dict[str, Any] = {}
-    for compiled_field in projection.fields:
-        if compiled_field.version_name is None:
-            continue
-        field_info = family.model.model_fields[compiled_field.current_name]
-        field_dict = field_info.asdict()
-        annotation = _rewrite_annotation(field_dict["annotation"], projection.label, family)
-        attributes = dict(field_dict["attributes"])
-        if compiled_field.version_name != compiled_field.current_name:
-            attributes["alias"] = None
-            attributes["alias_priority"] = None
-            attributes["validation_alias"] = None
-            attributes["serialization_alias"] = None
-        _rewrite_nested_default(
-            attributes,
-            field_dict["annotation"],
-            annotation,
-            family,
-        )
-        if compiled_field.default is not None:
-            if compiled_field.default.has_default:
-                attributes["default"] = deepcopy(compiled_field.default.default)
-                attributes["default_factory"] = None
-            else:
-                attributes["default"] = PydanticUndefined
-                attributes["default_factory"] = compiled_field.default.default_factory
-        fields[compiled_field.version_name] = Annotated[
-            annotation,
-            *field_dict["metadata"],
-            Field(**attributes),
-        ]
-
-    version_field_default = _version_field_default(family, projection.label)
-    if version_field_default is not None:
-        field_name, field_definition = version_field_default
-        if field_name not in fields:
-            fields[field_name] = field_definition
-
-    return create_model(
-        _generated_model_name(family.model, family.name, projection.label),
-        __config__=ConfigDict(**family.model.model_config),
-        __module__=family.model.__module__,
-        **fields,
-    )
-
-
-def _compat_child_family(
-    owner: SchemaFamily[Any],
-    annotation: Any,
-) -> SchemaFamily[Any] | None:
-    if not owner._decorator_created:
-        return None
-    if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
-        return None
-    from pydantic_versions.family import _default_family_for_model
-
-    child = _default_family_for_model(annotation)
-    if child is None or not child._decorator_created:
-        return None
-    owner_labels = tuple(version.label for version in owner.versions)
-    child_labels = tuple(version.label for version in child.versions)
-    if child_labels != owner_labels:
-        msg = (
-            f"Decorator child family {child.name!r} must use the exact labels of "
-            f"parent {owner.name!r}; declare an explicit nested mapping instead"
-        )
-        raise SchemaCompilationError(msg)
-    return child
-
-
-def _rewrite_annotation(annotation: Any, version: str, family: SchemaFamily[Any]) -> Any:
-    child = _compat_child_family(family, annotation)
-    if child is not None:
-        return child.model_for(version)
-
-    origin = get_origin(annotation)
-    if origin in (list, tuple, set, frozenset):
-        args = tuple(_rewrite_annotation(arg, version, family) for arg in get_args(annotation))
-        return GenericAlias(origin, args)
-    if origin is dict:
-        args = tuple(_rewrite_annotation(arg, version, family) for arg in get_args(annotation))
-        return GenericAlias(dict, args)
-    if origin in (Union, UnionType):
-        args = tuple(_rewrite_annotation(arg, version, family) for arg in get_args(annotation))
-        return reduce(or_, args)
-    return annotation
-
-
-def _rewrite_nested_default(
-    attributes: dict[str, Any],
-    original_annotation: Any,
-    version_annotation: Any,
-    family: SchemaFamily[Any],
-) -> None:
-    if original_annotation == version_annotation:
-        return
-    child = _compat_child_family(family, original_annotation)
-    if child is None or not (
-        isinstance(version_annotation, type) and issubclass(version_annotation, BaseModel)
-    ):
-        return
-    if attributes.get("default_factory") is original_annotation:
-        attributes["default_factory"] = version_annotation
-        return
-    default = attributes.get("default", PydanticUndefined)
-    if isinstance(default, original_annotation):
-        attributes["default"] = version_annotation.model_validate(
-            default.model_dump(exclude_defaults=True)
-        )
-
-
 def _to_current_names(
     compiled: _CompiledFamily,
     version: _CompiledVersion,
@@ -339,7 +197,10 @@ def _to_current_names(
         if metadata.owner == "family":
             _remove_version_field(normalized, metadata.path)
         else:
-            _set_version_field(normalized, metadata.path, compiled.current_version)
+            metadata_field = _model_metadata_field_name(compiled)
+            if metadata.path != metadata_field:
+                normalized.pop(metadata.path, None)
+            normalized[metadata_field] = compiled.current_version
     renamed = tuple(
         field
         for field in version.projection.fields
@@ -362,11 +223,39 @@ def _current_validation_input(
     model_cls: type[BaseModel], payload: dict[str, Any]
 ) -> dict[str, Any]:
     current_payload = dict(payload)
+    if model_cls.model_config.get("validate_by_alias", True) is False:
+        return current_payload
     for name, field_info in model_cls.model_fields.items():
-        alias = field_info.alias
-        if alias is not None and name in current_payload and alias not in current_payload:
-            current_payload[alias] = current_payload[name]
+        if name not in current_payload:
+            continue
+        validation_alias = field_info.validation_alias
+        alias = (
+            validation_alias
+            if isinstance(validation_alias, str)
+            else field_info.alias
+            if validation_alias is None
+            else None
+        )
+        if isinstance(alias, str):
+            current_payload[alias] = current_payload.pop(name)
     return current_payload
+
+
+def _model_metadata_field_name(compiled: _CompiledFamily) -> str:
+    metadata = compiled.version_metadata
+    if metadata is None or metadata.owner != "model" or not isinstance(metadata.path, str):
+        msg = f"Compiled family {compiled.name!r} has invalid model-owned version metadata"
+        raise SchemaCompilationError(msg)
+    for field_name, field_info in compiled.model.model_fields.items():
+        if metadata.path in (
+            field_name,
+            field_info.alias,
+            field_info.validation_alias,
+            field_info.serialization_alias,
+        ):
+            return field_name
+    msg = f"Compiled family {compiled.name!r} lost its model-owned version metadata field"
+    raise SchemaCompilationError(msg)
 
 
 def _to_version_names(version: _CompiledVersion, payload: Any) -> Any:

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -1,0 +1,1562 @@
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from dataclasses import is_dataclass
+from functools import reduce
+from operator import or_
+from types import GenericAlias, UnionType
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ForwardRef,
+    Literal,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
+from typing import (
+    TypeAliasType as StdlibTypeAliasType,
+)
+
+from annotated_types import GroupedMetadata, Not, Predicate
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    GetPydanticSchema,
+    WithJsonSchema,
+    create_model,
+)
+from pydantic.functional_serializers import PlainSerializer, WrapSerializer
+from pydantic.functional_validators import (
+    AfterValidator,
+    BeforeValidator,
+    PlainValidator,
+    WrapValidator,
+)
+from pydantic_core import PydanticUndefined
+from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
+
+from pydantic_versions._compiler import (
+    _generated_model_name,
+    _identifier_component,
+    _stable_digest,
+    _VersionProjection,
+)
+from pydantic_versions.exceptions import SchemaCompilationError, UnsupportedWireModelError
+
+if TYPE_CHECKING:
+    from pydantic_versions.family import SchemaFamily
+
+
+_TYPE_ALIAS_TYPES = (StdlibTypeAliasType, ExtensionsTypeAliasType)
+_SCHEMA_HOOK_NAMES = (
+    "__get_pydantic_core_schema__",
+    "__get_pydantic_json_schema__",
+    "__get_validators__",
+    "__modify_schema__",
+)
+_MISSING = object()
+
+_MODEL_SCHEMA_STRUCTURE_KEYS = frozenset(
+    {
+        "$defs",
+        "$dynamicRef",
+        "$ref",
+        "additionalProperties",
+        "allOf",
+        "anyOf",
+        "const",
+        "contains",
+        "dependentRequired",
+        "dependentSchemas",
+        "discriminator",
+        "else",
+        "enum",
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "if",
+        "items",
+        "maxContains",
+        "maxItems",
+        "maxLength",
+        "maxProperties",
+        "maximum",
+        "minContains",
+        "minItems",
+        "minLength",
+        "minProperties",
+        "minimum",
+        "multipleOf",
+        "not",
+        "oneOf",
+        "pattern",
+        "patternProperties",
+        "prefixItems",
+        "properties",
+        "propertyNames",
+        "required",
+        "then",
+        "type",
+        "unevaluatedProperties",
+        "uniqueItems",
+    }
+)
+
+
+_WIRE_CONFIG_KEYS = frozenset(
+    {
+        "alias_generator",
+        "allow_inf_nan",
+        "coerce_numbers_to_str",
+        "extra",
+        "json_schema_mode_override",
+        "json_schema_serialization_defaults_required",
+        "loc_by_alias",
+        "populate_by_name",
+        "regex_engine",
+        "ser_json_bytes",
+        "ser_json_inf_nan",
+        "ser_json_temporal",
+        "ser_json_timedelta",
+        "serialize_by_alias",
+        "str_max_length",
+        "str_min_length",
+        "str_strip_whitespace",
+        "str_to_lower",
+        "str_to_upper",
+        "strict",
+        "title",
+        "url_preserve_empty_path",
+        "use_enum_values",
+        "val_json_bytes",
+        "val_temporal_unit",
+        "validate_by_alias",
+        "validate_by_name",
+        "validate_default",
+    }
+)
+_DROPPED_CONFIG_KEYS = frozenset(
+    {
+        "cache_strings",
+        "defer_build",
+        "from_attributes",
+        "frozen",
+        "hide_input_in_errors",
+        "ignored_types",
+        "protected_namespaces",
+        "revalidate_instances",
+        "use_attribute_docstrings",
+        "validate_assignment",
+        "validate_return",
+        "validation_error_cause",
+    }
+)
+_REJECTED_CONFIG_KEYS = frozenset(
+    {
+        "arbitrary_types_allowed",
+        "field_title_generator",
+        "json_encoders",
+        "model_title_generator",
+        "plugin_settings",
+        "polymorphic_serialization",
+        "schema_generator",
+    }
+)
+_KNOWN_CONFIG_KEYS = (
+    _WIRE_CONFIG_KEYS | _DROPPED_CONFIG_KEYS | _REJECTED_CONFIG_KEYS | {"json_schema_extra"}
+)
+
+_WIRE_FIELD_ATTRIBUTES = frozenset(
+    {
+        "alias",
+        "alias_priority",
+        "default",
+        "default_factory",
+        "deprecated",
+        "description",
+        "discriminator",
+        "examples",
+        "json_schema_extra",
+        "serialization_alias",
+        "title",
+        "validate_default",
+        "validation_alias",
+    }
+)
+_DROPPED_FIELD_ATTRIBUTES = frozenset({"frozen", "init", "init_var", "kw_only", "repr"})
+_REJECTED_FIELD_ATTRIBUTES = frozenset({"exclude", "exclude_if", "field_title_generator"})
+_FUNCTIONAL_FIELD_BEHAVIOR = (
+    AfterValidator,
+    BeforeValidator,
+    PlainSerializer,
+    PlainValidator,
+    WrapSerializer,
+    WrapValidator,
+)
+_CUSTOM_MODEL_HOOKS = (
+    "__get_pydantic_core_schema__",
+    "__get_pydantic_json_schema__",
+    "model_json_schema",
+)
+
+
+def _validate_automatic_wire_model(family: SchemaFamily[Any]) -> None:
+    model = family.model
+    if getattr(model, "__pydantic_root_model__", False):
+        _raise_unsupported(family, "RootModel is not an object-shaped wire body")
+    if not getattr(model, "__pydantic_complete__", False):
+        _raise_unsupported(
+            family,
+            "the model is incomplete; resolve forward references and rebuild it first",
+        )
+
+    generic_metadata = getattr(model, "__pydantic_generic_metadata__", None)
+    if isinstance(generic_metadata, Mapping) and generic_metadata.get("parameters"):
+        _raise_unsupported(family, "unresolved generic parameters cannot define a wire body")
+
+    decorators = getattr(model, "__pydantic_decorators__", None)
+    if decorators is not None and getattr(decorators, "model_serializers", None):
+        _raise_unsupported(family, "model-level serializers cannot be projected automatically")
+
+    for hook in _CUSTOM_MODEL_HOOKS:
+        owner = _first_defining_class(model, hook)
+        if owner is not None and owner is not BaseModel:
+            _raise_unsupported(family, f"custom model hook {hook} cannot be projected")
+
+    _validate_model_config(family)
+    _validate_typed_extras(family)
+    _model_metadata_field(family)
+    _validate_family_metadata_collision(family)
+
+
+def _build_model_for_projection(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+) -> type[BaseModel]:
+    try:
+        return _build_model_for_projection_unchecked(family, projection)
+    except UnsupportedWireModelError:
+        raise
+    except Exception as exc:
+        msg = (
+            f"Automatic wire model for family {family.name!r}, version "
+            f"{projection.label!r}, and model {_model_display(family.model)!r} "
+            "could not be built safely"
+        )
+        raise UnsupportedWireModelError(msg) from exc
+
+
+def _build_model_for_projection_unchecked(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+) -> type[BaseModel]:
+    model_metadata_field = _model_metadata_field(family)
+    fields: dict[str, Any] = {}
+    for compiled_field in projection.fields:
+        if compiled_field.version_name is None:
+            if compiled_field.current_name == model_metadata_field:
+                _raise_unsupported(
+                    family,
+                    "model-owned version metadata cannot be removed from a wire version",
+                )
+            continue
+
+        field_info = family.model.model_fields[compiled_field.current_name]
+        if (
+            compiled_field.current_name == model_metadata_field
+            and compiled_field.default is not None
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                "model-owned version metadata cannot have a historical default patch",
+            )
+        if compiled_field.current_name != model_metadata_field and _factory_takes_validated_data(
+            field_info, compiled_field.default
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"validated-data default factory for field {compiled_field.current_name!r} "
+                "cannot be projected without materializing current-model behavior",
+            )
+        field_dict = field_info.asdict()
+        annotation = _rewrite_annotation(
+            field_dict["annotation"],
+            projection.label,
+            family,
+            field_name=compiled_field.current_name,
+            allow_child_projection=True,
+        )
+        attributes = _wire_field_attributes(
+            family,
+            compiled_field.current_name,
+            field_dict["attributes"],
+        )
+        if compiled_field.version_name != compiled_field.current_name:
+            if compiled_field.current_name == model_metadata_field:
+                _raise_unsupported(
+                    family,
+                    "model-owned version metadata must keep one invariant wire location",
+                )
+            attributes["alias"] = None
+            attributes["alias_priority"] = None
+            attributes["validation_alias"] = None
+            attributes["serialization_alias"] = None
+        if compiled_field.default is not None:
+            if compiled_field.default.has_default:
+                attributes["default"] = _safe_deepcopy(
+                    family,
+                    compiled_field.default.default,
+                    detail=f"default for field {compiled_field.current_name!r}",
+                )
+                attributes["default_factory"] = None
+            else:
+                attributes["default"] = PydanticUndefined
+                attributes["default_factory"] = compiled_field.default.default_factory
+        _rewrite_nested_default(
+            attributes,
+            field_dict["annotation"],
+            annotation,
+            family,
+            field_name=compiled_field.current_name,
+            version=projection.label,
+        )
+        if compiled_field.current_name == model_metadata_field:
+            annotation = _literal_type(projection.label)
+            attributes["default"] = projection.label
+            attributes["default_factory"] = None
+            attributes["json_schema_extra"] = None
+
+        metadata = (
+            ()
+            if compiled_field.current_name == model_metadata_field
+            else _wire_field_metadata(
+                family,
+                compiled_field.current_name,
+                field_dict["metadata"],
+            )
+        )
+        fields[compiled_field.version_name] = Annotated[
+            annotation,
+            *metadata,
+            Field(**attributes),
+        ]
+
+    _validate_metadata_field_name_collision(family, projection, fields)
+    _add_family_metadata_field(family, projection.label, fields)
+
+    generated = create_model(
+        _generated_model_name(family.model, family.name, projection.label),
+        __config__=_wire_model_config(family),
+        __module__=family.model.__module__,
+        **fields,
+    )
+    _validate_generated_metadata_aliases(
+        family,
+        projection,
+        generated,
+        model_metadata_field=model_metadata_field,
+    )
+    _validate_object_schema(family, projection, generated, mode="validation")
+    _validate_object_schema(family, projection, generated, mode="serialization")
+    return generated
+
+
+def _wire_model_config(family: SchemaFamily[Any]) -> ConfigDict:
+    config: dict[str, Any] = {
+        key: value for key, value in family.model.model_config.items() if key in _WIRE_CONFIG_KEYS
+    }
+    schema_extra = family.model.model_config.get("json_schema_extra")
+    if isinstance(schema_extra, Mapping):
+        config["json_schema_extra"] = _safe_deepcopy(
+            family,
+            dict(schema_extra),
+            detail="model JSON Schema metadata",
+        )
+    return ConfigDict(**config)
+
+
+def _factory_takes_validated_data(field_info: Any, patched_default: Any) -> bool:
+    if patched_default is None:
+        return bool(field_info.default_factory_takes_validated_data)
+    if patched_default.has_default:
+        return False
+    patched_field = Field(default_factory=patched_default.default_factory)
+    return bool(patched_field.default_factory_takes_validated_data)
+
+
+def _validate_model_config(family: SchemaFamily[Any]) -> None:
+    config = family.model.model_config
+    if any(not isinstance(key, str) for key in config):
+        _raise_unsupported(family, "model configuration keys must be strings")
+    unknown = sorted(set(config) - _KNOWN_CONFIG_KEYS)
+    if unknown:
+        _raise_unsupported(
+            family,
+            f"unsupported model configuration keys are set: {', '.join(unknown)}",
+        )
+
+    for key in sorted(_REJECTED_CONFIG_KEYS & set(config)):
+        if _has_effect(config[key]):
+            _raise_unsupported(family, f"model configuration {key!r} is not wire-declarative")
+
+    schema_extra = config.get("json_schema_extra")
+    if schema_extra is not None and not isinstance(schema_extra, Mapping):
+        _raise_unsupported(
+            family,
+            "callable model JSON Schema mutation cannot be projected automatically",
+        )
+    if isinstance(schema_extra, Mapping):
+        structural_keys = sorted(_MODEL_SCHEMA_STRUCTURE_KEYS & set(schema_extra))
+        if structural_keys:
+            _raise_unsupported(
+                family,
+                "model JSON Schema metadata cannot override generated structure: "
+                f"{', '.join(structural_keys)}",
+            )
+
+
+def _validate_typed_extras(family: SchemaFamily[Any]) -> None:
+    if family.model.model_config.get("extra") != "allow":
+        return
+    for owner in family.model.__mro__:
+        if owner is BaseModel:
+            continue
+        annotations = owner.__dict__.get("__annotations__", {})
+        if "__pydantic_extra__" in annotations:
+            _raise_unsupported(
+                family,
+                "typed extra values cannot be projected automatically",
+            )
+
+
+def _wire_field_attributes(
+    family: SchemaFamily[Any],
+    field_name: str,
+    source: Mapping[str, Any],
+) -> dict[str, Any]:
+    unknown = sorted(
+        set(source)
+        - _WIRE_FIELD_ATTRIBUTES
+        - _DROPPED_FIELD_ATTRIBUTES
+        - _REJECTED_FIELD_ATTRIBUTES
+    )
+    if unknown:
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses unsupported attributes: {', '.join(unknown)}",
+        )
+    for key in _REJECTED_FIELD_ATTRIBUTES:
+        if key in source and _has_effect(source[key]):
+            _raise_unsupported(
+                family,
+                f"field {field_name!r} uses non-declarative attribute {key!r}",
+            )
+
+    discriminator = source.get("discriminator")
+    discriminator_value = getattr(discriminator, "discriminator", discriminator)
+    if isinstance(discriminator, Discriminator) and type(discriminator) is not Discriminator:
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses a custom discriminator subtype",
+        )
+    if discriminator is not None and not isinstance(discriminator_value, str):
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses a callable discriminator",
+        )
+
+    schema_extra = source.get("json_schema_extra")
+    if schema_extra is not None and not isinstance(schema_extra, Mapping):
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses callable JSON Schema mutation",
+        )
+
+    attributes: dict[str, Any] = {}
+    for key in _WIRE_FIELD_ATTRIBUTES:
+        if key not in source:
+            continue
+        value = source[key]
+        if key == "default_factory" or value is PydanticUndefined:
+            attributes[key] = value
+        else:
+            attributes[key] = _safe_deepcopy(
+                family,
+                value,
+                detail=f"attribute {key!r} for field {field_name!r}",
+            )
+    return attributes
+
+
+def _wire_field_metadata(
+    family: SchemaFamily[Any],
+    field_name: str,
+    source: list[Any],
+) -> tuple[Any, ...]:
+    return _snapshot_wire_metadata(
+        family,
+        field_name,
+        source,
+        detail="metadata",
+    )
+
+
+def _snapshot_wire_metadata(
+    family: SchemaFamily[Any],
+    field_name: str,
+    source: Iterable[Any],
+    *,
+    detail: str,
+) -> tuple[Any, ...]:
+    snapshot: list[Any] = []
+    for item in source:
+        if isinstance(item, _FUNCTIONAL_FIELD_BEHAVIOR):
+            continue
+        if isinstance(item, Predicate | Not):
+            _raise_unsupported(
+                family,
+                f"field {field_name!r} uses callable predicate metadata",
+            )
+        if isinstance(item, GroupedMetadata) and not _is_trusted_declarative_type(
+            type(item),
+            include_annotated_types=True,
+        ):
+            _raise_unsupported(
+                family,
+                f"field {field_name!r} uses custom executable grouped metadata",
+            )
+        if isinstance(item, Discriminator):
+            if type(item) is not Discriminator:
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} uses a custom discriminator subtype",
+                )
+            if not isinstance(item.discriminator, str):
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} uses a callable discriminator",
+                )
+        elif isinstance(item, WithJsonSchema):
+            if type(item) is not WithJsonSchema:
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} uses a custom schema metadata subtype",
+                )
+        elif isinstance(item, GetPydanticSchema) or _has_schema_hook(item):
+            _raise_unsupported(
+                family,
+                f"field {field_name!r} uses custom schema or validation metadata",
+            )
+        snapshot.append(
+            _safe_deepcopy(
+                family,
+                item,
+                detail=f"{detail} for field {field_name!r}",
+            )
+        )
+    return tuple(snapshot)
+
+
+def _protocol_owners(item: Any) -> tuple[type[Any], ...]:
+    metaclass = type(item)
+    owners = list(_static_mro(metaclass))
+    if isinstance(item, type):
+        owners.extend(_static_mro(item))
+    deduped: list[type[Any]] = []
+    for owner in owners:
+        if owner not in deduped:
+            deduped.append(owner)
+    return tuple(deduped)
+
+
+def _static_type_attr(owner: type[Any], name: str, default: Any = None) -> Any:
+    try:
+        return type.__getattribute__(owner, name)
+    except AttributeError:
+        return default
+
+
+def _static_mro(owner: type[Any]) -> tuple[type[Any], ...]:
+    mro = _static_type_attr(owner, "__mro__", ())
+    return mro if isinstance(mro, tuple) else ()
+
+
+def _instance_dict(item: Any) -> Mapping[str, Any]:
+    try:
+        if isinstance(item, type):
+            return type.__getattribute__(item, "__dict__")
+        return object.__getattribute__(item, "__dict__")
+    except (AttributeError, TypeError):
+        return {}
+
+
+def _owner_has_dynamic_lookup(owner: type[Any]) -> bool:
+    if owner in (type, object):
+        return False
+    owner_dict = _instance_dict(owner)
+    return "__getattr__" in owner_dict or "__getattribute__" in owner_dict
+
+
+def _owner_has_schema_hook(owner: type[Any]) -> bool:
+    return any(name in _instance_dict(owner) for name in _SCHEMA_HOOK_NAMES)
+
+
+def _is_exact_module_member(owner: type[Any], *, module: str) -> bool:
+    module_name = _static_type_attr(owner, "__module__", None)
+    if not isinstance(module_name, str):
+        return False
+    if module_name != module and not module_name.startswith(module + "."):
+        return False
+    qualname = _static_type_attr(owner, "__qualname__", "")
+    if not qualname or qualname == "<locals>":
+        return False
+    current: Any = sys.modules.get(module_name)
+    if current is None:
+        return False
+    for component in qualname.split("."):
+        if component == "<locals>":
+            return False
+        namespace = _instance_dict(current) if isinstance(current, type) else vars(current)
+        if not isinstance(namespace, Mapping):
+            return False
+        value = namespace.get(component, _MISSING)
+        if value is _MISSING:
+            return False
+        current = value
+    return current is owner
+
+
+def _is_typing_reflection_owner(owner: type[Any]) -> bool:
+    module_name = _static_type_attr(owner, "__module__", "")
+    if not isinstance(module_name, str):
+        return False
+    if module_name in (
+        "typing",
+        "typing_extensions",
+        "types",
+        "collections.abc",
+        "builtins",
+    ):
+        return _is_exact_module_member(owner, module=module_name)
+    if module_name.startswith(("typing.", "typing_extensions.", "collections.abc.")):
+        return _is_exact_module_member(owner, module=module_name.split(".")[0])
+    return False
+
+
+def _has_schema_hook(item: Any) -> bool:
+    if any(name in _instance_dict(item) for name in _SCHEMA_HOOK_NAMES):
+        return True
+    return any(
+        _owner_has_dynamic_lookup(owner) or _owner_has_schema_hook(owner)
+        for owner in _protocol_owners(item)
+        if not _is_typing_reflection_owner(owner)
+    )
+
+
+def _has_custom_annotation_schema_hook(annotation: Any) -> bool:
+    if not isinstance(annotation, type):
+        return _has_schema_hook(annotation)
+    protocol_owners = tuple(
+        owner
+        for owner in _protocol_owners(annotation)
+        if _owner_has_dynamic_lookup(owner) or _owner_has_schema_hook(owner)
+    )
+    if not protocol_owners:
+        return False
+    if issubclass(annotation, BaseModel):
+        return any(
+            owner is not BaseModel and not _is_trusted_declarative_type(owner)
+            for owner in protocol_owners
+        )
+    return any(
+        not (
+            _is_trusted_declarative_type(owner, include_annotated_types=True)
+            or _is_typing_reflection_owner(owner)
+        )
+        for owner in protocol_owners
+    )
+
+
+def _is_trusted_declarative_type(
+    owner: type[Any],
+    *,
+    include_annotated_types: bool = False,
+) -> bool:
+    module_name = _static_type_attr(owner, "__module__", "")
+    prefixes = ("pydantic.", "pydantic_core")
+    if include_annotated_types:
+        prefixes = (*prefixes, "annotated_types")
+    if not (module_name == "pydantic" or module_name.startswith(prefixes)):
+        return False
+    return _is_exact_module_member(owner, module=module_name)
+
+
+def _decorators_have_behavior(annotation: Any) -> bool:
+    decorators = _instance_dict(annotation).get("__pydantic_decorators__", None)
+    if decorators is None:
+        return False
+    for name in (
+        "field_serializers",
+        "field_validators",
+        "model_serializers",
+        "model_validators",
+        "root_validators",
+        "validators",
+    ):
+        try:
+            if object.__getattribute__(decorators, name):
+                return True
+        except AttributeError:
+            continue
+    return False
+
+
+def _is_structured_annotation(annotation: Any) -> bool:
+    if not isinstance(annotation, type):
+        return False
+    if _mro_defines_attribute(annotation, "__dataclass_fields__"):
+        return is_dataclass(annotation)
+    if _mro_defines_attribute(annotation, "__required_keys__"):
+        return _mro_defines_attribute(annotation, "__optional_keys__") and _mro_defines_attribute(
+            annotation, "__total__"
+        )
+    return issubclass(annotation, tuple) and _mro_defines_attribute(annotation, "_fields")
+
+
+def _mro_defines_attribute(item: Any, attribute: str) -> bool:
+    if not isinstance(item, type):
+        return False
+    return any(attribute in _instance_dict(owner) for owner in _static_mro(item))
+
+
+def _mro_annotations(item: type[Any]) -> Iterable[tuple[str, Any]]:
+    if not isinstance(item, type):
+        return ()
+    return tuple(
+        (name, value)
+        for owner in _static_mro(item)
+        for name, value in _owner_annotations(owner).items()
+    )
+
+
+def _owner_annotations(owner: type[Any]) -> Mapping[str, Any]:
+    module_name = _static_type_attr(owner, "__module__", "")
+    module = sys.modules.get(module_name) if isinstance(module_name, str) else None
+    globals_dict = dict(_instance_dict(module) if module is not None else {})
+    builtins_object = globals_dict.get("__builtins__")
+    if not isinstance(builtins_object, Mapping):
+        globals_dict["__builtins__"] = vars(__import__("builtins"))
+    elif not isinstance(builtins_object, dict):
+        globals_dict["__builtins__"] = vars(builtins_object)
+
+    annotations = _instance_dict(owner).get("__annotations__")
+    if not isinstance(annotations, Mapping):
+        annotations = getattr(owner, "__annotations__", {})
+        if not isinstance(annotations, Mapping):
+            return {}
+
+    resolved = {}
+    localns = dict(_instance_dict(owner))
+    for name, value in annotations.items():
+        if not isinstance(value, str):
+            resolved[name] = value
+            continue
+        try:
+            resolved[name] = ForwardRef(value)._evaluate(
+                globalns=globals_dict,
+                localns=localns,
+                recursive_guard=frozenset(),
+            )
+        except (AttributeError, NameError, SyntaxError, TypeError):
+            resolved[name] = value
+    return resolved
+
+
+def _has_behavioral_structured_annotation(
+    annotation: Any,
+    *,
+    seen: set[int] | None = None,
+) -> bool:
+    if not _is_structured_annotation(annotation):
+        return False
+    visited = set() if seen is None else seen
+    if id(annotation) in visited:
+        return False
+    visited.add(id(annotation))
+    if _mro_defines_attribute(annotation, "__post_init__"):
+        return True
+    if _decorators_have_behavior(annotation):
+        return True
+    return any(
+        _annotation_contains_runtime_behavior(value, seen=visited)
+        for value in (value for _, value in _mro_annotations(annotation))
+    )
+
+
+def _annotation_contains_runtime_behavior(annotation: Any, *, seen: set[int]) -> bool:
+    if id(annotation) in seen:
+        return False
+    if _is_structured_annotation(annotation):
+        return _has_behavioral_structured_annotation(annotation, seen=seen)
+    seen.add(id(annotation))
+    if isinstance(annotation, str | ForwardRef):
+        return True
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        return _annotation_contains_runtime_behavior(annotation.__value__, seen=seen) or any(
+            _annotation_contains_runtime_behavior(value, seen=seen)
+            for parameter in annotation.__type_params__
+            for value in _type_parameter_values(parameter)
+        )
+    if isinstance(annotation, TypeVar):
+        return any(
+            _annotation_contains_runtime_behavior(value, seen=seen)
+            for value in _type_parameter_values(annotation)
+        )
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        return _annotation_contains_runtime_behavior(supertype, seen=seen)
+    if _has_custom_annotation_schema_hook(annotation):
+        return True
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        if _decorators_have_behavior(annotation):
+            return True
+
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return False
+    if origin is not None and _has_custom_annotation_schema_hook(origin):
+        return True
+    if origin is Annotated:
+        base, *metadata = get_args(annotation)
+        for item in metadata:
+            if isinstance(item, (*_FUNCTIONAL_FIELD_BEHAVIOR, Predicate, Not)):
+                return True
+            if isinstance(item, Discriminator) and (
+                type(item) is not Discriminator or not isinstance(item.discriminator, str)
+            ):
+                return True
+            if isinstance(item, WithJsonSchema) and type(item) is not WithJsonSchema:
+                return True
+            if isinstance(item, GroupedMetadata) and not _is_trusted_declarative_type(
+                type(item),
+                include_annotated_types=True,
+            ):
+                return True
+            if isinstance(item, GetPydanticSchema) or _has_schema_hook(item):
+                return True
+        return _annotation_contains_runtime_behavior(base, seen=seen)
+    return any(
+        _annotation_contains_runtime_behavior(argument, seen=seen)
+        for argument in get_args(annotation)
+    )
+
+
+def _type_parameter_values(parameter: Any) -> tuple[Any, ...]:
+    values: list[Any] = []
+    bound = getattr(parameter, "__bound__", None)
+    if bound is not None:
+        values.append(bound)
+    values.extend(getattr(parameter, "__constraints__", ()))
+    default = getattr(parameter, "__default__", None)
+    default_type = type(default)
+    if default is not None and not (
+        default_type.__module__ in ("typing", "typing_extensions")
+        and "NoDefault" in default_type.__name__
+    ):
+        values.append(default)
+    return tuple(values)
+
+
+def _validate_annotation_behavior(
+    family: SchemaFamily[Any],
+    field_name: str,
+    annotation: Any,
+    *,
+    hidden_in_alias: bool = False,
+) -> None:
+    if _has_custom_annotation_schema_hook(annotation):
+        location = " hidden in a type alias" if hidden_in_alias else ""
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses a custom annotation schema hook{location}",
+        )
+    if _has_behavioral_structured_annotation(annotation):
+        location = " hidden in a type alias" if hidden_in_alias else ""
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses a behavioral structured annotation{location}",
+        )
+    if isinstance(annotation, TypeVar) and any(
+        _annotation_contains_runtime_behavior(value, seen=set())
+        for value in _type_parameter_values(annotation)
+    ):
+        location = " hidden in a type alias" if hidden_in_alias else ""
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses a behavioral type parameter{location}",
+        )
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        if _annotation_contains_runtime_behavior(supertype, seen=set()):
+            location = " hidden in a type alias" if hidden_in_alias else ""
+            _raise_unsupported(
+                family,
+                f"field {field_name!r} uses a behavioral NewType target{location}",
+            )
+
+
+def _model_metadata_field(family: SchemaFamily[Any]) -> str | None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "model":
+        return None
+    if not isinstance(metadata.path, str):
+        _raise_unsupported(
+            family,
+            "nested model-owned version metadata requires the top-level conversion compiler",
+        )
+
+    matches = tuple(
+        field_name
+        for field_name, field_info in family.model.model_fields.items()
+        if metadata.path
+        in (
+            field_name,
+            field_info.alias,
+            field_info.validation_alias,
+            field_info.serialization_alias,
+        )
+    )
+    if len(matches) != 1:
+        _raise_unsupported(
+            family,
+            "model-owned version metadata must resolve to exactly one direct field or alias",
+        )
+    field_name = matches[0]
+    field_info = family.model.model_fields[field_name]
+    config = family.model.model_config
+    if metadata.path == field_name:
+        accepted_by_name = field_info.validation_alias is None or config.get(
+            "validate_by_name", False
+        )
+        accepted_by_alias = (
+            field_info.validation_alias == metadata.path
+            and config.get("validate_by_alias", True) is not False
+        )
+        if not (accepted_by_name or accepted_by_alias):
+            _raise_unsupported(
+                family,
+                "model-owned version metadata uses a field name disabled for validation",
+            )
+        return field_name
+
+    validation_alias = field_info.validation_alias
+    validation_path = (
+        validation_alias
+        if isinstance(validation_alias, str)
+        else field_info.alias
+        if validation_alias is None
+        else None
+    )
+    if metadata.path != validation_path:
+        _raise_unsupported(
+            family,
+            "model-owned version metadata must use an enabled direct validation location",
+        )
+    if config.get("validate_by_alias", True) is False:
+        _raise_unsupported(
+            family,
+            "model-owned version metadata uses an alias disabled for validation",
+        )
+    return field_name
+
+
+def _validate_family_metadata_collision(family: SchemaFamily[Any]) -> None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "family":
+        return
+    root_name = metadata.path if isinstance(metadata.path, str) else metadata.path[0]
+    for field_name, field_info in family.model.model_fields.items():
+        if (
+            root_name == field_name
+            or root_name == field_info.alias
+            or root_name == field_info.validation_alias
+            or root_name == field_info.serialization_alias
+        ):
+            _raise_unsupported(
+                family,
+                f"family-owned version metadata collides with body field {field_name!r}",
+            )
+
+
+def _validate_metadata_field_name_collision(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    fields: Mapping[str, Any],
+) -> None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "family":
+        return
+    root_name = metadata.path if isinstance(metadata.path, str) else metadata.path[0]
+    if root_name in fields:
+        _raise_projection_unsupported(
+            family,
+            projection,
+            f"family-owned version metadata collides with projected field {root_name!r}",
+        )
+
+
+def _validate_generated_metadata_aliases(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    model: type[BaseModel],
+    *,
+    model_metadata_field: str | None,
+) -> None:
+    metadata = family.version_metadata
+    if metadata is None:
+        return
+    metadata_root = metadata.path if isinstance(metadata.path, str) else metadata.path[0]
+    family_metadata_field = metadata_root if metadata.owner == "family" else None
+    reserved_roots = {metadata_root}
+    if model_metadata_field is not None:
+        metadata_field_info = model.model_fields[model_metadata_field]
+        metadata_paths = (
+            (model_metadata_field,),
+            *_alias_paths(metadata_field_info.alias),
+            *_alias_paths(metadata_field_info.validation_alias),
+            *_alias_paths(metadata_field_info.serialization_alias),
+        )
+        reserved_roots.update(path[0] for path in metadata_paths if path)
+
+    for field_name, field_info in model.model_fields.items():
+        if field_name == family_metadata_field or field_name == model_metadata_field:
+            continue
+        paths = (
+            (field_name,),
+            *_alias_paths(field_info.alias),
+            *_alias_paths(field_info.validation_alias),
+            *_alias_paths(field_info.serialization_alias),
+        )
+        if any(path and path[0] in reserved_roots for path in paths):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"version metadata overlaps projected field or alias {field_name!r}",
+            )
+
+
+def _alias_paths(alias: Any) -> tuple[tuple[str | int, ...], ...]:
+    if isinstance(alias, str):
+        return ((alias,),)
+    if isinstance(alias, AliasPath):
+        return (tuple(alias.path),)
+    if isinstance(alias, AliasChoices):
+        return tuple(path for choice in alias.choices for path in _alias_paths(choice))
+    return ()
+
+
+def _add_family_metadata_field(
+    family: SchemaFamily[Any],
+    version: str,
+    fields: dict[str, Any],
+) -> None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "family":
+        return
+    if not isinstance(metadata.path, str):
+        _add_nested_family_metadata_field(family, version, metadata.path, fields)
+        return
+    annotation = _literal_type(version)
+    fields[metadata.path] = Annotated[
+        annotation,
+        Field(
+            default=version,
+            alias=metadata.path,
+            alias_priority=2,
+            validation_alias=metadata.path,
+            serialization_alias=metadata.path,
+        ),
+    ]
+
+
+def _add_nested_family_metadata_field(
+    family: SchemaFamily[Any],
+    version: str,
+    path: tuple[str, ...],
+    fields: dict[str, Any],
+) -> None:
+    if len(path) == 1:
+        field_name = path[0]
+        annotation = _literal_type(version)
+        fields[field_name] = Annotated[
+            annotation,
+            Field(
+                default=version,
+                alias=field_name,
+                alias_priority=2,
+                validation_alias=field_name,
+                serialization_alias=field_name,
+            ),
+        ]
+        return
+
+    child_model: type[BaseModel] | None = None
+    for index in range(len(path) - 1, 0, -1):
+        field_name = path[index]
+        if child_model is None:
+            annotation = _literal_type(version)
+            field = Field(
+                default=version,
+                alias=field_name,
+                alias_priority=2,
+                validation_alias=field_name,
+                serialization_alias=field_name,
+            )
+        else:
+            annotation = child_model
+            field = Field(
+                default_factory=child_model,
+                alias=field_name,
+                alias_priority=2,
+                validation_alias=field_name,
+                serialization_alias=field_name,
+            )
+        field_definitions: dict[str, Any] = {field_name: Annotated[annotation, field]}
+        child_model = create_model(
+            _metadata_model_name(family, version, path, index),
+            __config__=_metadata_wrapper_config(family),
+            __module__=family.model.__module__,
+            **field_definitions,
+        )
+
+    if child_model is None:  # pragma: no cover - paths are non-empty and handled above
+        _raise_unsupported(family, "family-owned metadata path cannot be empty")
+    root_name = path[0]
+    fields[root_name] = Annotated[
+        child_model,
+        Field(
+            default_factory=child_model,
+            alias=root_name,
+            alias_priority=2,
+            validation_alias=root_name,
+            serialization_alias=root_name,
+        ),
+    ]
+
+
+def _metadata_wrapper_config(family: SchemaFamily[Any]) -> ConfigDict:
+    extra = family.model.model_config.get("extra")
+    if extra is None:
+        return ConfigDict()
+    return ConfigDict(extra=extra)
+
+
+def _metadata_model_name(
+    family: SchemaFamily[Any],
+    version: str,
+    path: tuple[str, ...],
+    index: int,
+) -> str:
+    components = (
+        family.model.__module__,
+        family.model.__qualname__,
+        family.name,
+        version,
+        "version-metadata",
+        *path[: index + 1],
+    )
+    suffix = _stable_digest(components)[:12]
+    return (
+        f"{_generated_model_name(family.model, family.name, version)}"
+        f"_Metadata_{_identifier_component(path[index])}_{suffix}"
+    )
+
+
+def _validate_object_schema(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    model: type[BaseModel],
+    *,
+    mode: Literal["validation", "serialization"],
+) -> None:
+    schema = model.model_json_schema(mode=mode)
+    try:
+        json.dumps(schema, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        msg = (
+            f"Automatic wire model for family {family.name!r}, version "
+            f"{projection.label!r}, and model {_model_display(family.model)!r} "
+            f"has a non-JSON-serializable {mode} schema"
+        )
+        raise UnsupportedWireModelError(msg) from exc
+    root: Any = schema
+    seen: set[str] = set()
+    while isinstance(root, Mapping) and isinstance(root.get("$ref"), str):
+        ref = root["$ref"]
+        if ref in seen or not ref.startswith("#/"):
+            break
+        seen.add(ref)
+        root = schema
+        for component in ref[2:].split("/"):
+            if not isinstance(root, Mapping) or component not in root:
+                root = None
+                break
+            root = root[component]
+    if not isinstance(root, Mapping) or root.get("type") != "object":
+        msg = (
+            f"Automatic wire model for family {family.name!r}, version "
+            f"{projection.label!r}, and model {_model_display(family.model)!r} "
+            f"has a non-object {mode} schema"
+        )
+        raise UnsupportedWireModelError(msg)
+
+
+def _first_defining_class(model: type[BaseModel], attribute: str) -> type[Any] | None:
+    return next((owner for owner in model.__mro__ if attribute in owner.__dict__), None)
+
+
+def _literal_type(value: str) -> Any:
+    return cast(Any, Literal)[value]
+
+
+def _has_effect(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, Mapping | tuple | list | set | frozenset) and not value:
+        return False
+    return True
+
+
+def _safe_deepcopy(
+    family: SchemaFamily[Any],
+    value: Any,
+    *,
+    detail: str,
+) -> Any:
+    try:
+        return deepcopy(value)
+    except Exception as exc:
+        msg = (
+            f"Automatic wire model for family {family.name!r} and model "
+            f"{_model_display(family.model)!r} cannot safely copy {detail}"
+        )
+        raise UnsupportedWireModelError(msg) from exc
+
+
+def _raise_unsupported(family: SchemaFamily[Any], detail: str) -> None:
+    msg = (
+        f"Automatic wire model for family {family.name!r} and model "
+        f"{_model_display(family.model)!r} is unsupported: {detail}"
+    )
+    raise UnsupportedWireModelError(msg)
+
+
+def _raise_projection_unsupported(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    detail: str,
+) -> None:
+    msg = (
+        f"Automatic wire model for family {family.name!r}, version "
+        f"{projection.label!r}, and model {_model_display(family.model)!r} "
+        f"is unsupported: {detail}"
+    )
+    raise UnsupportedWireModelError(msg)
+
+
+def _model_display(model: type[BaseModel]) -> str:
+    return f"{model.__module__}.{model.__qualname__}"
+
+
+def _compat_child_family(
+    owner: SchemaFamily[Any],
+    annotation: Any,
+) -> SchemaFamily[Any] | None:
+    if not owner._decorator_created:
+        return None
+    if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+        return None
+    from pydantic_versions.family import _default_family_for_model
+
+    child = _default_family_for_model(annotation)
+    if child is None or not child._decorator_created:
+        return None
+    owner_labels = tuple(version.label for version in owner.versions)
+    child_labels = tuple(version.label for version in child.versions)
+    if child_labels != owner_labels:
+        msg = (
+            f"Decorator child family {child.name!r} must use the exact labels of "
+            f"parent {owner.name!r}; declare an explicit nested mapping instead"
+        )
+        raise SchemaCompilationError(msg)
+    return child
+
+
+def _rewrite_annotation(
+    annotation: Any,
+    version: str,
+    family: SchemaFamily[Any],
+    *,
+    field_name: str,
+    allow_child_projection: bool,
+) -> Any:
+    child = _compat_child_family(family, annotation) if allow_child_projection else None
+    if child is not None:
+        return child.model_for(version)
+
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        _validate_type_alias(family, field_name, annotation)
+        return annotation
+    _validate_annotation_behavior(family, field_name, annotation)
+
+    origin = get_origin(annotation)
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        _validate_type_alias(family, field_name, origin)
+    if origin is not None:
+        _validate_annotation_behavior(family, field_name, origin)
+    if origin is Annotated:
+        base, *source_metadata = get_args(annotation)
+        rewritten = _rewrite_annotation(
+            base,
+            version,
+            family,
+            field_name=field_name,
+            allow_child_projection=allow_child_projection,
+        )
+        metadata = _snapshot_wire_metadata(
+            family,
+            field_name,
+            source_metadata,
+            detail="nested annotation metadata",
+        )
+        if not metadata:
+            return rewritten
+        return Annotated[rewritten, *metadata]
+
+    source_args = get_args(annotation)
+    if not source_args:
+        return annotation
+    legacy_container = origin in (
+        list,
+        tuple,
+        set,
+        frozenset,
+        dict,
+        Union,
+        UnionType,
+    )
+    args = tuple(
+        _rewrite_annotation(
+            arg,
+            version,
+            family,
+            field_name=field_name,
+            allow_child_projection=allow_child_projection and legacy_container,
+        )
+        for arg in source_args
+    )
+    if all(rewritten is source for rewritten, source in zip(args, source_args, strict=True)):
+        return annotation
+    if origin in (Union, UnionType):
+        return reduce(or_, args)
+    if isinstance(annotation, GenericAlias):
+        return GenericAlias(origin, args)
+    copy_with = getattr(annotation, "copy_with", None)
+    if callable(copy_with):
+        return copy_with(args)
+    try:
+        return origin[args]
+    except Exception as exc:
+        msg = (
+            f"Automatic wire model for family {family.name!r} and model "
+            f"{_model_display(family.model)!r} cannot safely rewrite annotation "
+            f"for field {field_name!r}"
+        )
+        raise UnsupportedWireModelError(msg) from exc
+
+
+def _validate_type_alias(
+    family: SchemaFamily[Any],
+    field_name: str,
+    alias: Any,
+    *,
+    seen: set[int] | None = None,
+) -> None:
+    visited = set() if seen is None else seen
+    if id(alias) in visited:
+        return
+    visited.add(id(alias))
+    _validate_type_alias_value(family, field_name, alias.__value__, seen=visited)
+    for parameter in alias.__type_params__:
+        for value in _type_parameter_values(parameter):
+            _validate_type_alias_value(family, field_name, value, seen=visited)
+
+
+def _validate_type_alias_value(
+    family: SchemaFamily[Any],
+    field_name: str,
+    value: Any,
+    *,
+    seen: set[int],
+) -> None:
+    if isinstance(value, _TYPE_ALIAS_TYPES):
+        _validate_type_alias(family, field_name, value, seen=seen)
+        return
+    origin = get_origin(value)
+    if origin is Literal:
+        return
+    if isinstance(value, str | ForwardRef):
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} has an unresolved forward reference hidden in a type alias",
+        )
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        _validate_type_alias(family, field_name, origin, seen=seen)
+    if origin is not None:
+        _validate_annotation_behavior(
+            family,
+            field_name,
+            origin,
+            hidden_in_alias=True,
+        )
+    _validate_annotation_behavior(
+        family,
+        field_name,
+        value,
+        hidden_in_alias=True,
+    )
+    if origin is Annotated:
+        base, *metadata = get_args(value)
+        for item in metadata:
+            if isinstance(item, (*_FUNCTIONAL_FIELD_BEHAVIOR, Predicate, Not)):
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} has runtime behavior hidden in a type alias",
+                )
+            if isinstance(item, Discriminator | WithJsonSchema):
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} has schema metadata hidden in a type alias",
+                )
+            elif isinstance(item, GroupedMetadata) and not _is_trusted_declarative_type(
+                type(item),
+                include_annotated_types=True,
+            ):
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} has executable metadata hidden in a type alias",
+                )
+            elif isinstance(item, GetPydanticSchema) or (_has_schema_hook(item)):
+                _raise_unsupported(
+                    family,
+                    f"field {field_name!r} has custom schema metadata hidden in a type alias",
+                )
+        _validate_type_alias_value(family, field_name, base, seen=seen)
+        return
+    for argument in get_args(value):
+        _validate_type_alias_value(family, field_name, argument, seen=seen)
+
+
+def _rewrite_nested_default(
+    attributes: dict[str, Any],
+    original_annotation: Any,
+    version_annotation: Any,
+    family: SchemaFamily[Any],
+    *,
+    field_name: str,
+    version: str,
+) -> None:
+    if original_annotation == version_annotation:
+        return
+    child = _compat_child_family(family, original_annotation)
+    if child is None or not (
+        isinstance(version_annotation, type) and issubclass(version_annotation, BaseModel)
+    ):
+        return
+    default_factory = attributes.get("default_factory")
+    if default_factory is original_annotation:
+        attributes["default_factory"] = version_annotation
+    elif callable(default_factory):
+        _raise_unsupported(
+            family,
+            f"field {field_name!r} uses an opaque factory for a projected nested model",
+        )
+    default = attributes.get("default", PydanticUndefined)
+    if isinstance(default, original_annotation):
+        attributes["default"] = _project_child_default_value(
+            default,
+            source_model=original_annotation,
+            target_model=version_annotation,
+            child=child,
+            owner=family,
+            version=version,
+        )
+
+
+def _project_child_default_value(
+    value: Any,
+    *,
+    source_model: type[BaseModel],
+    target_model: type[BaseModel],
+    child: SchemaFamily[Any],
+    owner: SchemaFamily[Any],
+    version: str,
+) -> BaseModel:
+    if not isinstance(value, source_model):  # pragma: no cover - narrowed by the caller
+        _raise_unsupported(owner, "a projected nested default changed type unexpectedly")
+    fields_set = value.model_fields_set
+    extra = value.__pydantic_extra__ or {}
+    payload = {
+        name: value.__dict__[name] if name in value.__dict__ else extra[name]
+        for name in fields_set
+        if name in value.__dict__ or name in extra
+    }
+
+    from pydantic_versions._runtime import _remove_version_field, _to_version_names
+
+    target_version = child._compiled_family().version(version)
+    projected = _to_version_names(target_version, payload)
+    safe_factory_fields: set[str] = set()
+    metadata = child.version_metadata
+    if metadata is not None and metadata.owner == "model":
+        metadata_field = _model_metadata_field(child)
+        if metadata_field is not None:  # pragma: no branch - owner='model' resolves a field
+            projected[metadata_field] = version
+    elif metadata is not None:
+        _remove_version_field(projected, metadata.path)
+        if not isinstance(metadata.path, str) and len(metadata.path) > 1:
+            metadata_root = metadata.path[0]
+            metadata_field_info = target_model.model_fields[metadata_root]
+            factory = metadata_field_info.default_factory
+            if (
+                isinstance(factory, type)
+                and issubclass(factory, BaseModel)
+                and factory is metadata_field_info.annotation
+            ):
+                safe_factory_fields.add(metadata_root)
+    factory_fields = sorted(
+        name
+        for name, field_info in target_model.model_fields.items()
+        if name not in projected
+        and name not in safe_factory_fields
+        and field_info.default_factory is not None
+    )
+    if factory_fields:
+        _raise_unsupported(
+            owner,
+            "a nested model default would execute default factories during compilation: "
+            f"{', '.join(factory_fields)}",
+        )
+    return target_model.model_construct(_fields_set=set(projected), **projected)

--- a/src/pydantic_versions/exceptions.py
+++ b/src/pydantic_versions/exceptions.py
@@ -9,6 +9,10 @@ class SchemaCompilationError(SchemaVersionError):
     """Raised when a schema-family declaration cannot be compiled safely."""
 
 
+class UnsupportedWireModelError(SchemaCompilationError):
+    """Raised when a model cannot be represented as an automatic wire contract."""
+
+
 class SchemaFamilySelectionError(SchemaVersionError):
     """Raised when a model-only call has no unambiguous explicit default family."""
 

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -18,10 +18,13 @@ from pydantic_versions._compiler import (
 )
 from pydantic_versions._planning import _build_planning_catalog
 from pydantic_versions._runtime import (
-    _build_model_for_projection,
     _dump_family,
     _runtime_label,
     _validate_family,
+)
+from pydantic_versions._wire import (
+    _build_model_for_projection,
+    _validate_automatic_wire_model,
 )
 from pydantic_versions.declarations import (
     _DEFAULT_VERSION_METADATA,
@@ -142,6 +145,7 @@ class SchemaFamily[T: BaseModel]:
                     transitions=self.transitions,
                     nested=self.nested,
                 )
+                _validate_automatic_wire_model(self)
                 projections = tuple(
                     _compile_projection(self.model, declaration) for declaration in self.versions
                 )

--- a/tests/typing/schema_family_contract.py
+++ b/tests/typing/schema_family_contract.py
@@ -18,6 +18,7 @@ from pydantic_versions import (
     StepKind,
     StepSemantics,
     TransitionDescription,
+    UnsupportedWireModelError,
     VersionDescription,
     VersionedValidation,
     VersionPatch,
@@ -76,5 +77,6 @@ assert_type(family.dump(version="1"), dict[str, Any])
 assert_type(dump_versioned(family, version="1"), dict[str, Any])
 
 compilation_error: type[Exception] = SchemaCompilationError
+unsupported_wire_error: type[SchemaCompilationError] = UnsupportedWireModelError
 selection_error: type[Exception] = SchemaFamilySelectionError
 irreversible_error: type[Exception] = IrreversibleTransitionError

--- a/tests/unit/test_django_ninja_compat.py
+++ b/tests/unit/test_django_ninja_compat.py
@@ -70,6 +70,8 @@ def test_generated_historical_model_has_openapi_json_schema_shape() -> None:
 
     assert schema["properties"]["is_completed"]["default"] is False
     assert schema["properties"]["timeout"]["default"] == 5.0
+    assert schema["properties"]["schema_version"]["const"] == "v1"
+    assert schema["properties"]["schema_version"]["default"] == "v1"
     assert "completed" not in schema["properties"]
 
 
@@ -120,6 +122,19 @@ def test_version_renames_take_precedence_over_ninja_aliases() -> None:
 TaskPayloadV1 = model_for_version(NinjaPayload, "v1")
 TaskPayloadV2 = model_for_version(NinjaPayload, "v2")
 
+
+@versioned_schema(
+    name="ninja_openapi_collision",
+    versions=["1.0", "1-0", "2"],
+    current="2",
+)
+class NinjaCollisionPayload(Schema):
+    value: int
+
+
+CollisionPayloadDotted = model_for_version(NinjaCollisionPayload, "1.0")
+CollisionPayloadDashed = model_for_version(NinjaCollisionPayload, "1-0")
+
 api = NinjaAPI(title="Versioned Test API", urls_namespace="test_ninja_compat")
 
 
@@ -145,6 +160,32 @@ create_task_v1.__annotations__["payload"] = TaskPayloadV1
 create_task_v2.__annotations__["payload"] = TaskPayloadV2
 api.post("/v1/tasks")(create_task_v1)
 api.post("/v2/tasks")(create_task_v2)
+
+
+def read_task_v1(request):
+    return {
+        "schema_version": "v1",
+        "name": "job",
+        "is_completed": True,
+        "timeout": 5.0,
+    }
+
+
+api.get("/v1/task-response", response=TaskPayloadV1)(read_task_v1)
+
+
+def accept_collision_dotted(request, payload):
+    return payload.model_dump()
+
+
+def accept_collision_dashed(request, payload):
+    return payload.model_dump()
+
+
+accept_collision_dotted.__annotations__["payload"] = CollisionPayloadDotted
+accept_collision_dashed.__annotations__["payload"] = CollisionPayloadDashed
+api.post("/collision/dotted")(accept_collision_dotted)
+api.post("/collision/dashed")(accept_collision_dashed)
 
 
 def test_generated_historical_schema_works_as_real_ninja_request_body() -> None:
@@ -179,6 +220,43 @@ def test_generated_current_schema_works_as_real_ninja_request_body() -> None:
     }
 
 
+def test_generated_historical_schema_works_as_real_ninja_response_body() -> None:
+    response = Client().get("/api/v1/task-response")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "schema_version": "v1",
+        "name": "job",
+        "is_completed": True,
+        "timeout": 5.0,
+    }
+
+    openapi = api.get_openapi_schema()
+    response_schema = openapi["paths"]["/api/v1/task-response"]["get"]["responses"][200]["content"][
+        "application/json"
+    ]["schema"]
+    ref_name = response_schema["$ref"].split("/")[-1]
+    payload_schema = openapi["components"]["schemas"][ref_name]
+    assert "is_completed" in payload_schema["properties"]
+    assert payload_schema["properties"]["schema_version"]["const"] == "v1"
+
+
+def test_generated_ninja_schema_rejects_a_wrong_discriminator_before_the_handler() -> None:
+    response = Client().post(
+        "/api/v1/tasks",
+        data=json.dumps(
+            {
+                "schema_version": "v2",
+                "name": "job",
+                "is_completed": True,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 422
+
+
 def test_ninja_openapi_uses_generated_historical_schema() -> None:
     openapi = api.get_openapi_schema()
     request_schema = openapi["paths"]["/api/v1/tasks"]["post"]["requestBody"]["content"][
@@ -190,6 +268,35 @@ def test_ninja_openapi_uses_generated_historical_schema() -> None:
     assert "is_completed" in payload_schema["properties"]
     assert "completed" not in payload_schema["properties"]
     assert payload_schema["properties"]["timeout"]["default"] == 5.0
+    assert payload_schema["properties"]["schema_version"]["const"] == "v1"
+    assert payload_schema["properties"]["schema_version"]["default"] == "v1"
+
+    current_request_schema = openapi["paths"]["/api/v2/tasks"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    current_ref_name = current_request_schema["$ref"].split("/")[-1]
+    current_payload_schema = openapi["components"]["schemas"][current_ref_name]
+
+    assert current_ref_name != ref_name
+    assert current_payload_schema["properties"]["schema_version"]["const"] == "v2"
+    assert current_payload_schema["properties"]["schema_version"]["default"] == "v2"
+
+
+def test_ninja_openapi_keeps_sanitized_label_collisions_in_distinct_components() -> None:
+    openapi = api.get_openapi_schema()
+    dotted_request = openapi["paths"]["/api/collision/dotted"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    dashed_request = openapi["paths"]["/api/collision/dashed"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    dotted_ref = dotted_request["$ref"].split("/")[-1]
+    dashed_ref = dashed_request["$ref"].split("/")[-1]
+    components = openapi["components"]["schemas"]
+
+    assert dotted_ref != dashed_ref
+    assert components[dotted_ref]["properties"]["schema_version"]["const"] == "1.0"
+    assert components[dashed_ref]["properties"]["schema_version"]["const"] == "1-0"
 
 
 class TaskModel(models.Model):

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -1,0 +1,1684 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    NamedTuple,
+    NewType,
+    Self,
+    TypedDict,
+    cast,
+    get_args,
+    get_origin,
+)
+from typing import (
+    TypeAliasType as StdlibTypeAliasType,
+)
+
+import pytest
+from pydantic import (
+    AfterValidator,
+    AliasChoices,
+    AliasPath,
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    GetPydanticSchema,
+    PlainSerializer,
+    RootModel,
+    SecretStr,
+    Tag,
+    TypeAdapter,
+    ValidateAs,
+    ValidationError,
+    WithJsonSchema,
+    computed_field,
+    create_model,
+    field_serializer,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
+
+from pydantic_versions import (
+    SchemaCompilationError,
+    SchemaFamily,
+    SchemaVersion,
+    UnsupportedWireModelError,
+    VersionMetadata,
+    VersionTransition,
+    field_default,
+    field_renamed,
+)
+
+
+def _assert_exact_version_field(
+    model: type[BaseModel],
+    *,
+    field_name: str,
+    label: str,
+) -> None:
+    field = model.model_fields[field_name]
+    assert get_origin(field.annotation) is Literal
+    assert get_args(field.annotation) == (label,)
+    assert field.default == label
+
+    property_schema = model.model_json_schema()["properties"][field_name]
+    assert property_schema["const"] == label
+    assert property_schema["default"] == label
+
+
+def _assert_unsupported(model: type[BaseModel], *, family_name: str) -> None:
+    family = SchemaFamily(
+        model=model,
+        name=family_name,
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    with pytest.raises(UnsupportedWireModelError):
+        family.compile()
+
+    assert family._compiled is None
+
+    with pytest.raises(UnsupportedWireModelError):
+        family.compile()
+
+    assert family._compiled is None
+
+
+def test_unsupported_wire_model_error_is_a_public_compilation_error() -> None:
+    assert issubclass(UnsupportedWireModelError, SchemaCompilationError)
+
+
+def test_unsupported_wire_model_error_has_safe_context_and_chained_cause() -> None:
+    sensitive_value = "never-render-this-schema-metadata"
+
+    class NonJsonMetadata:
+        def __repr__(self) -> str:
+            return sensitive_value
+
+    class NonJsonSchemaPayload(BaseModel):
+        model_config = ConfigDict(
+            json_schema_extra={"x-private": cast(Any, NonJsonMetadata())},
+        )
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=NonJsonSchemaPayload,
+        name="safe_error_context",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError) as exc_info:
+        family.compile()
+
+    message = str(exc_info.value)
+    model_name = f"{NonJsonSchemaPayload.__module__}.{NonJsonSchemaPayload.__qualname__}"
+    assert "safe_error_context" in message
+    assert "version '1'" in message
+    assert model_name in message
+    assert "non-JSON-serializable validation schema" in message
+    assert sensitive_value not in message
+    assert isinstance(exc_info.value.__cause__, TypeError)
+    assert family._compiled is None
+
+
+def test_current_behavior_runs_only_at_the_final_application_boundary() -> None:
+    events: list[str] = []
+
+    def validate_annotated(value: int) -> int:
+        events.append("annotated-validator")
+        if value != 10:
+            msg = "current annotated value must be migrated first"
+            raise ValueError(msg)
+        return value
+
+    def serialize_annotated(value: int) -> str:
+        events.append("annotated-serializer")
+        return f"annotated:{value}"
+
+    class BehavioralPayload(BaseModel):
+        annotated_value: Annotated[
+            int,
+            Field(gt=0),
+            AfterValidator(validate_annotated),
+            PlainSerializer(serialize_annotated, return_type=str),
+        ]
+        decorated_value: Annotated[int, Field(gt=0)]
+
+        @field_validator("decorated_value")
+        @classmethod
+        def validate_decorated(cls, value: int) -> int:
+            events.append("decorator-validator")
+            if value != 10:
+                msg = "current decorated value must be migrated first"
+                raise ValueError(msg)
+            return value
+
+        @model_validator(mode="after")
+        def validate_model(self) -> Self:
+            events.append("model-validator")
+            if self.annotated_value != self.decorated_value:
+                msg = "current values must agree"
+                raise ValueError(msg)
+            return self
+
+        @field_serializer("decorated_value")
+        def serialize_decorated(self, value: int) -> str:
+            events.append("decorator-serializer")
+            return f"decorated:{value}"
+
+        @computed_field
+        @property
+        def total(self) -> int:
+            return self.annotated_value + self.decorated_value
+
+        def model_post_init(self, context: Any, /) -> None:
+            events.append("model-post-init")
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **data,
+            "annotated_value": 10,
+            "decorated_value": 10,
+        }
+
+    family = SchemaFamily(
+        model=BehavioralPayload,
+        name="behavioral_boundary",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(VersionTransition("1", "2", upgrade=upgrade),),
+        version_metadata=None,
+    )
+    historical = family.model_for("1")
+    current_wire = family.model_for("2")
+
+    assert historical is not BehavioralPayload
+    assert current_wire is not BehavioralPayload
+    assert not issubclass(historical, BehavioralPayload)
+    assert not issubclass(current_wire, BehavioralPayload)
+
+    source = historical.model_validate({"annotated_value": 1, "decorated_value": 1})
+    assert source.model_dump() == {"annotated_value": 1, "decorated_value": 1}
+    assert "total" not in source.model_dump()
+    assert (
+        historical.model_json_schema(mode="serialization")["properties"]["annotated_value"]["type"]
+        == "integer"
+    )
+    assert events == []
+
+    with pytest.raises(ValidationError):
+        historical.model_validate({"annotated_value": 0, "decorated_value": 1})
+
+    result = family.validate(
+        {"annotated_value": 1, "decorated_value": 1},
+        version="1",
+    )
+
+    assert result.source_model.model_dump()["annotated_value"] == 1
+    assert result.current_model.annotated_value == 10
+    assert result.current_model.decorated_value == 10
+    assert Counter(events) == Counter(
+        {
+            "annotated-validator": 1,
+            "decorator-validator": 1,
+            "model-validator": 1,
+            "model-post-init": 1,
+        }
+    )
+
+    assert result.current_model.model_dump() == {
+        "annotated_value": "annotated:10",
+        "decorated_value": "decorated:10",
+        "total": 20,
+    }
+    assert events.count("annotated-serializer") == 1
+    assert events.count("decorator-serializer") == 1
+
+    events.clear()
+    current_result = family.validate(
+        {"annotated_value": 10, "decorated_value": 10},
+        version="2",
+    )
+
+    assert current_result.current_model.annotated_value == 10
+    assert Counter(events) == Counter(
+        {
+            "annotated-validator": 1,
+            "decorator-validator": 1,
+            "model-validator": 1,
+            "model-post-init": 1,
+        }
+    )
+
+
+def test_nested_annotated_behavior_runs_only_on_the_current_model() -> None:
+    events: list[str] = []
+
+    def validate_nested(value: int) -> int:
+        events.append("validator")
+        return value + 1
+
+    def serialize_nested(value: int) -> str:
+        events.append("serializer")
+        return str(value)
+
+    behavior = (
+        AfterValidator(validate_nested),
+        PlainSerializer(serialize_nested, return_type=str),
+    )
+
+    class NestedBehaviorPayload(BaseModel):
+        values: list[Annotated[int, *behavior]]
+        optional: Annotated[int, *behavior] | None = None
+        mapping: Mapping[str, Annotated[int, *behavior]]
+        sequence: Sequence[Annotated[int, *behavior]]
+
+    family = SchemaFamily(
+        model=NestedBehaviorPayload,
+        name="nested_behavior_boundary",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = family.model_for("1")
+    payload = {
+        "values": [1],
+        "optional": 2,
+        "mapping": {"value": 3},
+        "sequence": [4],
+    }
+    source = wire.model_validate(payload)
+
+    assert source.model_dump() == payload
+    assert wire.model_json_schema(mode="serialization")["properties"]["values"]["items"] == {
+        "type": "integer"
+    }
+    assert events == []
+
+    result = family.validate(payload, version="1")
+
+    assert result.current_model.values == [2]
+    assert result.current_model.optional == 3
+    assert result.current_model.mapping == {"value": 4}
+    assert result.current_model.sequence == [5]
+    assert events == ["validator"] * 4
+    assert result.current_model.model_dump() == {
+        "values": ["2"],
+        "optional": "3",
+        "mapping": {"value": "4"},
+        "sequence": ["5"],
+    }
+    assert events == ["validator"] * 4 + ["serializer"] * 4
+
+
+@pytest.mark.parametrize(
+    "alias_type",
+    [StdlibTypeAliasType, ExtensionsTypeAliasType],
+    ids=["typing", "typing_extensions"],
+)
+def test_type_aliases_cannot_hide_runtime_field_behavior(alias_type: Any) -> None:
+    calls: Counter[str] = Counter()
+
+    def validate_alias(value: int) -> int:
+        calls["validator"] += 1
+        return value
+
+    def serialize_alias(value: int) -> str:
+        calls["serializer"] += 1
+        return str(value)
+
+    behavior_alias = alias_type(
+        "BehaviorAlias",
+        Annotated[
+            int,
+            AfterValidator(validate_alias),
+            PlainSerializer(serialize_alias, return_type=str),
+        ],
+    )
+    payload = create_model(
+        "AliasBehaviorPayload",
+        values=(list[behavior_alias], ...),
+    )
+
+    baseline = calls.copy()
+    _assert_unsupported(payload, family_name="unsupported_alias_behavior")
+    assert calls == baseline
+
+
+@pytest.mark.parametrize(
+    "alias_type",
+    [StdlibTypeAliasType, ExtensionsTypeAliasType],
+    ids=["typing", "typing_extensions"],
+)
+def test_type_aliases_cannot_hide_mutable_schema_metadata(alias_type: Any) -> None:
+    schema_extra: dict[str, Any] = {"type": "integer", "x-static": ["source"]}
+    schema_alias = alias_type("SchemaAlias", Annotated[int, WithJsonSchema(schema_extra)])
+    payload = create_model(
+        "AliasSchemaPayload",
+        value=(schema_alias, ...),
+    )
+
+    _assert_unsupported(payload, family_name="unsupported_alias_schema")
+    schema_extra["x-static"].append("caller")
+
+
+def test_generated_fields_preserve_constraints_defaults_factories_and_static_schema() -> None:
+    factory_calls = 0
+
+    def make_tags() -> list[str]:
+        nonlocal factory_calls
+        factory_calls += 1
+        return []
+
+    class RichFields(BaseModel):
+        required_value: Annotated[
+            int,
+            Field(
+                gt=0,
+                title="Positive value",
+                description="Must remain positive on every wire contract.",
+                examples=[3],
+                json_schema_extra={"x-wire-field": "preserved"},
+            ),
+        ]
+        threshold: Annotated[int, Field(ge=1, le=20)] = 10
+        optional_note: str | None = None
+        mutable_default: list[int] = [1]
+        tags: list[str] = Field(default_factory=make_tags)
+
+    family = SchemaFamily(
+        model=RichFields,
+        name="rich_fields",
+        versions=(
+            SchemaVersion("1", patches=(field_default("threshold", 5),)),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+    historical = family.model_for("1")
+
+    assert factory_calls == 0
+    assert historical.model_fields["required_value"].is_required()
+    assert historical.model_fields["threshold"].default == 5
+    assert historical.model_fields["optional_note"].default is None
+
+    schema = historical.model_json_schema()
+    required_schema = schema["properties"]["required_value"]
+    assert required_schema["exclusiveMinimum"] == 0
+    assert required_schema["title"] == "Positive value"
+    assert required_schema["description"] == "Must remain positive on every wire contract."
+    assert required_schema["examples"] == [3]
+    assert required_schema["x-wire-field"] == "preserved"
+    assert schema["properties"]["threshold"]["minimum"] == 1
+    assert schema["properties"]["threshold"]["maximum"] == 20
+    assert schema["properties"]["threshold"]["default"] == 5
+    assert "required_value" in schema["required"]
+
+    first = historical.model_validate({"required_value": 1})
+    second = historical.model_validate({"required_value": 2})
+
+    assert factory_calls == 2
+    first.tags.append("first")
+    first.mutable_default.append(2)
+    assert second.tags == []
+    assert second.mutable_default == [1]
+
+    with pytest.raises(ValidationError):
+        historical.model_validate({"required_value": 0})
+    with pytest.raises(ValidationError):
+        historical.model_validate({"required_value": 1, "threshold": 21})
+
+
+def test_validated_data_factory_rejects_a_changed_preceding_namespace() -> None:
+    def from_value(data: dict[str, Any]) -> int:
+        return data["value"] + 1
+
+    class DependentFactoryPayload(BaseModel):
+        value: int
+        derived: int = Field(default_factory=from_value)
+
+    family = SchemaFamily(
+        model=DependentFactoryPayload,
+        name="dependent_factory",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("value", "old_value"),)),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="validated-data default factory"):
+        family.compile()
+
+
+def test_validated_data_factory_is_rejected_when_preceding_behavior_is_stripped() -> None:
+    calls: Counter[str] = Counter()
+
+    def validate_value(value: int) -> int:
+        calls["validator"] += 1
+        return value + 1
+
+    def from_value(data: dict[str, Any]) -> int:
+        calls["factory"] += 1
+        return data["value"] + 1
+
+    class BehavioralFactoryPayload(BaseModel):
+        value: Annotated[int, AfterValidator(validate_value)]
+        derived: int = Field(default_factory=from_value)
+
+    family = SchemaFamily(
+        model=BehavioralFactoryPayload,
+        name="behavioral_validated_data_factory",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="validated-data default factory"):
+        family.compile()
+
+    assert calls == Counter()
+    assert family._compiled is None
+
+
+def test_zero_argument_factory_survives_a_changed_preceding_namespace() -> None:
+    class IndependentFactoryPayload(BaseModel):
+        value: int
+        tags: list[str] = Field(default_factory=list)
+
+    family = SchemaFamily(
+        model=IndependentFactoryPayload,
+        name="independent_factory",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("value", "old_value"),)),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.model_for("1").model_validate({"old_value": 1}).model_dump() == {
+        "old_value": 1,
+        "tags": [],
+    }
+
+
+def test_static_schema_mappings_are_deeply_snapshotted_at_compilation() -> None:
+    model_schema_extra: dict[str, Any] = {"x-model": {"owners": ["source"]}}
+    field_schema_extra: dict[str, Any] = {"x-field": {"owners": ["source"]}}
+
+    class SnapshotPayload(BaseModel):
+        model_config = ConfigDict(json_schema_extra=model_schema_extra)
+
+        value: int = Field(json_schema_extra=field_schema_extra)
+
+    family = SchemaFamily(
+        model=SnapshotPayload,
+        name="schema_mapping_snapshot",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    ).compile()
+    wire = family.model_for("1")
+
+    assert (
+        wire.model_config["json_schema_extra"]
+        is not SnapshotPayload.model_config["json_schema_extra"]
+    )
+    assert (
+        wire.model_fields["value"].json_schema_extra
+        is not SnapshotPayload.model_fields["value"].json_schema_extra
+    )
+
+    model_schema_extra["x-model"]["owners"].append("caller")
+    field_schema_extra["x-field"]["owners"].append("caller")
+    source_model_extra = SnapshotPayload.model_config["json_schema_extra"]
+    source_field_extra = SnapshotPayload.model_fields["value"].json_schema_extra
+    assert isinstance(source_model_extra, dict)
+    assert isinstance(source_field_extra, dict)
+    cast(dict[str, Any], source_model_extra)["x-model"]["owners"].append("model")
+    cast(dict[str, Any], source_field_extra)["x-field"]["owners"].append("field")
+
+    schema = wire.model_json_schema()
+    assert schema["x-model"] == {"owners": ["source"]}
+    assert schema["properties"]["value"]["x-field"] == {"owners": ["source"]}
+
+
+@pytest.mark.parametrize(
+    "schema_extra",
+    [
+        {"type": "string"},
+        {"properties": {"fake": {"type": "string"}}},
+        {"required": []},
+        {"allOf": []},
+        {"discriminator": {"propertyName": "wrong"}},
+    ],
+    ids=["type", "properties", "required", "composition", "discriminator"],
+)
+def test_model_schema_metadata_cannot_override_generated_structure(
+    schema_extra: dict[str, Any],
+) -> None:
+    class StructuralSchemaPayload(BaseModel):
+        model_config = ConfigDict(json_schema_extra=schema_extra)
+
+        value: int
+
+    _assert_unsupported(
+        StructuralSchemaPayload,
+        family_name="unsupported_structural_model_schema",
+    )
+
+
+def test_static_with_json_schema_metadata_is_preserved() -> None:
+    class StaticSchemaPayload(BaseModel):
+        value: Annotated[int, WithJsonSchema({"type": "integer", "x-static": True})]
+
+    family = SchemaFamily(
+        model=StaticSchemaPayload,
+        name="static_schema_metadata",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    assert family.model_for("1").model_json_schema()["properties"]["value"]["x-static"] is True
+
+
+def test_custom_with_json_schema_subtype_fails_without_hook_invocation() -> None:
+    calls: Counter[str] = Counter()
+
+    class CustomWithJsonSchema(WithJsonSchema):
+        def __get_pydantic_json_schema__(self, core_schema: Any, handler: Any) -> Any:
+            calls["schema"] += 1
+            return super().__get_pydantic_json_schema__(core_schema, handler)
+
+    class CustomSchemaPayload(BaseModel):
+        value: Annotated[
+            int,
+            CustomWithJsonSchema({"type": "integer", "x-custom": True}),
+        ]
+
+    baseline = calls.copy()
+    _assert_unsupported(
+        CustomSchemaPayload,
+        family_name="unsupported_custom_schema_metadata_subtype",
+    )
+    assert calls == baseline
+
+
+def test_declarative_annotated_discriminator_is_preserved() -> None:
+    class Cat(BaseModel):
+        kind: Literal["cat"]
+        lives: int
+
+    class Dog(BaseModel):
+        kind: Literal["dog"]
+        bark: bool
+
+    class PetPayload(BaseModel):
+        pet: Annotated[Cat | Dog, Discriminator("kind")]
+
+    family = SchemaFamily(
+        model=PetPayload,
+        name="declarative_discriminator",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = family.model_for("1")
+
+    value = wire.model_validate({"pet": {"kind": "cat", "lives": 9}})
+    assert value.model_dump()["pet"] == {"kind": "cat", "lives": 9}
+    assert wire.model_json_schema()["properties"]["pet"]["discriminator"]["propertyName"] == "kind"
+
+
+def test_generated_fields_preserve_alias_modes_and_apply_generators_after_rename() -> None:
+    def to_camel(field_name: str) -> str:
+        head, *tail = field_name.split("_")
+        return head + "".join(part.title() for part in tail)
+
+    class AliasedPayload(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=to_camel,
+            populate_by_name=True,
+            validate_by_alias=True,
+            validate_by_name=True,
+            serialize_by_alias=True,
+        )
+
+        value: int = Field(
+            validation_alias=AliasChoices("valueIn", AliasPath("envelope", "value")),
+            serialization_alias="valueOut",
+        )
+        current_name: bool = Field(alias="currentAlias")
+
+    family = SchemaFamily(
+        model=AliasedPayload,
+        name="aliased_fields",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("current_name", "legacy_name"),)),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+    historical = family.model_for("1")
+    current = family.model_for("2")
+
+    first = historical.model_validate({"valueIn": 1, "legacyName": True})
+    second = historical.model_validate(
+        {"envelope": {"value": 2}, "legacyName": False},
+    )
+
+    assert first.model_dump() == {"valueOut": 1, "legacyName": True}
+    assert second.model_dump()["valueOut"] == 2
+    assert historical.model_json_schema(mode="validation")["properties"].keys() >= {
+        "valueIn",
+        "legacyName",
+    }
+    assert historical.model_json_schema(mode="serialization")["properties"].keys() >= {
+        "valueOut",
+        "legacyName",
+    }
+    assert "currentAlias" not in historical.model_json_schema()["properties"]
+
+    current_value = current.model_validate({"valueIn": 3, "currentAlias": True})
+    assert current_value.model_dump() == {"valueOut": 3, "currentAlias": True}
+
+
+def test_alias_handoff_uses_canonical_names_without_creating_forbidden_extras() -> None:
+    class DisabledAliasPayload(BaseModel):
+        model_config = ConfigDict(
+            validate_by_alias=False,
+            validate_by_name=True,
+            extra="forbid",
+        )
+
+        value: int = Field(alias="wireValue")
+
+    class SplitAliasPayload(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        value: int = Field(alias="wireOut", validation_alias="wireIn")
+
+    class ComplexAliasPayload(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        choice: int = Field(validation_alias=AliasChoices("choiceIn", "legacyChoice"))
+        path: int = Field(validation_alias=AliasPath("envelope", "path"))
+
+    disabled = SchemaFamily(
+        model=DisabledAliasPayload,
+        name="disabled_alias_handoff",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    split = SchemaFamily(
+        model=SplitAliasPayload,
+        name="split_alias_handoff",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    complex_alias = SchemaFamily(
+        model=ComplexAliasPayload,
+        name="complex_alias_handoff",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    assert disabled.validate({"value": 1}, version="1").current_model.value == 1
+    assert split.validate({"wireIn": 2}, version="1").current_model.value == 2
+    complex_result = complex_alias.validate(
+        {"choiceIn": 3, "envelope": {"path": 4}},
+        version="1",
+    )
+    assert complex_result.current_model.choice == 3
+    assert complex_result.current_model.path == 4
+
+
+def test_generated_config_preserves_wire_settings_but_omits_lifecycle_settings() -> None:
+    class Mode(StrEnum):
+        FAST = "fast"
+
+    class ConfiguredPayload(BaseModel):
+        model_config = ConfigDict(
+            title="Configured wire payload",
+            json_schema_extra={"x-wire-contract": True},
+            extra="forbid",
+            strict=True,
+            populate_by_name=True,
+            validate_by_alias=True,
+            validate_by_name=True,
+            serialize_by_alias=True,
+            loc_by_alias=True,
+            use_enum_values=True,
+            str_strip_whitespace=True,
+            str_to_lower=True,
+            coerce_numbers_to_str=True,
+            val_temporal_unit="seconds",
+            ser_json_temporal="milliseconds",
+            ser_json_bytes="base64",
+            val_json_bytes="base64",
+            frozen=True,
+            validate_assignment=True,
+        )
+
+        name: str
+        count: int = Field(alias="Count")
+        mode: Mode
+        payload: bytes
+
+    family = SchemaFamily(
+        model=ConfiguredPayload,
+        name="configured_payload",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = family.model_for("1")
+
+    preserved_keys = (
+        "extra",
+        "strict",
+        "populate_by_name",
+        "validate_by_alias",
+        "validate_by_name",
+        "serialize_by_alias",
+        "loc_by_alias",
+        "use_enum_values",
+        "str_strip_whitespace",
+        "str_to_lower",
+        "coerce_numbers_to_str",
+        "val_temporal_unit",
+        "ser_json_temporal",
+        "ser_json_bytes",
+        "val_json_bytes",
+    )
+    for key in preserved_keys:
+        assert wire.model_config[key] == ConfiguredPayload.model_config[key]
+
+    assert wire.model_config.get("frozen") is None
+    assert wire.model_config.get("validate_assignment") is None
+
+    schema = wire.model_json_schema()
+    assert schema["title"] == "Configured wire payload"
+    assert schema["x-wire-contract"] is True
+
+    value = wire.model_validate(
+        {
+            "name": " FAST ",
+            "Count": 1,
+            "mode": Mode.FAST,
+            "payload": b"data",
+        }
+    )
+    assert value.model_dump()["name"] == "fast"
+    assert value.model_dump()["mode"] == "fast"
+    assert value.model_dump()["Count"] == 1
+
+    dynamic_value = cast(Any, value)
+    dynamic_value.count = "not validated"
+    assert dynamic_value.count == "not validated"
+
+    with pytest.raises(ValidationError) as strict_error:
+        wire.model_validate(
+            {
+                "name": "fast",
+                "Count": "1",
+                "mode": Mode.FAST,
+                "payload": b"data",
+            }
+        )
+    assert strict_error.value.errors()[0]["loc"] == ("Count",)
+
+    with pytest.raises(ValidationError):
+        wire.model_validate(
+            {
+                "name": "fast",
+                "Count": 1,
+                "mode": Mode.FAST,
+                "payload": b"data",
+                "unexpected": True,
+            }
+        )
+
+
+def test_non_string_model_config_keys_raise_a_contextual_wire_error() -> None:
+    class NonStringConfigPayload(BaseModel):
+        value: int = 1
+
+    config = cast(dict[Any, Any], NonStringConfigPayload.model_config)
+    config[1] = True
+    family = SchemaFamily(
+        model=NonStringConfigPayload,
+        name="non_string_config_key",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError) as exc_info:
+        family.compile()
+
+    message = str(exc_info.value)
+    assert "non_string_config_key" in message
+    assert NonStringConfigPayload.__qualname__ in message
+    assert "model configuration keys must be strings" in message
+    assert family._compiled is None
+
+
+def test_typed_extra_values_fail_instead_of_losing_their_wire_type() -> None:
+    class TypedExtraPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        __pydantic_extra__: dict[str, int] = Field(init=False)
+        value: int = 1
+
+    _assert_unsupported(TypedExtraPayload, family_name="unsupported_typed_extras")
+
+
+def test_typed_extra_values_in_a_mixin_after_base_model_are_rejected() -> None:
+    class TypedExtraMixin:
+        __pydantic_extra__: dict[str, int]
+
+    class InheritedTypedExtraPayload(BaseModel, TypedExtraMixin):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    assert InheritedTypedExtraPayload.__mro__.index(TypedExtraMixin) > (
+        InheritedTypedExtraPayload.__mro__.index(BaseModel)
+    )
+    _assert_unsupported(
+        InheritedTypedExtraPayload,
+        family_name="unsupported_inherited_typed_extras",
+    )
+
+
+def test_nested_metadata_wrappers_preserve_the_body_extra_mode() -> None:
+    class IgnoredExtraPayload(BaseModel):
+        value: int = 1
+
+    class AllowedExtraPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    class ForbiddenExtraPayload(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        value: int = 1
+
+    metadata = VersionMetadata(("meta", "version"), owner="family")
+    ignored = SchemaFamily(
+        model=IgnoredExtraPayload,
+        name="ignored_envelope_extra",
+        versions=(SchemaVersion("1"),),
+        version_metadata=metadata,
+    ).model_for("1")
+    allowed = SchemaFamily(
+        model=AllowedExtraPayload,
+        name="allowed_envelope_extra",
+        versions=(SchemaVersion("1"),),
+        version_metadata=metadata,
+    ).model_for("1")
+    forbidden = SchemaFamily(
+        model=ForbiddenExtraPayload,
+        name="forbidden_envelope_extra",
+        versions=(SchemaVersion("1"),),
+        version_metadata=metadata,
+    ).model_for("1")
+    payload = {"meta": {"version": "1", "note": "keep"}}
+
+    assert ignored.model_validate(payload).model_dump()["meta"] == {"version": "1"}
+    assert allowed.model_validate(payload).model_dump()["meta"] == {
+        "version": "1",
+        "note": "keep",
+    }
+    with pytest.raises(ValidationError):
+        forbidden.model_validate(payload)
+
+
+def test_every_family_owned_direct_discriminator_is_an_exact_literal() -> None:
+    class FamilyOwnedPayload(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=FamilyOwnedPayload,
+        name="family_owned_metadata",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    for label in ("1", "2"):
+        wire = family.model_for(label)
+        _assert_exact_version_field(wire, field_name="schema_version", label=label)
+        assert wire is not FamilyOwnedPayload
+        assert not issubclass(wire, FamilyOwnedPayload)
+        assert wire.model_validate({}).model_dump()["schema_version"] == label
+        with pytest.raises(ValidationError):
+            wire.model_validate({"schema_version": "wrong"})
+
+
+def test_every_model_owned_direct_discriminator_is_an_exact_literal() -> None:
+    class ModelOwnedPayload(BaseModel):
+        schema_version: str = "2"
+        value: int = 1
+
+    family = SchemaFamily(
+        model=ModelOwnedPayload,
+        name="model_owned_metadata",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    for label in ("1", "2"):
+        wire = family.model_for(label)
+        _assert_exact_version_field(wire, field_name="schema_version", label=label)
+        assert wire is not ModelOwnedPayload
+        assert not issubclass(wire, ModelOwnedPayload)
+        assert (
+            wire.model_validate({"schema_version": label}).model_dump()["schema_version"] == label
+        )
+        with pytest.raises(ValidationError):
+            wire.model_validate({"schema_version": "wrong"})
+
+
+def test_model_owned_metadata_alias_modes_end_at_the_current_label() -> None:
+    class AliasMetadataPayload(BaseModel):
+        schema_version: str = Field(default="2", alias="wire_version")
+        value: int = 1
+
+    class ValidationAliasMetadataPayload(BaseModel):
+        schema_version: str = Field(default="2", validation_alias="wire_version")
+        value: int = 1
+
+    class IdentityAliasMetadataPayload(BaseModel):
+        model_config = ConfigDict(alias_generator=lambda name: name)
+
+        schema_version: str = "2"
+        value: int = 1
+
+    cases = (
+        ("alias", AliasMetadataPayload, "wire_version", "wire_version", "wire_version"),
+        (
+            "validation_alias",
+            ValidationAliasMetadataPayload,
+            "wire_version",
+            "wire_version",
+            "schema_version",
+        ),
+        (
+            "identity_alias_generator",
+            IdentityAliasMetadataPayload,
+            "schema_version",
+            "schema_version",
+            "schema_version",
+        ),
+    )
+    for suffix, model, metadata_path, validation_name, serialization_name in cases:
+        family = SchemaFamily(
+            model=model,
+            name=f"model_metadata_{suffix}",
+            versions=(SchemaVersion("1"), SchemaVersion("2")),
+            version_metadata=VersionMetadata(metadata_path, owner="model"),
+        )
+        historical = family.model_for("1")
+
+        validation_schema = historical.model_json_schema(mode="validation")
+        serialization_schema = historical.model_json_schema(mode="serialization")
+        assert validation_schema["properties"][validation_name]["const"] == "1"
+        assert serialization_schema["properties"][serialization_name]["const"] == "1"
+
+        result = family.validate({metadata_path: "1"})
+        assert result.source_version == "1"
+        assert result.source_model.model_dump()["schema_version"] == "1"
+        assert result.current_model.model_dump()["schema_version"] == "2"
+
+
+def test_model_owned_metadata_rejects_disabled_or_output_only_locations() -> None:
+    class SerializationAliasPayload(BaseModel):
+        schema_version: str = Field(default="2", serialization_alias="wire_version")
+
+    class DisabledAliasPayload(BaseModel):
+        model_config = ConfigDict(validate_by_alias=False, validate_by_name=True)
+
+        schema_version: str = Field(default="2", alias="wire_version")
+
+    class DisabledNamePayload(BaseModel):
+        schema_version: str = Field(default="2", validation_alias="wire_version")
+
+    cases = (
+        ("serialization_alias", SerializationAliasPayload, "wire_version"),
+        ("disabled_alias", DisabledAliasPayload, "wire_version"),
+        ("disabled_name", DisabledNamePayload, "schema_version"),
+    )
+    for suffix, model, path in cases:
+        family = SchemaFamily(
+            model=model,
+            name=f"unsupported_model_metadata_{suffix}",
+            versions=(SchemaVersion("1"), SchemaVersion("2")),
+            version_metadata=VersionMetadata(path, owner="model"),
+        )
+        with pytest.raises(UnsupportedWireModelError, match="model-owned version metadata"):
+            family.compile()
+        assert family._compiled is None
+
+
+def test_model_owned_metadata_rejects_a_historical_default_patch() -> None:
+    class PatchedMetadataPayload(BaseModel):
+        schema_version: str = "2"
+        value: int = 1
+
+    family = SchemaFamily(
+        model=PatchedMetadataPayload,
+        name="patched_model_metadata",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_default("schema_version", "legacy"),),
+            ),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="historical default patch"):
+        family.compile()
+
+    assert family._compiled is None
+
+
+def test_exact_model_metadata_replaces_incompatible_historical_constraints() -> None:
+    class ConstrainedMetadataPayload(BaseModel):
+        schema_version: Annotated[str, Field(pattern=r"^v\d+$")] = "v2"
+        value: int = 1
+
+    family = SchemaFamily(
+        model=ConstrainedMetadataPayload,
+        name="constrained_model_metadata",
+        versions=(SchemaVersion("legacy"), SchemaVersion("v2")),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+    historical = family.model_for("legacy")
+
+    assert (
+        historical.model_validate({"schema_version": "legacy"}).model_dump()["schema_version"]
+        == "legacy"
+    )
+    schema = historical.model_json_schema()["properties"]["schema_version"]
+    assert schema["const"] == "legacy"
+    assert "pattern" not in schema
+    assert family.validate({"schema_version": "legacy"}).current_model.schema_version == "v2"
+
+
+def test_nested_family_owned_discriminator_is_an_exact_literal_document_wrapper() -> None:
+    class NestedMetadataPayload(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=NestedMetadataPayload,
+        name="nested_family_metadata",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata(("meta", "details", "version"), owner="family"),
+    )
+
+    for label in ("1", "2"):
+        wire = family.model_for(label)
+        meta_model = wire.model_fields["meta"].annotation
+        details_model = meta_model.model_fields["details"].annotation
+
+        _assert_exact_version_field(details_model, field_name="version", label=label)
+        assert wire.model_validate({}).model_dump()["meta"] == {"details": {"version": label}}
+        with pytest.raises(ValidationError):
+            wire.model_validate(
+                {"meta": {"details": {"version": "wrong"}}},
+            )
+
+
+def test_single_segment_tuple_metadata_keeps_tuple_path_semantics() -> None:
+    class TupleMetadataPayload(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=TupleMetadataPayload,
+        name="tuple_family_metadata",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata(("version",), owner="family"),
+    )
+    wire = family.model_for("1")
+
+    _assert_exact_version_field(wire, field_name="version", label="1")
+    assert wire.model_validate({}).model_dump() == {"value": 1, "version": "1"}
+
+
+def test_version_metadata_rejects_projected_name_and_alias_collisions() -> None:
+    class RenamedCollisionPayload(BaseModel):
+        value: int
+
+    renamed = SchemaFamily(
+        model=RenamedCollisionPayload,
+        name="renamed_metadata_collision",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("value", "schema_version"),)),
+            SchemaVersion("2"),
+        ),
+    )
+
+    class ChoiceCollisionPayload(BaseModel):
+        value: int = Field(validation_alias=AliasChoices("schema_version", "value"))
+
+    choice = SchemaFamily(
+        model=ChoiceCollisionPayload,
+        name="choice_metadata_collision",
+        versions=(SchemaVersion("1"),),
+    )
+
+    class PathCollisionPayload(BaseModel):
+        value: int = Field(validation_alias=AliasPath("meta", "value"))
+
+    alias_path = SchemaFamily(
+        model=PathCollisionPayload,
+        name="path_metadata_collision",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata(("meta", "version"), owner="family"),
+    )
+
+    class ModelOwnedAliasCollisionPayload(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+
+        schema_version: str = Field(default="1", alias="wire")
+        value: int = Field(default=1, serialization_alias="wire")
+
+    model_owned = SchemaFamily(
+        model=ModelOwnedAliasCollisionPayload,
+        name="model_owned_alias_collision",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    for family in (renamed, choice, alias_path, model_owned):
+        with pytest.raises(UnsupportedWireModelError):
+            family.compile()
+        assert family._compiled is None
+
+
+def test_generated_schema_refs_remain_distinct_after_label_sanitization() -> None:
+    class CollisionPayload(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=CollisionPayload,
+        name="wire_collision",
+        versions=(SchemaVersion("1.0"), SchemaVersion("1-0"), SchemaVersion("2")),
+    )
+    dotted = family.model_for("1.0")
+    dashed = family.model_for("1-0")
+
+    schema = TypeAdapter(dotted | dashed).json_schema()
+    definitions = schema["$defs"]
+    version_constants = {
+        definition["properties"]["schema_version"]["const"] for definition in definitions.values()
+    }
+
+    assert dotted.__name__ != dashed.__name__
+    assert len(definitions) == 2
+    assert version_constants == {"1.0", "1-0"}
+    assert len({branch["$ref"] for branch in schema["anyOf"]}) == 2
+
+
+def test_generated_schema_refs_resist_sanitized_family_name_collisions() -> None:
+    class FamilyCollisionPayload(BaseModel):
+        value: int = 1
+
+    dotted = SchemaFamily(
+        model=FamilyCollisionPayload,
+        name="family.one",
+        versions=(SchemaVersion("1"),),
+    ).model_for("1")
+    dashed = SchemaFamily(
+        model=FamilyCollisionPayload,
+        name="family-one",
+        versions=(SchemaVersion("1"),),
+    ).model_for("1")
+
+    schema = TypeAdapter(dotted | dashed).json_schema()
+
+    assert dotted.__name__ != dashed.__name__
+    assert len(schema["$defs"]) == 2
+    assert len({branch["$ref"] for branch in schema["anyOf"]}) == 2
+
+
+def test_generated_schema_refs_resist_sanitized_dynamic_model_name_collisions() -> None:
+    dotted_model = create_model("Payload.One", value=(int, 1))
+    dashed_model = create_model("Payload-One", value=(int, 2))
+    dotted = SchemaFamily(
+        model=dotted_model,
+        name="dynamic_model_collision",
+        versions=(SchemaVersion("1"),),
+    ).model_for("1")
+    dashed = SchemaFamily(
+        model=dashed_model,
+        name="dynamic_model_collision",
+        versions=(SchemaVersion("1"),),
+    ).model_for("1")
+
+    schema = TypeAdapter(dotted | dashed).json_schema()
+    defaults = {
+        definition["properties"]["value"]["default"] for definition in schema["$defs"].values()
+    }
+
+    assert dotted.__name__ != dashed.__name__
+    assert len(schema["$defs"]) == 2
+    assert defaults == {1, 2}
+    assert len({branch["$ref"] for branch in schema["anyOf"]}) == 2
+
+
+def test_root_models_fail_automatic_projection_without_partial_cache() -> None:
+    class RootPayload(RootModel[list[str]]):
+        pass
+
+    _assert_unsupported(RootPayload, family_name="unsupported_root")
+
+
+def test_unresolved_generics_fail_but_concrete_generic_models_are_supported() -> None:
+    class GenericPayload[T](BaseModel):
+        value: T
+
+    _assert_unsupported(GenericPayload, family_name="unsupported_generic")
+
+    concrete = SchemaFamily(
+        model=GenericPayload[int],
+        name="concrete_generic",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = concrete.model_for("1")
+
+    assert wire.model_validate({"value": 3}).model_dump()["value"] == 3
+    with pytest.raises(ValidationError):
+        wire.model_validate({"value": "not-an-int"})
+
+
+def test_model_serializers_and_custom_model_schema_hooks_fail_projection() -> None:
+    class SerializedPayload(BaseModel):
+        value: int
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, int]:
+            return {"renamed": self.value}
+
+    class CoreHookPayload(BaseModel):
+        value: int
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            source_type: Any,
+            handler: Any,
+        ) -> Any:
+            return handler(source_type)
+
+    class JsonHookBase(BaseModel):
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls,
+            core_schema: Any,
+            handler: Any,
+        ) -> Any:
+            schema = handler(core_schema)
+            schema["x-custom-hook"] = True
+            return schema
+
+    class InheritedJsonHookPayload(JsonHookBase):
+        value: int
+
+    unsupported = (
+        ("serializer", SerializedPayload),
+        ("core_hook", CoreHookPayload),
+        ("inherited_json_hook", InheritedJsonHookPayload),
+    )
+    for suffix, model in unsupported:
+        _assert_unsupported(model, family_name=f"unsupported_{suffix}")
+
+
+def test_legacy_json_encoders_fail_automatic_projection() -> None:
+    encoder_calls = 0
+
+    def encode_datetime(value: datetime) -> str:
+        nonlocal encoder_calls
+        encoder_calls += 1
+        return value.isoformat()
+
+    with pytest.warns(DeprecationWarning, match="json_encoders"):
+
+        class EncodedPayload(BaseModel):
+            model_config = ConfigDict(json_encoders={datetime: encode_datetime})
+
+            created_at: datetime
+
+    _assert_unsupported(EncodedPayload, family_name="unsupported_json_encoders")
+    assert encoder_calls == 0
+
+
+def test_serialization_exclusions_fail_automatic_projection() -> None:
+    class ExcludedPayload(BaseModel):
+        value: int = Field(default=1, exclude=True)
+
+    class ConditionalExclusionPayload(BaseModel):
+        value: int = Field(default=1, exclude_if=lambda value: value == 0)
+
+    unsupported = (
+        ("exclude", ExcludedPayload),
+        ("exclude_if", ConditionalExclusionPayload),
+    )
+    for suffix, model in unsupported:
+        _assert_unsupported(model, family_name=f"unsupported_{suffix}")
+
+
+def test_callable_discriminators_fail_in_field_and_annotated_forms() -> None:
+    def discriminator(value: Any) -> str | None:
+        candidate = (
+            value.get("kind") if isinstance(value, Mapping) else getattr(value, "kind", None)
+        )
+        return candidate if isinstance(candidate, str) else None
+
+    class Cat(BaseModel):
+        kind: Literal["cat"]
+
+    class Dog(BaseModel):
+        kind: Literal["dog"]
+
+    class FieldDiscriminatorPayload(BaseModel):
+        pet: Annotated[Cat, Tag("cat")] | Annotated[Dog, Tag("dog")] = Field(
+            discriminator=Discriminator(discriminator),
+        )
+
+    class AnnotatedDiscriminatorPayload(BaseModel):
+        pet: Annotated[
+            Annotated[Cat, Tag("cat")] | Annotated[Dog, Tag("dog")],
+            Discriminator(discriminator),
+        ]
+
+    unsupported = (
+        ("field_callable_discriminator", FieldDiscriminatorPayload),
+        ("annotated_callable_discriminator", AnnotatedDiscriminatorPayload),
+    )
+    for suffix, model in unsupported:
+        _assert_unsupported(model, family_name=f"unsupported_{suffix}")
+
+
+def test_custom_annotation_hooks_fail_without_generated_hook_invocation() -> None:
+    calls: Counter[str] = Counter()
+
+    class HookBase:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> Any:
+            calls[cls.__name__] += 1
+            return handler(int)
+
+    class InheritedHook(HookBase):
+        pass
+
+    class GenericHook[T]:
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> Any:
+            calls[cls.__name__] += 1
+            return handler(int)
+
+    class SpoofedHook:
+        __module__ = "pydantic.types"
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> Any:
+            calls[cls.__name__] += 1
+            return handler(int)
+
+    type HiddenHook = InheritedHook
+
+    class DirectHookPayload(BaseModel):
+        value: InheritedHook
+
+    class GenericHookPayload(BaseModel):
+        value: GenericHook[int]
+
+    class AliasedHookPayload(BaseModel):
+        value: HiddenHook
+
+    class SpoofedHookPayload(BaseModel):
+        value: SpoofedHook
+
+    baseline = calls.copy()
+    unsupported = (
+        ("direct_annotation_hook", DirectHookPayload),
+        ("generic_annotation_hook", GenericHookPayload),
+        ("aliased_annotation_hook", AliasedHookPayload),
+        ("spoofed_annotation_hook", SpoofedHookPayload),
+    )
+    for suffix, model in unsupported:
+        _assert_unsupported(model, family_name=f"unsupported_{suffix}")
+        assert calls == baseline
+
+
+AliasValue = NewType("AliasValue", int)
+
+
+def test_builtin_annotations_continue_to_work_with_compiled_wire_models() -> None:
+    class BuiltinAliasPayload(BaseModel):
+        value_int: int
+        value_bool: bool
+        alias: AliasValue
+
+    family = SchemaFamily(
+        model=BuiltinAliasPayload,
+        name="builtin_annotations_supported",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = family.model_for("1")
+    value = wire.model_validate({"value_int": 1, "value_bool": True, "alias": 3})
+    assert value.model_dump() == {"value_int": 1, "value_bool": True, "alias": 3}
+
+
+def test_declarative_pydantic_annotation_hooks_remain_supported() -> None:
+    class PydanticTypesPayload(BaseModel):
+        secret: SecretStr
+        url: AnyUrl
+
+    family = SchemaFamily(
+        model=PydanticTypesPayload,
+        name="pydantic_annotation_types",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = family.model_for("1")
+    value = wire.model_validate({"secret": "hidden", "url": "https://example.com/path"})
+
+    assert isinstance(value.model_dump()["secret"], SecretStr)
+    assert isinstance(value.model_dump()["url"], AnyUrl)
+    assert wire.model_json_schema()["properties"]["secret"]["format"] == "password"
+
+
+def test_behavioral_dataclass_annotations_fail_but_plain_dataclasses_remain_supported() -> None:
+    post_init_calls: list[int] = []
+
+    @dataclass
+    class PlainValue:
+        value: int
+
+    @dataclass
+    class BehavioralValue:
+        value: int
+
+        def __post_init__(self) -> None:
+            post_init_calls.append(self.value)
+            self.value += 1
+
+    class PlainDataclassPayload(BaseModel):
+        item: PlainValue
+
+    class BehavioralDataclassPayload(BaseModel):
+        item: BehavioralValue
+
+    plain_family = SchemaFamily(
+        model=PlainDataclassPayload,
+        name="plain_dataclass_annotation",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    assert plain_family.model_for("1").model_validate({"item": {"value": 1}}).model_dump() == {
+        "item": {"value": 1}
+    }
+
+    baseline = list(post_init_calls)
+    _assert_unsupported(
+        BehavioralDataclassPayload,
+        family_name="unsupported_behavioral_dataclass",
+    )
+    assert post_init_calls == baseline
+
+
+def test_structured_annotations_with_behavior_in_nested_dataclass_are_rejected() -> None:
+    @dataclass
+    class InnerValue:
+        value: Annotated[int, AfterValidator(lambda value: value if value > 0 else 0)]
+
+    class NestedBehavioralPayload(BaseModel):
+        value: InnerValue
+
+    _assert_unsupported(
+        NestedBehavioralPayload,
+        family_name="unsupported_nested_behavioral_dataclass",
+    )
+
+
+def test_structured_annotations_with_behavior_in_nested_typed_dict_are_rejected() -> None:
+    class InnerTypedDict(TypedDict):
+        value: Annotated[int, AfterValidator(lambda value: value if value > 0 else 0)]
+
+    class NestedBehavioralTypedDictPayload(BaseModel):
+        value: InnerTypedDict
+
+    _assert_unsupported(
+        NestedBehavioralTypedDictPayload,
+        family_name="unsupported_nested_behavioral_typeddict",
+    )
+
+
+def test_structured_annotations_with_behavior_in_nested_named_tuple_are_rejected() -> None:
+    class InnerNamedTuple(NamedTuple):
+        value: Annotated[int, AfterValidator(lambda value: value if value > 0 else 0)]
+
+    class NestedBehavioralNamedTuplePayload(BaseModel):
+        value: InnerNamedTuple
+
+    _assert_unsupported(
+        NestedBehavioralNamedTuplePayload,
+        family_name="unsupported_nested_behavioral_namedtuple",
+    )
+
+
+if TYPE_CHECKING:
+
+    class NotDefinedYet:
+        value: int
+
+
+if "NotDefinedYet" in globals():
+    del NotDefinedYet
+
+
+def test_structured_annotations_with_unresolved_forward_refs_are_rejected() -> None:
+    @dataclass
+    class ResolvingFuture:
+        value: NotDefinedYet
+
+    class ForwardRefStructuredPayload(BaseModel):
+        value: ResolvingFuture
+
+    _assert_unsupported(
+        ForwardRefStructuredPayload,
+        family_name="unsupported_structured_forward_ref",
+    )
+
+
+def test_custom_field_schema_metadata_fails_without_compiler_invocation() -> None:
+    calls: Counter[str] = Counter()
+
+    class ValidatedValue:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    class ValidationShape(BaseModel):
+        value: int
+
+    def instantiate(value: ValidationShape) -> ValidatedValue:
+        calls["instantiate"] += 1
+        return ValidatedValue(value.value)
+
+    def generate_schema(source_type: Any, handler: Any) -> Any:
+        calls["schema"] += 1
+        return handler(int)
+
+    class ValidateAsPayload(BaseModel):
+        value: Annotated[ValidatedValue, ValidateAs(ValidationShape, instantiate)]
+
+    class SchemaMetadataPayload(BaseModel):
+        value: Annotated[int, GetPydanticSchema(generate_schema)]
+
+    baseline = calls.copy()
+    _assert_unsupported(ValidateAsPayload, family_name="unsupported_validate_as")
+    _assert_unsupported(SchemaMetadataPayload, family_name="unsupported_field_schema")
+    assert calls == baseline
+
+
+def test_callable_schema_and_title_mutation_fails_without_compiler_invocation() -> None:
+    calls: Counter[str] = Counter()
+
+    def mutate_model_schema(schema: dict[str, Any]) -> None:
+        calls["model_schema"] += 1
+        schema["x-mutated"] = True
+
+    def mutate_field_schema(schema: dict[str, Any]) -> None:
+        calls["field_schema"] += 1
+        schema["x-mutated"] = True
+
+    def generate_model_title(model: type) -> str:
+        calls["model_title"] += 1
+        return model.__name__
+
+    def generate_field_title(field_name: str, field_info: Any) -> str:
+        calls["field_title"] += 1
+        return field_name
+
+    class CallableModelSchemaPayload(BaseModel):
+        model_config = ConfigDict(json_schema_extra=mutate_model_schema)
+
+        value: int
+
+    class CallableFieldSchemaPayload(BaseModel):
+        value: int = Field(json_schema_extra=mutate_field_schema)
+
+    class CallableModelTitlePayload(BaseModel):
+        model_config = ConfigDict(model_title_generator=generate_model_title)
+
+        value: int
+
+    class CallableFieldTitlePayload(BaseModel):
+        model_config = ConfigDict(field_title_generator=generate_field_title)
+
+        value: int
+
+    baseline = calls.copy()
+    unsupported = (
+        ("model_schema_callable", CallableModelSchemaPayload),
+        ("field_schema_callable", CallableFieldSchemaPayload),
+        ("model_title_callable", CallableModelTitlePayload),
+        ("field_title_callable", CallableFieldTitlePayload),
+    )
+    for suffix, model in unsupported:
+        _assert_unsupported(model, family_name=f"unsupported_{suffix}")
+        assert calls == baseline

--- a/tests/unit/test_versioned_schema.py
+++ b/tests/unit/test_versioned_schema.py
@@ -4,7 +4,7 @@ import warnings
 from typing import Any, cast
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_serializer
 
 from pydantic_versions import (
     DuplicateSchemaVersionError,
@@ -12,6 +12,7 @@ from pydantic_versions import (
     MissingSchemaVersionError,
     SchemaVersionError,
     UnknownSchemaVersionError,
+    UnsupportedWireModelError,
     dump_versioned,
     field_default,
     field_removed,
@@ -118,15 +119,13 @@ def test_validate_versioned_uses_embedded_version_and_applies_migrations() -> No
     assert result.migrations_applied == (("1", "2"),)
 
 
-def test_validate_versioned_uses_explicit_version_over_embedded_version() -> None:
-    result = validate_versioned(
-        AppConfig,
-        {"schema_version": "3", "attempts": 1},
-        version="1",
-    )
-
-    assert result.source_version == "1"
-    assert result.current_model.timeout == 5.0
+def test_validate_versioned_does_not_overwrite_a_conflicting_embedded_version() -> None:
+    with pytest.raises(ValidationError):
+        validate_versioned(
+            AppConfig,
+            {"schema_version": "3", "attempts": 1},
+            version="1",
+        )
 
 
 def test_validate_versioned_uses_missing_version_fallback() -> None:
@@ -221,7 +220,10 @@ def test_nested_version_field_can_live_outside_model_payload() -> None:
     )
 
     assert result.source_version == "v1"
-    assert result.source_model.model_dump() == {"timeout": 3.5}
+    assert result.source_model.model_dump() == {
+        "timeout": 3.5,
+        "metadata": {"schema_version": "v1"},
+    }
     assert result.current_model == MetadataConfig(timeout=3.5)
 
 
@@ -229,7 +231,10 @@ def test_nested_version_field_can_be_supplied_explicitly_when_missing_from_paylo
     result = validate_versioned(MetadataConfig, {"timeout": 4.5}, version="v1")
 
     assert result.source_version == "v1"
-    assert result.source_model.model_dump() == {"timeout": 4.5}
+    assert result.source_model.model_dump() == {
+        "timeout": 4.5,
+        "metadata": {"schema_version": "v1"},
+    }
 
 
 def test_nested_version_field_is_rendered_and_removed_on_request() -> None:
@@ -499,5 +504,193 @@ def test_nested_default_instances_use_matching_version_models() -> None:
 
     assert service_v1().model_dump() == {
         "database": {"host": "localhost", "port": 5432, "schema_version": "1"},
+        "schema_version": "1",
+    }
+
+
+def test_nested_patched_instance_and_factory_defaults_use_the_historical_child() -> None:
+    @versioned_schema(
+        name="patched_default_child",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    @schema_version("1", patches=[field_default("port", 5432)])
+    class PatchedDefaultChild(BaseModel):
+        port: int = 6432
+
+    @versioned_schema(
+        name="patched_default_parent",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    @schema_version(
+        "1",
+        patches=[
+            field_default("instance_child", PatchedDefaultChild(port=6432)),
+            field_default("factory_child", default_factory=PatchedDefaultChild),
+        ],
+    )
+    class PatchedDefaultParent(BaseModel):
+        instance_child: PatchedDefaultChild = Field(default_factory=PatchedDefaultChild)
+        factory_child: PatchedDefaultChild = Field(default_factory=PatchedDefaultChild)
+
+    parent_v1 = model_for_version(PatchedDefaultParent, "1")()
+    typed_parent_v1 = cast(Any, parent_v1)
+
+    assert not isinstance(typed_parent_v1.instance_child, PatchedDefaultChild)
+    assert not isinstance(typed_parent_v1.factory_child, PatchedDefaultChild)
+    assert parent_v1.model_dump() == {
+        "instance_child": {"port": 6432, "schema_version": "1"},
+        "factory_child": {"port": 5432, "schema_version": "1"},
+        "schema_version": "1",
+    }
+
+
+def test_opaque_nested_child_factory_is_rejected_without_execution() -> None:
+    factory_events: list[str] = []
+
+    @versioned_schema(
+        name="opaque_factory_child",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class OpaqueFactoryChild(BaseModel):
+        value: int = 1
+
+    def make_child() -> OpaqueFactoryChild:
+        factory_events.append("factory")
+        return OpaqueFactoryChild()
+
+    @versioned_schema(
+        name="opaque_factory_parent",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class OpaqueFactoryParent(BaseModel):
+        child: OpaqueFactoryChild = Field(default_factory=make_child)
+
+    with pytest.raises(UnsupportedWireModelError, match="opaque factory"):
+        model_for_version(OpaqueFactoryParent, "1")
+
+    assert factory_events == []
+
+
+def test_nested_default_projection_does_not_run_current_child_serializers() -> None:
+    serialization_events: list[int] = []
+
+    @versioned_schema(
+        name="serializer_default_child",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class SerializerDefaultChild(BaseModel):
+        value: int = 1
+
+        @field_serializer("value")
+        def serialize_value(self, value: int) -> int:
+            serialization_events.append(value)
+            return value
+
+    child_default = SerializerDefaultChild()
+
+    @versioned_schema(
+        name="serializer_default_parent",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class SerializerDefaultParent(BaseModel):
+        child: SerializerDefaultChild = child_default
+
+    baseline = list(serialization_events)
+    parent_v1 = model_for_version(SerializerDefaultParent, "1")
+
+    assert serialization_events == baseline
+    assert parent_v1().model_dump() == {
+        "child": {"value": 1, "schema_version": "1"},
+        "schema_version": "1",
+    }
+    assert serialization_events == baseline
+
+
+def test_nested_model_owned_metadata_default_is_normalized_to_the_target_version() -> None:
+    @versioned_schema(
+        name="model_owned_default_child",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class ModelOwnedDefaultChild(BaseModel):
+        schema_version: str = "2"
+        value: int = 1
+
+    @versioned_schema(
+        name="model_owned_default_parent",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class ModelOwnedDefaultParent(BaseModel):
+        child: ModelOwnedDefaultChild = ModelOwnedDefaultChild(schema_version="2")
+
+    parent_v1 = model_for_version(ModelOwnedDefaultParent, "1")()
+
+    assert parent_v1.model_dump() == {
+        "child": {"schema_version": "1", "value": 1},
+        "schema_version": "1",
+    }
+
+
+def test_nested_family_metadata_defaults_are_normalized_without_user_factories() -> None:
+    @versioned_schema(
+        name="family_default_child",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class FamilyDefaultChild(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    @versioned_schema(
+        name="family_default_parent",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class FamilyDefaultParent(BaseModel):
+        child: FamilyDefaultChild = FamilyDefaultChild.model_validate({"schema_version": "2"})
+
+    direct_v1 = model_for_version(FamilyDefaultParent, "1")()
+    assert direct_v1.model_dump()["child"]["schema_version"] == "1"
+
+    @versioned_schema(
+        name="nested_metadata_default_child",
+        versions=["1", "2"],
+        current="2",
+        version_field=("meta", "version"),
+        missing_version="1",
+    )
+    class NestedMetadataDefaultChild(BaseModel):
+        value: int = 1
+
+    @versioned_schema(
+        name="nested_metadata_default_parent",
+        versions=["1", "2"],
+        current="2",
+        missing_version="1",
+    )
+    class NestedMetadataDefaultParent(BaseModel):
+        child: NestedMetadataDefaultChild = NestedMetadataDefaultChild()
+
+    nested_v1 = model_for_version(NestedMetadataDefaultParent, "1")()
+    assert nested_v1.model_dump() == {
+        "child": {"value": 1, "meta": {"version": "1"}},
         "schema_version": "1",
     }

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
   { "User Guide" = [
     { "Getting Started" = "guide/getting-started.md" },
     { "Concepts" = "guide/concepts.md" },
+    { "Generated Wire Contracts" = "guide/generated-wire-contracts.md" },
     { "External Schema Families" = "guide/external-families.md" },
     { "Complex Config Example" = "guide/complex-config-example.md" },
     { "Django Ninja" = "guide/django-ninja.md" },


### PR DESCRIPTION
## Summary
- Implements issue #6 scoped wire-contract behavior in generated historical models with compatibility-safe projection boundaries.
- Preserves supported annotations, constraints, defaults, aliases, configuration, and JSON schema shape.
- Enforces exact discriminators per declared version in generated models.
- Adds runtime/model-kind safety checks and clearer unsupported-wire errors for RootModel/custom behavior.
- Keeps Django Ninja/OpenAPI contract surface through generated contracts with collision-resistant schema refs.
- Adds focused regression tests and docs in generated-wire-contracts guide and API reference.

## Acceptance mapping
- [x] Current-model validators run at final boundary (unchanged behavior contract).
- [x] Field constraints/defaults/aliases and JSON Schema stay correct for supported wire models.
- [x] Generated models are documented as wire contracts, not full behavior clones.
- [x] RootModel/custom schema behavior handled via contextual errors.
- [x] Generated discriminators are exact-label literals.
- [x] Sanitized label collisions avoid duplicate references.
- [x] Django Ninja/OpenAPI compatibility tests included.

Closes #6