### PR TITLE
feat(runtime): align nested family migration flow

### DIFF
--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -1,0 +1,55 @@
+name: Commit Messages
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, reopened, edited, converted_to_draft]
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-commits:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.repository.default_branch || github.sha }}
+
+      - name: Validate PR title and commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_SHA: ${{ github.sha }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ]; then
+            pr_ref="refs/remotes/pull/${PR_NUMBER}/head"
+            git fetch --no-tags --force origin \
+              "refs/pull/${PR_NUMBER}/head:${pr_ref}"
+
+            fetched_head="$(git rev-parse "$pr_ref")"
+            if [ "$fetched_head" != "$PR_HEAD_SHA" ]; then
+              echo "Fetched PR head does not match the event head SHA." >&2
+              exit 1
+            fi
+            git cat-file -e "${PR_BASE_SHA}^{commit}"
+
+            python scripts/check_conventional_commits.py \
+              --title "$PR_TITLE" \
+              --range "${PR_BASE_SHA}..${pr_ref}"
+          else
+            if git cat-file -e "${PUSH_BEFORE_SHA}^{commit}" 2>/dev/null; then
+              python scripts/check_conventional_commits.py \
+                --range "${PUSH_BEFORE_SHA}..${PUSH_SHA}"
+            else
+              python scripts/check_conventional_commits.py \
+                --commit "$(git log -1 --pretty=%B "$PUSH_SHA")"
+            fi
+          fi

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -51,9 +51,8 @@ class SchemaVersion:
 ```
 
 Labels are exact non-empty strings. The final label is current and cannot carry
-historical patches or an explicit wire model. `wire_model` is reserved by the
-0.2 contract; the current foundation rejects non-empty use until explicit
-historical-model support lands.
+historical patches or an explicit wire model. `wire_model` is the bounded
+historical escape hatch for behavior that automatic projection cannot model.
 
 ### `VersionTransition`
 

--- a/scripts/check_conventional_commits.py
+++ b/scripts/check_conventional_commits.py
@@ -1,0 +1,1065 @@
+#!/usr/bin/env python3
+"""Validate descriptive Conventional Commits for pull requests and rebase auto-merge."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+_HEADER_RE = re.compile(
+    r"^(?P<type>[a-z][a-z0-9-]*)(?:\((?P<scope>[^()\r\n]+)\))?(?P<breaking>!)?: (?P<summary>\S.*)$"
+)
+_HEADER_TITLE_ISSUE_REF_RE = re.compile(r"(^|[\s(])#\d+(?!\d)")
+_ALLOWED_TYPES = frozenset(
+    {
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+    }
+)
+_MAX_LINE_LENGTH = 72
+_MARKDOWN_LINK_RE = re.compile(r"\[([^]\r\n]+)\]\(https?://[^)\s]+\)", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_MARKDOWN_TABLE_DELIMITER_CELL_RE = re.compile(r"^:?-{3,}:?$")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(?P<name>\S.*?)(?:\s+#+)?$")
+_SETEXT_UNDERLINE_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
+_FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
+_BLOCK_STRUCTURE_RE = re.compile(
+    r"^(?: {4}|\t| {0,3}(?:>|#{1,6}\s|[-+*]\s+|\d+[.)]\s+|`{3,}|~{3,}))"
+)
+_VALIDATION_LABEL_RE = re.compile(
+    r"^(?:tests?|testing|validation|verification|checks?|all checks)\s*[:=-]\s*",
+    re.IGNORECASE,
+)
+_VALIDATION_COMMAND_RE = re.compile(
+    r"^(?:"
+    r"uv\s+run\s+\S+|"
+    r"python\s+-m\s+(?:pytest|mypy)\b|"
+    r"pytest\b|"
+    r"ruff\s+(?:check|format)\b|"
+    r"ty\s+check\b|"
+    r"mypy\b|"
+    r"make\s+(?:ci|check|test\S*|lint\S*|typecheck|docs\S*|build|format|fix)\b"
+    r")"
+)
+_VALIDATION_RESULT_RE = re.compile(
+    r"^(?:all\s+)?(?:tests?|checks?)\s+"
+    r"(?:passed|succeeded|completed|are\s+green)\b",
+    re.IGNORECASE,
+)
+_VALIDATION_STATUS_RE = re.compile(
+    r"^[A-Za-z0-9_. /+()\-]+:\s*"
+    r"(?:pass(?:ed)?|fail(?:ed)?|success(?:ful)?|succeeded|skipped|green|ok|not run)"
+    r"(?:[.!]|\s+\([^)]*\)|\s+(?:in|on|with)\b.*)?$",
+    re.IGNORECASE,
+)
+_VALIDATION_SECTION_NAMES = frozenset({"checks", "testing", "tests", "validation", "verification"})
+_VALIDATION_OUTCOME_TRAIL_RE = re.compile(
+    r"(?:\b(?:clean|completed|failed|green|ok|passed|succeeded|"
+    r"successful(?:ly)?)\b|"
+    r"\bno (?:errors?|issues?) found\b)"
+    r"(?:[.!]|\s+\([^)]*\)|\s+(?:as|in|on|with)\b.*)?$",
+    re.IGNORECASE,
+)
+_VALIDATION_EXPLICIT_OUTCOME_TRAIL_RE = re.compile(
+    r"(?:\b(?:clean|completed|fail(?:ed|ure)?|green|ok|pass(?:ed)?|"
+    r"succeed(?:ed)?|success(?:ful(?:ly)?)?)\b|"
+    r"\bno (?:errors?|issues?) found\b)"
+    r"(?:[.!]|\s+\([^)]*\)|\s+(?:as|in|on|with)\b.*)?$",
+    re.IGNORECASE,
+)
+_VALIDATION_COUNT_RESULT_RE = re.compile(
+    r"\b(?:exit code \d+|\d+\s+(?:deselected|errors?|failed|passed|skipped|"
+    r"warnings?|xfailed|xpassed)|no failures|\d+\s+files? left unchanged)\b",
+    re.IGNORECASE,
+)
+_VALIDATION_EXECUTED_COUNT_RE = re.compile(
+    r"\b\d+\s+(?:errors?|failed|passed|xfailed|xpassed)\b",
+    re.IGNORECASE,
+)
+_VALIDATION_MODAL_RESULT_RE = re.compile(
+    r"\b(?:can|could|expected to|may|might|must|should|will|would)\s+"
+    r"(?:have\s+)?(?:fail(?:ed)?|pass(?:ed)?|succeed(?:ed)?)\b",
+    re.IGNORECASE,
+)
+_VALIDATION_SUBJECT_RE = re.compile(
+    r"(?:\b(?:build|coverage|docs?|documentation|gate|lint|matrix|package|"
+    r"pytest|ruff|suite|tests?|checks?|typecheck|typing)\b|\bcommit messages\b)"
+    r"(?:\s+(?:across|against|for|in|on|under|with)\s+\S+(?:\s+\S+){0,7})?"
+    r"(?:\s+(?:are|have been|is|was|were))?$",
+    re.IGNORECASE,
+)
+_VALIDATION_NARRATIVE_RE = re.compile(
+    r"\b(?:allegedly|describes?|documents?|explains?|if|meant|means?|perhaps|"
+    r"possibly|records?|reportedly|verifies?|when|why)\b|"
+    r"\b(?:earlier|historical|previous|prior)(?!-)\b",
+    re.IGNORECASE,
+)
+_GENERIC_VALIDATION_SUBJECT_RE = re.compile(
+    r"^(?:(?:all|the)\s+)?(?:tests?|checks?)$",
+    re.IGNORECASE,
+)
+_VALIDATION_NOT_RUN_RE = re.compile(
+    r"\b(?:not run|not executed|not applicable)\b(?P<suffix>.*)$",
+    re.IGNORECASE,
+)
+_VALIDATION_SKIPPED_RE = re.compile(r"\bskipped\b(?P<suffix>.*)$", re.IGNORECASE)
+_VALIDATION_REASON_RE = re.compile(
+    r"^(?:(?:because|as|due to)\s+|[:;\-\N{EM DASH}]\s*|\()"
+    r"(?P<reason>\S.*?)(?:\))?[.!]?$",
+    re.IGNORECASE,
+)
+_GENERIC_VALIDATION_REASON_RE = re.compile(
+    r"^(?:reasons?|not (?:applicable|needed|required)|"
+    r"(?:it|this|checks?|tests?|validation)\s+(?:(?:was|were)\s+)?"
+    r"(?:not run|skipped)|skipped)$",
+    re.IGNORECASE,
+)
+_TEMPLATE_TOKEN_RE = re.compile(r"<(?:command|result|describe[^>]*)>", re.IGNORECASE)
+_PLACEHOLDER_PREFIX_RE = re.compile(
+    r"^(?:(?:wip|todo|tbd)(?:\s*(?::|-|\N{EM DASH})\s*|\s+)"
+    r"|(?:work[ -]in[ -]progress|placeholder)\s*(?::|-|\N{EM DASH})\s*)\S",
+    re.IGNORECASE,
+)
+_DEVELOPMENT_ONLY_RE = re.compile(
+    r"\b(?:"
+    r"(?:address(?:ed|es|ing)?|apply|applied|fix(?:ed|es|ing)?)\s+"
+    r"(?:the\s+)?(?:latest\s+)?(?:review(?:er)?\s+)?"
+    r"(?:feedback|comments?|changes)"
+    r"|fix(?:ed|es|ing)?\s+(?:ci|tests?|lint)(?:\s+(?:failures?|errors?))?"
+    r"|(?:ci|tests?|lint)\s+fix(?:es)?"
+    r")\b",
+    re.IGNORECASE,
+)
+_DEPENDABOT_METADATA_RECORD_RE = re.compile(r"^- dependency-name: (?P<value>\S+)$")
+_DEPENDABOT_METADATA_FIELD_RE = re.compile(r"^  (?P<key>[a-z][a-z-]*): (?P<value>\S+)$")
+_DEPENDABOT_REQUIRED_FIELDS = frozenset(
+    {"dependency-name", "dependency-version", "dependency-type", "update-type"}
+)
+_DEPENDABOT_ALLOWED_FIELDS = _DEPENDABOT_REQUIRED_FIELDS | {"dependency-group"}
+_DEPENDABOT_METADATA_PREFIXES = tuple(
+    ["- dependency-name:"] + [f"  {field}:" for field in sorted(_DEPENDABOT_ALLOWED_FIELDS)]
+)
+_DEPENDABOT_SIGNOFF = "Signed-off-by: dependabot[bot] <support@github.com>"
+_DEPENDABOT_BUMP_RE = re.compile(
+    r"^Bumps (?P<dependency>\S+) from (?P<old>\S+) to (?P<new>\S+?)\.?$",
+    re.IGNORECASE,
+)
+_DEPENDABOT_SINGLE_SUMMARY_RE = re.compile(
+    r"^bump (?P<dependency>\S+) from (?P<old>\S+) to (?P<new>\S+)$",
+    re.IGNORECASE,
+)
+_DEPENDABOT_GROUP_SUMMARY_RE = re.compile(
+    r"^bump the (?P<group>\S+) group"
+    r"(?: across \d+ director(?:y|ies))? with (?P<count>\d+) updates$",
+    re.IGNORECASE,
+)
+_BULLET_RE = re.compile(r"^\s*[-*+]\s+(?:\[[ xX]\]\s+)?")
+_ISSUE_TRAILER_RE = re.compile(
+    r"^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\s+#\d+(?:\s*,\s*#\d+)*$",
+    re.IGNORECASE,
+)
+_KNOWN_TRAILER_RE = re.compile(
+    r"^(?:BREAKING CHANGE|BREAKING-CHANGE|Co-authored-by|Signed-off-by|Reviewed-by|"
+    r"Acked-by|Tested-by|Reported-by|Suggested-by|Helped-by): \S",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_RE = re.compile(
+    r"""
+    ^(?:
+        <[^>]*>
+        | \[[^]]*\]
+        | \.{3}
+        | …
+        | wip
+        | work[ -]in[ -]progress
+        | todo
+        | tbd
+        | n/?a
+        | none
+        | pending
+        | placeholder
+        | temp(?:orary)?
+        | changes?
+        | updates?
+        | misc(?:ellaneous)?
+        | more[ -]changes
+        | (?:iteration|round|pass|attempt)(?:\s*\#?\d+)?
+        | (?:address(?:ed|es)?|apply|applied)\s+
+          (?:the\s+)?(?:latest\s+)?(?:review(?:er)?\s+)?
+          (?:feedback|comments?|changes)
+        | fix(?:ed|es)?\s+(?:review\s+)?(?:feedback|comments?)
+        | fix(?:ed|es)?\s+(?:ci|tests?|lint)
+        | (?:ci|tests?|lint)\s+fix(?:es)?
+        | cleanup
+        | polish
+    )[.!]?
+    $
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_MIN_BODY_WORDS = 8
+
+
+def validate_header(header: str, *, label: str) -> str | None:
+    """Return an actionable error for an invalid Conventional Commit header."""
+    match = _HEADER_RE.fullmatch(header.strip())
+    if match is None:
+        return (
+            f"{label} is not a Conventional Commit header: {header!r}. "
+            "Expected <type>[optional scope][!]: <imperative summary>."
+        )
+    if match.group("type") not in _ALLOWED_TYPES:
+        allowed = ", ".join(sorted(_ALLOWED_TYPES))
+        return f"{label} uses unsupported type {match.group('type')!r}; use one of: {allowed}."
+    summary = match.group("summary")
+    if _MARKDOWN_LINK_RE.search(summary):
+        return f"{label} summary must be plain text: {summary!r}. Move links and issue references to the body."
+    if _HEADER_TITLE_ISSUE_REF_RE.search(summary):
+        return f"{label} summary must stay issue-agnostic: {summary!r}. Put issue references in body sections instead."
+    if _is_placeholder(match.group("summary")):
+        return (
+            f"{label} uses a development placeholder as its summary: "
+            f"{match.group('summary')!r}. Describe the durable change instead."
+        )
+    return None
+
+
+def _strip_markup(line: str) -> str:
+    """Return visible prose without list markers or unwrappable destinations."""
+    stripped = _BULLET_RE.sub("", line.strip()).strip()
+    stripped = _MARKDOWN_LINK_RE.sub(lambda match: match.group(1), stripped)
+    stripped = _URL_RE.sub("", stripped)
+    return re.sub(r"[`*_~]+", "", stripped).strip()
+
+
+def _is_placeholder(line: str) -> bool:
+    """Return whether one complete line is development-only placeholder prose."""
+    visible = _strip_markup(line)
+    return bool(_PLACEHOLDER_RE.fullmatch(visible) or _PLACEHOLDER_PREFIX_RE.match(visible))
+
+
+def _is_trailer(line: str) -> bool:
+    """Return whether a line is commit metadata rather than explanatory prose."""
+    stripped = line.strip()
+    return bool(_ISSUE_TRAILER_RE.fullmatch(stripped) or _KNOWN_TRAILER_RE.match(stripped))
+
+
+def _meaningful_lines(lines: Sequence[str]) -> list[str]:
+    """Return visible body lines, excluding headings, comments, and trailers."""
+    meaningful: list[str] = []
+    in_html_comment = False
+    setext_lines = _setext_heading_lines(lines)
+    for index, line in enumerate(lines):
+        stripped = _strip_markup(line)
+        if in_html_comment:
+            if "-->" in stripped:
+                in_html_comment = False
+            continue
+        if stripped.startswith("<!--"):
+            in_html_comment = "-->" not in stripped
+            continue
+        if (
+            not stripped
+            or index in setext_lines
+            or stripped.startswith(";")
+            or _HEADING_RE.fullmatch(stripped)
+            or _is_trailer(stripped)
+        ):
+            continue
+        meaningful.append(stripped)
+    return meaningful
+
+
+def _context_lines(lines: Sequence[str]) -> list[str]:
+    """Return change-context prose, excluding mechanical validation evidence."""
+    context: list[str] = []
+    validation_section = False
+    in_html_comment = False
+    setext_lines = _setext_heading_lines(lines)
+    for index, line in enumerate(lines):
+        raw = line.strip()
+        if in_html_comment:
+            if "-->" in raw:
+                in_html_comment = False
+            continue
+        if raw.startswith("<!--"):
+            in_html_comment = "-->" not in raw
+            continue
+        if index in setext_lines:
+            if index + 1 < len(lines) and _SETEXT_UNDERLINE_RE.fullmatch(lines[index + 1]):
+                validation_section = _strip_markup(raw).casefold() in _VALIDATION_SECTION_NAMES
+            continue
+        if heading := _HEADING_RE.fullmatch(raw):
+            section_name = _strip_markup(heading.group("name")).casefold()
+            validation_section = section_name in _VALIDATION_SECTION_NAMES
+            continue
+
+        visible = _strip_markup(line)
+        if (
+            not visible
+            or visible.startswith(";")
+            or _is_trailer(visible)
+            or validation_section
+            or _VALIDATION_LABEL_RE.match(visible)
+            or _VALIDATION_COMMAND_RE.match(visible)
+            or _VALIDATION_RESULT_RE.match(visible)
+            or _VALIDATION_STATUS_RE.match(visible)
+        ):
+            continue
+        context.append(visible)
+    return context
+
+
+def _has_explicit_not_run_reason(text: str) -> bool:
+    """Require a concrete reason after a validation not-run statement."""
+    match = _VALIDATION_NOT_RUN_RE.search(text)
+    if match is None or not (
+        reason_match := _VALIDATION_REASON_RE.match(match.group("suffix").strip())
+    ):
+        return False
+    reason = _strip_markup(reason_match.group("reason")).strip(" ().")
+    return bool(reason) and not (
+        _is_placeholder(reason) or _GENERIC_VALIDATION_REASON_RE.fullmatch(reason)
+    )
+
+
+def _validation_blocks(
+    lines: Sequence[str],
+    *,
+    metadata_candidate_bounds: tuple[int, int] | None,
+) -> list[tuple[tuple[str, ...], bool, tuple[int, ...]]]:
+    """Return top-level logical body blocks and validation-section state."""
+    blocks: list[tuple[tuple[str, ...], bool, tuple[int, ...]]] = []
+    parts: list[str] = []
+    part_indexes: list[int] = []
+    parts_are_validation = False
+    validation_section = False
+    in_html_comment = False
+    setext_lines = _setext_heading_lines(lines)
+    top_level_indexes = _top_level_line_indexes(lines)
+    body_start = 2 if len(lines) >= 2 and lines[1] == "" else 1
+
+    def flush() -> None:
+        nonlocal part_indexes, parts
+        if parts:
+            blocks.append((tuple(parts), parts_are_validation, tuple(part_indexes)))
+            parts = []
+            part_indexes = []
+
+    for index, line in enumerate(lines):
+        raw = line.strip()
+        if index < body_start:
+            continue
+        if in_html_comment:
+            if "-->" in raw:
+                in_html_comment = False
+            continue
+        if raw.startswith("<!--"):
+            flush()
+            in_html_comment = "-->" not in raw
+            continue
+        if index not in top_level_indexes or (
+            metadata_candidate_bounds is not None
+            and metadata_candidate_bounds[0] <= index <= metadata_candidate_bounds[1]
+        ):
+            flush()
+            continue
+        if index in setext_lines:
+            flush()
+            if index + 1 < len(lines) and _SETEXT_UNDERLINE_RE.fullmatch(lines[index + 1]):
+                validation_section = _strip_markup(raw).casefold() in _VALIDATION_SECTION_NAMES
+            continue
+        if heading := _HEADING_RE.fullmatch(raw):
+            flush()
+            validation_section = (
+                _strip_markup(heading.group("name")).casefold() in _VALIDATION_SECTION_NAMES
+            )
+            continue
+
+        visible = _strip_markup(line)
+        if not visible or visible.startswith(";") or _is_trailer(visible):
+            flush()
+            continue
+
+        starts_record = bool(
+            _BULLET_RE.match(line)
+            or _VALIDATION_LABEL_RE.match(visible)
+            or _VALIDATION_COMMAND_RE.match(visible)
+        )
+        if parts and (starts_record or parts_are_validation != validation_section):
+            flush()
+        if not parts:
+            parts_are_validation = validation_section
+        parts.append(visible)
+        part_indexes.append(index)
+    flush()
+    return blocks
+
+
+def _has_concrete_command_result(candidate: str, command_match: re.Match[str] | None) -> bool:
+    """Accept an explicit result attached to a recognized command."""
+    if command_match is None:
+        return False
+    result_match = re.search(r":\s+(?P<result>\S.*)$", candidate)
+    if result_match is None:
+        return False
+    result = _strip_markup(result_match.group("result")).strip()
+    return bool(
+        result
+        and not _is_placeholder(result)
+        and not _VALIDATION_MODAL_RESULT_RE.search(result)
+        and (
+            _VALIDATION_COUNT_RESULT_RE.search(result)
+            or _VALIDATION_EXPLICIT_OUTCOME_TRAIL_RE.search(result)
+        )
+    )
+
+
+def _has_unstructured_validation_subject(subject: str) -> bool:
+    """Reject narrative prose while accepting a concise named check or suite."""
+    return bool(
+        _VALIDATION_SUBJECT_RE.search(subject) and not _VALIDATION_NARRATIVE_RE.search(subject)
+    )
+
+
+def _is_validation_record(candidate: str, *, validation_section: bool) -> bool:
+    """Return whether one logical candidate records a concrete validation result."""
+    label_match = _VALIDATION_LABEL_RE.match(candidate)
+    explicit_context = validation_section or label_match is not None
+    if label_match:
+        candidate = candidate[label_match.end() :].strip()
+    command_match = _VALIDATION_COMMAND_RE.match(candidate)
+
+    if not_run_match := _VALIDATION_NOT_RUN_RE.search(candidate):
+        not_run_subject = candidate[: not_run_match.start()].strip(" :=-\N{EM DASH}")
+        return bool(
+            (
+                explicit_context
+                or command_match
+                or _has_unstructured_validation_subject(not_run_subject)
+            )
+            and _has_explicit_not_run_reason(candidate)
+        )
+
+    if skipped_match := _VALIDATION_SKIPPED_RE.search(candidate):
+        if not _VALIDATION_EXECUTED_COUNT_RE.search(candidate):
+            skipped_subject = candidate[: skipped_match.start()].strip(" :=-\N{EM DASH}")
+            return bool(
+                (
+                    explicit_context
+                    or command_match
+                    or _has_unstructured_validation_subject(skipped_subject)
+                )
+                and _has_explicit_not_run_reason(f"not run {skipped_match.group('suffix')}")
+            )
+
+    if command_match:
+        return _has_concrete_command_result(candidate, command_match)
+
+    if count_result := _VALIDATION_COUNT_RESULT_RE.search(candidate):
+        subject = candidate[: count_result.start()].strip(" :=-\N{EM DASH}")
+        normalized_subject = " ".join(subject.casefold().split())
+        if subject and _GENERIC_VALIDATION_SUBJECT_RE.fullmatch(normalized_subject):
+            return False
+        return bool(explicit_context or _has_unstructured_validation_subject(subject))
+
+    outcome = _VALIDATION_OUTCOME_TRAIL_RE.search(candidate)
+    if outcome is None and explicit_context:
+        outcome = _VALIDATION_EXPLICIT_OUTCOME_TRAIL_RE.search(candidate)
+    if outcome is None or _VALIDATION_MODAL_RESULT_RE.search(candidate):
+        return False
+    subject = candidate[: outcome.start()].strip(" :=-\N{EM DASH}")
+    normalized_subject = " ".join(subject.casefold().split())
+    if not subject or _GENERIC_VALIDATION_SUBJECT_RE.fullmatch(normalized_subject):
+        return False
+    return bool(explicit_context or _has_unstructured_validation_subject(subject))
+
+
+def _classify_validation_block(
+    parts: Sequence[str], *, validation_section: bool
+) -> tuple[bool, str]:
+    """Return validation status and any descriptive prefix in a mixed block."""
+    block = " ".join(parts)
+    if validation_section or _VALIDATION_LABEL_RE.match(block):
+        return _is_validation_record(block, validation_section=validation_section), ""
+
+    candidate_starts = {0}
+    offset = 0
+    for part in parts[:-1]:
+        offset += len(part) + 1
+        candidate_starts.add(offset)
+    candidate_starts.update(match.end() for match in re.finditer(r"(?<=[.!?])\s+", block))
+    for start in sorted(candidate_starts, reverse=True):
+        candidate = block[start:].strip()
+        if _is_validation_record(candidate, validation_section=False):
+            return True, block[:start].strip()
+    return False, block
+
+
+def _analyze_validation(
+    lines: Sequence[str],
+    *,
+    metadata_candidate_bounds: tuple[int, int] | None,
+) -> tuple[bool, set[int], list[str]]:
+    """Return evidence state, excluded lines, and mixed-block context."""
+    has_evidence = False
+    indexes: set[int] = set()
+    context_prefixes: list[str] = []
+    for parts, validation_section, block_indexes in _validation_blocks(
+        lines,
+        metadata_candidate_bounds=metadata_candidate_bounds,
+    ):
+        is_validation, context_prefix = _classify_validation_block(
+            parts,
+            validation_section=validation_section,
+        )
+        if not is_validation:
+            continue
+        has_evidence = True
+        indexes.update(block_indexes)
+        if context_prefix:
+            context_prefixes.append(context_prefix)
+    return has_evidence, indexes, context_prefixes
+
+
+def _word_count(lines: Sequence[str]) -> int:
+    return sum(len(re.findall(r"[A-Za-z][A-Za-z0-9_-]*", line)) for line in lines)
+
+
+def _normalized_prose(lines: Sequence[str]) -> str:
+    visible = " ".join(_strip_markup(line) for line in lines)
+    return " ".join(re.findall(r"[a-z0-9]+", visible.casefold()))
+
+
+def _setext_heading_lines(lines: Sequence[str]) -> set[int]:
+    """Return text and underline indexes for Setext-style headings."""
+    headings: set[int] = set()
+    for index in range(1, len(lines)):
+        if not _SETEXT_UNDERLINE_RE.fullmatch(lines[index]):
+            continue
+        heading = lines[index - 1].strip()
+        if heading and not heading.startswith(("- ", "* ", "+ ", ">", "    ")):
+            headings.update({index - 1, index})
+    return headings
+
+
+def _without_summary_repetitions(
+    context: Sequence[str], summary: str | None
+) -> tuple[list[str], bool]:
+    """Remove complete header-summary token sequences from joined body prose."""
+    context_tokens = _normalized_prose(context).split()
+    summary_tokens = _normalized_prose([summary]).split() if summary is not None else []
+    if not summary_tokens:
+        return context_tokens, False
+
+    remaining: list[str] = []
+    repeated = False
+    index = 0
+    while index < len(context_tokens):
+        if context_tokens[index : index + len(summary_tokens)] == summary_tokens:
+            repeated = True
+            index += len(summary_tokens)
+            continue
+        remaining.append(context_tokens[index])
+        index += 1
+    return remaining, repeated
+
+
+def _generated_metadata_candidate_bounds(lines: Sequence[str]) -> tuple[int, int] | None:
+    """Return syntactic bounds for a generated dependency metadata block."""
+    body_start = 2 if len(lines) >= 2 and lines[1] == "" else 1
+    top_level_indexes = _top_level_line_indexes(lines)
+    metadata_headers = [
+        index
+        for index in range(body_start, len(lines))
+        if index in top_level_indexes and lines[index].strip() == "updated-dependencies:"
+    ]
+    if len(metadata_headers) != 1:
+        return None
+
+    metadata_header = metadata_headers[0]
+    metadata_start = metadata_header - 1
+    if (
+        metadata_start < body_start
+        or metadata_start not in top_level_indexes
+        or lines[metadata_start].strip() != "---"
+    ):
+        return None
+
+    metadata_ends = [
+        index
+        for index in range(metadata_header + 1, len(lines))
+        if index in top_level_indexes and lines[index].strip() == "..."
+    ]
+    if len(metadata_ends) != 1:
+        return None
+    metadata_end = metadata_ends[0]
+
+    return metadata_start, metadata_end
+
+
+def _generated_metadata_records(
+    lines: Sequence[str], bounds: tuple[int, int] | None
+) -> list[dict[str, str]] | None:
+    """Parse complete, recognized records from a candidate metadata block."""
+    if bounds is None:
+        return None
+    metadata_start, metadata_end = bounds
+    metadata_lines = list(lines[metadata_start + 2 : metadata_end])
+    if not metadata_lines:
+        return None
+
+    records: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in metadata_lines:
+        if record_match := _DEPENDABOT_METADATA_RECORD_RE.fullmatch(line):
+            if current is not None:
+                records.append(current)
+            current = {"dependency-name": record_match.group("value")}
+            continue
+        if current is None or not (field_match := _DEPENDABOT_METADATA_FIELD_RE.fullmatch(line)):
+            return None
+        key = field_match.group("key")
+        if key not in _DEPENDABOT_ALLOWED_FIELDS or key in current:
+            return None
+        current[key] = field_match.group("value")
+    if current is not None:
+        records.append(current)
+    if not records or any(not _DEPENDABOT_REQUIRED_FIELDS <= record.keys() for record in records):
+        return None
+
+    return records
+
+
+def _generated_metadata_bounds(lines: Sequence[str]) -> tuple[int, int] | None:
+    """Return bounds only for a complete, recognized Dependabot metadata block."""
+    bounds = _generated_metadata_candidate_bounds(lines)
+    if _generated_metadata_records(lines, bounds) is None:
+        return None
+    assert bounds is not None
+    trailers = [line.strip() for line in lines[bounds[1] + 1 :] if line.strip()]
+    return bounds if trailers == [_DEPENDABOT_SIGNOFF] else None
+
+
+def _top_level_line_indexes(lines: Sequence[str]) -> set[int]:
+    """Return lines outside fenced, quoted, and indented code examples."""
+    indexes: set[int] = set()
+    fence_marker: str | None = None
+    for index, line in enumerate(lines):
+        if fence_match := _FENCE_RE.match(line):
+            marker = fence_match.group("marker")[0]
+            if fence_marker is None:
+                fence_marker = marker
+            elif marker == fence_marker:
+                fence_marker = None
+            continue
+        if fence_marker is not None or line.startswith(("    ", "\t")):
+            continue
+        if re.match(r"^ {0,3}>", line):
+            continue
+        indexes.add(index)
+    return indexes
+
+
+def _contains_generated_metadata_shape(lines: Sequence[str]) -> bool:
+    """Return whether commit text contains dependency metadata-shaped lines."""
+    top_level_indexes = _top_level_line_indexes(lines)
+    return any(
+        lines[index].strip() == "updated-dependencies:"
+        or lines[index].startswith(_DEPENDABOT_METADATA_PREFIXES)
+        for index in top_level_indexes
+    )
+
+
+def _split_markdown_table_row(line: str) -> list[str] | None:
+    """Split a GFM table row on unescaped pipes, including one-cell rows."""
+    stripped = line.strip()
+    cells: list[str] = []
+    current: list[str] = []
+    escaped = False
+    saw_pipe = False
+    for character in stripped:
+        if escaped:
+            current.append(character)
+            escaped = False
+        elif character == "\\":
+            current.append(character)
+            escaped = True
+        elif character == "|":
+            cells.append("".join(current).strip())
+            current = []
+            saw_pipe = True
+        else:
+            current.append(character)
+    cells.append("".join(current).strip())
+    if not saw_pipe:
+        return None
+    if cells and not cells[0]:
+        cells.pop(0)
+    if cells and not cells[-1]:
+        cells.pop()
+    return cells or None
+
+
+def _markdown_table_lines(lines: Sequence[str]) -> set[int]:
+    """Return line indexes belonging to complete GFM-style tables."""
+    table_lines: set[int] = set()
+    for index in range(1, len(lines)):
+        header_cells = _split_markdown_table_row(lines[index - 1])
+        delimiter_cells = _split_markdown_table_row(lines[index])
+        if (
+            header_cells is None
+            or delimiter_cells is None
+            or len(header_cells) != len(delimiter_cells)
+            or not all(
+                _MARKDOWN_TABLE_DELIMITER_CELL_RE.fullmatch(cell) for cell in delimiter_cells
+            )
+        ):
+            continue
+        table_lines.update({index - 1, index})
+        row_index = index + 1
+        while row_index < len(lines):
+            if _BLOCK_STRUCTURE_RE.match(lines[row_index]):
+                break
+            row_cells = _split_markdown_table_row(lines[row_index])
+            if row_cells is None:
+                break
+            table_lines.add(row_index)
+            row_index += 1
+    return table_lines
+
+
+def _has_generated_dependency_context(
+    context: Sequence[str], records: Sequence[dict[str, str]] | None
+) -> bool:
+    """Recognize Dependabot's complete short-name prose and links."""
+    if records is None or len(records) != 1 or not context:
+        return False
+    bump = _DEPENDABOT_BUMP_RE.fullmatch(context[0])
+    if bump is None:
+        return False
+    record = records[0]
+    if (
+        _normalized_prose([bump.group("dependency")])
+        != _normalized_prose([record["dependency-name"]])
+        or bump.group("new").casefold() != record["dependency-version"].casefold()
+    ):
+        return False
+    labels = {line.casefold().rstrip(":") for line in context[1:]}
+    return "commits" in labels and ("release notes" in labels or "changelog" in labels)
+
+
+def _has_generated_dependency_header(header: str, records: Sequence[dict[str, str]] | None) -> bool:
+    """Recognize a canonical Dependabot header backed by validated metadata."""
+    if records is None or not records:
+        return False
+    header_match = _HEADER_RE.fullmatch(header.strip())
+    if header_match is None:
+        return False
+    summary = header_match.group("summary")
+
+    if single_match := _DEPENDABOT_SINGLE_SUMMARY_RE.fullmatch(summary):
+        if len(records) != 1:
+            return False
+        record = records[0]
+        return (
+            _normalized_prose([single_match.group("dependency")])
+            == _normalized_prose([record["dependency-name"]])
+            and single_match.group("new").casefold() == record["dependency-version"].casefold()
+        )
+
+    if group_match := _DEPENDABOT_GROUP_SUMMARY_RE.fullmatch(summary):
+        group = group_match.group("group").casefold()
+        return len(records) == int(group_match.group("count")) and all(
+            record.get("dependency-group", "").casefold() == group for record in records
+        )
+    return False
+
+
+def _validate_descriptive_body(
+    lines: Sequence[str],
+    *,
+    label: str,
+    summary: str | None,
+    metadata_candidate_bounds: tuple[int, int] | None,
+    metadata_bounds: tuple[int, int] | None,
+    metadata_records: Sequence[dict[str, str]] | None,
+    validation_indexes: set[int],
+    validation_context_prefixes: Sequence[str],
+) -> list[str]:
+    """Require useful historical context without prescribing Markdown sections."""
+    errors: list[str] = []
+    if len(lines) < 2 or lines[1] != "":
+        errors.append(f"{label} must separate its header and body with a blank line.")
+
+    body_start = 2 if len(lines) >= 2 and lines[1] == "" else 1
+    full_body = list(lines[body_start:])
+    body = [
+        "" if index in validation_indexes else line
+        for index, line in enumerate(lines[body_start:], start=body_start)
+        if metadata_candidate_bounds is None
+        or not metadata_candidate_bounds[0] <= index <= metadata_candidate_bounds[1]
+    ]
+    placeholder_body = [
+        line
+        for index, line in enumerate(full_body, start=body_start)
+        if metadata_candidate_bounds is None
+        or index
+        not in {
+            metadata_candidate_bounds[0],
+            metadata_candidate_bounds[0] + 1,
+            metadata_candidate_bounds[1],
+        }
+    ]
+    placeholder_indexes = _top_level_line_indexes(placeholder_body)
+    meaningful = _meaningful_lines(
+        [
+            line if index in placeholder_indexes else ""
+            for index, line in enumerate(placeholder_body)
+        ]
+    )
+    placeholders = [
+        line for line in meaningful if _is_placeholder(line) or _TEMPLATE_TOKEN_RE.search(line)
+    ]
+    context = [*_context_lines(body), *validation_context_prefixes]
+    joined_context = " ".join(context)
+    if joined_context and _is_placeholder(joined_context):
+        placeholders.append(joined_context)
+    if placeholders:
+        errors.append(
+            f"{label} body contains placeholder content {placeholders[0]!r}. "
+            "Describe the durable change and its context instead."
+        )
+
+    scored_context = [_DEVELOPMENT_ONLY_RE.sub(" ", " ".join(context))]
+    descriptive_tokens, repeated_summary = _without_summary_repetitions(scored_context, summary)
+    descriptive_word_count = _word_count([" ".join(descriptive_tokens)])
+    if repeated_summary and descriptive_word_count < _MIN_BODY_WORDS:
+        errors.append(
+            f"{label} body repeats the header summary without enough additional context. "
+            "Explain enough context to understand the change without reading its diff."
+        )
+    elif descriptive_word_count < _MIN_BODY_WORDS and not (
+        metadata_bounds is not None and _has_generated_dependency_context(context, metadata_records)
+    ):
+        errors.append(
+            f"{label} body must contain meaningful context "
+            f"({_MIN_BODY_WORDS} or more prose words outside headings, validation, "
+            "metadata, and trailers)."
+        )
+    return errors
+
+
+def _line_length_errors(
+    lines: Sequence[str],
+    *,
+    label: str,
+    metadata_bounds: tuple[int, int] | None = None,
+    generated_header: bool = False,
+) -> list[str]:
+    """Validate wrappable prose while tolerating mechanical Markdown structures."""
+    errors: list[str] = []
+    table_lines = _markdown_table_lines(lines)
+    for index, line in enumerate(lines):
+        line_number = index + 1
+        if index == 0 and generated_header:
+            continue
+        if metadata_bounds is not None and metadata_bounds[0] <= index <= metadata_bounds[1]:
+            continue
+
+        if index in table_lines or _is_trailer(line):
+            continue
+
+        measured = _MARKDOWN_LINK_RE.sub(lambda match: match.group(1), line)
+        measured = _URL_RE.sub("", measured)
+        if len(measured) > _MAX_LINE_LENGTH:
+            errors.append(
+                f"{label} line {line_number} exceeds {_MAX_LINE_LENGTH} characters "
+                f"({len(measured)} visible characters). "
+                "Wrap commit-message prose for narrow terminals."
+            )
+    return errors
+
+
+def validate_message(message: str, *, label: str) -> list[str]:
+    """Validate a full commit message, including its explanatory body."""
+    lines = message.strip().splitlines()
+    if not lines:
+        return [f"{label} is empty; provide a Conventional Commit header and descriptive body."]
+
+    errors: list[str] = []
+    header_match = _HEADER_RE.fullmatch(lines[0].strip())
+    if error := validate_header(lines[0], label=label):
+        errors.append(error)
+    summary = header_match.group("summary") if header_match is not None else None
+    metadata_candidate_bounds = _generated_metadata_candidate_bounds(lines)
+    metadata_bounds = _generated_metadata_bounds(lines)
+    metadata_records = _generated_metadata_records(lines, metadata_bounds)
+    validation_evidence, validation_indexes, validation_context_prefixes = _analyze_validation(
+        lines,
+        metadata_candidate_bounds=metadata_candidate_bounds,
+    )
+    generated_dependency_message = metadata_bounds is not None and _has_generated_dependency_header(
+        lines[0], metadata_records
+    )
+    if (metadata_candidate_bounds is not None and metadata_bounds is None) or (
+        metadata_candidate_bounds is None and _contains_generated_metadata_shape(lines)
+    ):
+        errors.append(
+            f"{label} contains an unrecognized generated dependency metadata block. "
+            "Use complete Dependabot fields with single-token values and its signed-off trailer."
+        )
+    errors.extend(
+        _validate_descriptive_body(
+            lines,
+            label=label,
+            summary=summary,
+            metadata_candidate_bounds=metadata_candidate_bounds,
+            metadata_bounds=metadata_bounds,
+            metadata_records=metadata_records,
+            validation_indexes=validation_indexes,
+            validation_context_prefixes=validation_context_prefixes,
+        )
+    )
+    if not generated_dependency_message and not validation_evidence:
+        errors.append(
+            f"{label} must record validation evidence or a specific reason validation "
+            "was not run. Include a result such as `uv run make ci: passed` or "
+            "`Validation: not run because this changes documentation only`."
+        )
+    errors.extend(
+        _line_length_errors(
+            lines,
+            label=label,
+            metadata_bounds=metadata_bounds,
+            generated_header=generated_dependency_message,
+        )
+    )
+    return errors
+
+
+def _messages_from_git(commit_range: str) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "log", "--format=%B%x1e", "--no-merges", commit_range],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or "git log failed"
+        raise RuntimeError(f"Unable to inspect commit range {commit_range!r}: {detail}") from exc
+    return [message.strip() for message in result.stdout.split("\x1e") if message.strip()]
+
+
+def _messages_from_file(path: str) -> list[str]:
+    """Read one full commit message from a file."""
+    try:
+        contents = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read commit message file {path!r}: {exc}") from exc
+    message = contents.strip()
+    return [message] if message else []
+
+
+def _messages_from_json_file(path: str) -> list[str]:
+    """Read a JSON array of full commit messages for newline-safe transport."""
+    try:
+        values = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Unable to read commit message file {path!r}: {exc}") from exc
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        raise RuntimeError(f"Commit message file {path!r} must contain a JSON string array")
+    return [value for value in values if value.strip()]
+
+
+def validate(
+    *,
+    title: str | None,
+    commits: Sequence[str],
+    commit_range: str | None,
+    commit_file: str | None = None,
+    commit_json_file: str | None = None,
+) -> list[str]:
+    """Validate a PR title and/or commit headers and return all errors."""
+    messages = list(commits)
+    if commit_range is not None:
+        messages.extend(_messages_from_git(commit_range))
+    if commit_file is not None:
+        messages.extend(_messages_from_file(commit_file))
+    if commit_json_file is not None:
+        messages.extend(_messages_from_json_file(commit_json_file))
+
+    errors: list[str] = []
+    if title is not None:
+        if error := validate_header(title, label="PR title"):
+            errors.append(error)
+    if not messages:
+        errors.append("No commit headers were found to validate.")
+    for index, message in enumerate(messages, start=1):
+        errors.extend(validate_message(message, label=f"Commit {index}"))
+    return errors
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--title", help="Pull request title to validate.")
+    parser.add_argument(
+        "--commit",
+        action="append",
+        default=[],
+        help="Full commit message to validate; may be supplied multiple times.",
+    )
+    parser.add_argument(
+        "--range",
+        dest="commit_range",
+        help="Git revision range whose non-merge commit messages should be validated.",
+    )
+    parser.add_argument(
+        "--commit-file",
+        help="File containing one full commit message.",
+    )
+    parser.add_argument(
+        "--commit-json-file",
+        help="JSON file containing an array of full commit messages.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        errors = validate(
+            title=args.title,
+            commits=args.commit,
+            commit_range=args.commit_range,
+            commit_file=args.commit_file,
+            commit_json_file=args.commit_json_file,
+        )
+    except RuntimeError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    if errors:
+        for error in errors:
+            print(f"::error::{error}", file=sys.stderr)
+        return 1
+    print("Conventional Commit validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
 
 from pydantic_versions.declarations import (
+    MatchingLabels,
     NestedFamily,
     SchemaVersion,
     TransitionFunc,
@@ -25,10 +27,12 @@ from pydantic_versions.patches import FieldDefault, FieldRemoved, FieldRenamed, 
 
 if TYPE_CHECKING:
     from pydantic_versions._planning import _PlanningCatalog
+    from pydantic_versions.family import SchemaFamily
 
 type UpgradeKind = Literal["implicit_identity", "custom_transition"]
 type DowngradeKind = Literal["implicit_identity", "custom_transition", "unavailable"]
 type WireModelKind = Literal["current", "generated", "explicit"]
+type _NestedLabelPairs = tuple[tuple[str, str], ...]
 
 
 @dataclass(frozen=True)
@@ -65,8 +69,23 @@ class _CompiledTransition:
     target: str
     upgrade_kind: UpgradeKind
     upgrade: TransitionFunc | None
+    downgrade: TransitionFunc | None
     downgrade_kind: DowngradeKind
     downgrade_semantics: Literal["exact", "lossy", "unavailable"]
+
+
+@dataclass(frozen=True)
+class _CompiledNestedFamily:
+    path: tuple[str, ...]
+    family: SchemaFamily[Any]
+    versions: _NestedLabelPairs
+
+    def child_label(self, parent_label: str) -> str:
+        for parent, child in self.versions:
+            if parent == parent_label:
+                return child
+        msg = f"Nested mapping for path {self.path!r} has no child label for {parent_label!r}"
+        raise SchemaCompilationError(msg)
 
 
 @dataclass(frozen=True)
@@ -78,6 +97,7 @@ class _CompiledFamily:
     version_metadata: VersionMetadata | None
     missing_version: str | None
     catalog: _PlanningCatalog
+    nested: tuple[_CompiledNestedFamily, ...]
 
     @property
     def labels(self) -> tuple[str, ...]:
@@ -161,23 +181,97 @@ def _validate_family_declarations(
 def _validate_compilation_boundary(
     *,
     name: str,
-    versions: tuple[SchemaVersion, ...],
-    transitions: tuple[VersionTransition, ...],
+    model: type[BaseModel],
+    labels: tuple[str, ...],
     nested: tuple[NestedFamily, ...],
-) -> None:
-    explicit = [version.label for version in versions if version.wire_model is not None]
-    if explicit:
-        msg = (
-            f"Explicit wire models are not supported by the foundation compiler for "
-            f"{name!r}: {explicit!r}"
+) -> tuple[_CompiledNestedFamily, ...]:
+    from pydantic_versions.family import SchemaFamily
+
+    if not nested:
+        return ()
+
+    compiled_nested: list[_CompiledNestedFamily] = []
+    used_paths: set[tuple[str, ...]] = set()
+    for declaration in nested:
+        path = (declaration.path,) if isinstance(declaration.path, str) else tuple(declaration.path)
+        if path in used_paths:
+            msg = f"Duplicate nested family declaration path {path!r} for {name!r}"
+            raise SchemaCompilationError(msg)
+        used_paths.add(path)
+
+        declaration_family = declaration.family
+        if isinstance(declaration_family, SchemaFamily):
+            child_family = declaration_family
+        elif callable(declaration_family):
+            resolved = declaration_family()
+            if not isinstance(resolved, SchemaFamily):
+                msg = (
+                    f"Nested family declaration at path {path!r} for {name!r} must resolve to a "
+                    "SchemaFamily"
+                )
+                raise SchemaCompilationError(msg)
+            child_family = resolved
+        else:
+            msg = (
+                f"Nested family declaration at path {path!r} for {name!r} must use a SchemaFamily "
+                "or callable provider"
+            )
+            raise SchemaCompilationError(msg)
+
+        if child_family.model == model:
+            msg = (
+                f"Nested family declaration at path {path!r} for {name!r} cannot reference "
+                "the same owning model"
+            )
+            raise SchemaCompilationError(msg)
+
+        parent_labels = labels
+        child_labels = tuple(version.label for version in child_family.versions)
+        if isinstance(declaration.versions, MatchingLabels):
+            if child_labels != parent_labels:
+                msg = (
+                    f"Nested family declaration at path {path!r} for {name!r} must use matching "
+                    f"labels {parent_labels!r}"
+                )
+                raise SchemaCompilationError(msg)
+            nested_versions: _NestedLabelPairs = tuple(
+                zip(parent_labels, parent_labels, strict=False)
+            )
+        else:
+            if not isinstance(declaration.versions, Mapping):
+                msg = f"Nested family declaration at path {path!r} for {name!r} must be a mapping"
+                raise SchemaCompilationError(msg)
+            parent_map = dict(declaration.versions)
+            missing = tuple(label for label in parent_labels if label not in parent_map)
+            if missing:
+                msg = (
+                    f"Nested family declaration at path {path!r} for {name!r} is missing mappings "
+                    f"for parent labels {missing!r}"
+                )
+                raise SchemaCompilationError(msg)
+            unknown = tuple(parent for parent in parent_map if parent not in parent_labels)
+            if unknown:
+                msg = (
+                    f"Nested family declaration at path {path!r} for {name!r} has unknown parent labels "
+                    f"{unknown!r}"
+                )
+                raise SchemaCompilationError(msg)
+            child_unknown = tuple(
+                child for child in parent_map.values() if child not in child_labels
+            )
+            if child_unknown:
+                msg = (
+                    f"Nested family declaration at path {path!r} for {name!r} has unknown child labels "
+                    f"{child_unknown!r}"
+                )
+                raise SchemaCompilationError(msg)
+            nested_versions = tuple((parent, parent_map[parent]) for parent in parent_labels)
+
+        compiled_nested.append(
+            _CompiledNestedFamily(path=path, family=child_family, versions=nested_versions),
         )
-        raise SchemaCompilationError(msg)
-    if nested:
-        msg = f"Explicit nested family compilation is not supported yet for {name!r}"
-        raise SchemaCompilationError(msg)
-    if any(transition.downgrade is not None for transition in transitions):
-        msg = f"Downgrade execution is not supported yet for {name!r}"
-        raise SchemaCompilationError(msg)
+
+    return tuple(compiled_nested)
 
 
 def _validate_required_field_introductions(
@@ -402,6 +496,7 @@ def _compile_transition(
         target=target,
         upgrade_kind="implicit_identity" if upgrade is None else "custom_transition",
         upgrade=upgrade,
+        downgrade=downgrade,
         downgrade_kind=downgrade_kind,
         downgrade_semantics=downgrade_semantics,
     )

--- a/src/pydantic_versions/_planning.py
+++ b/src/pydantic_versions/_planning.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_versions._compiler import (
     _CompiledField,
+    _CompiledNestedFamily,
     _CompiledTransition,
     _CompiledVersion,
     _stable_digest,
@@ -14,6 +15,7 @@ from pydantic_versions.declarations import VersionPath
 from pydantic_versions.exceptions import SchemaCompilationError
 from pydantic_versions.inspection import (
     ConversionPlan,
+    NestedFamilyDescription,
     PlanStep,
     ProjectionDescription,
     SchemaInventory,
@@ -40,6 +42,7 @@ def _build_planning_catalog(
     family: SchemaFamily[Any],
     versions: tuple[_CompiledVersion, ...],
     transitions: tuple[_CompiledTransition, ...],
+    nested: tuple[_CompiledNestedFamily, ...] = (),
 ) -> _PlanningCatalog:
     version_descriptions = tuple(_describe_version(version) for version in versions)
     transition_descriptions = tuple(_describe_transition(transition) for transition in transitions)
@@ -49,7 +52,9 @@ def _build_planning_catalog(
         current_version=family.current_version,
         versions=version_descriptions,
         transitions=transition_descriptions,
-        nested=(),
+        nested=tuple(
+            _describe_nested_family(nested_family=family_entry) for family_entry in nested
+        ),
         version_metadata=family.version_metadata,
     )
     validation_plans = tuple(
@@ -74,6 +79,16 @@ def _build_planning_catalog(
         inventory=inventory,
         validation_plans=validation_plans,
         render_plans=render_plans,
+    )
+
+
+def _describe_nested_family(
+    nested_family: _CompiledNestedFamily,
+) -> NestedFamilyDescription:
+    return NestedFamilyDescription(
+        schema_path=_schema_path(nested_family.path),
+        family=nested_family.family.name,
+        versions=nested_family.versions,
     )
 
 

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, get_origin
 
 from pydantic import AliasChoices, AliasPath, BaseModel
 
@@ -38,11 +38,22 @@ def _validate_family[T: BaseModel](
     source_version = _detect_version(compiled, data, explicit_version=version)
     source = compiled.version(source_version)
     source_model = source.model.model_validate(data, by_name=True)
-    payload = _to_current_names(compiled, source, source_model.model_dump(by_alias=False))
+    payload = _to_current_names(
+        compiled,
+        source,
+        source_model.model_dump(by_alias=False, mode="json"),
+    )
 
     migrations_applied: list[tuple[str, str]] = []
     source_index = compiled.index(source_version)
     for transition in compiled.transitions[source_index:]:
+        if source_version != compiled.current_version:
+            payload = _apply_nested_family_migrations(
+                payload=payload,
+                compiled=compiled,
+                source_label=transition.source,
+                target_label=transition.target,
+            )
         if transition.upgrade is None:
             continue
         migrated = transition.upgrade(dict(payload))
@@ -76,24 +87,537 @@ def _dump_family[T: BaseModel](
     compiled = family._compiled_family()
     requested = _runtime_label(version, family_name=family.name)
     target = compiled.version(requested)
+    target_index = compiled.index(requested)
+    current_index = len(compiled.versions) - 1
+    if requested != compiled.current_version:
+        family.plan_render(requested)
 
     if data is None:
-        target_model = target.model()
+        payload = {}
     elif isinstance(data, BaseModel):
-        target_model = target.model.model_validate(
-            _to_version_names(target, data.model_dump(by_alias=False)),
-            by_name=True,
-        )
+        raw_payload = data.model_dump(by_alias=False, mode="json")
+        if requested == compiled.current_version:
+            payload = raw_payload
+        else:
+            payload = _to_current_names(
+                compiled,
+                compiled.version(compiled.current_version),
+                raw_payload,
+            )
     else:
-        target_model = target.model.model_validate(_to_version_names(target, data), by_name=True)
+        payload = dict(data)
 
-    dumped = target_model.model_dump(**dump_kwargs)
+    if requested != compiled.current_version:
+        for edge_index in range(current_index - 1, target_index - 1, -1):
+            transition = compiled.transitions[edge_index]
+            payload = _apply_nested_family_migrations(
+                payload=payload,
+                compiled=compiled,
+                source_label=transition.target,
+                target_label=transition.source,
+            )
+            if transition.downgrade is None:
+                continue
+            migrated = transition.downgrade(dict(payload))
+            if not isinstance(migrated, dict):
+                msg = (
+                    f"Migration {transition.source!r} -> {transition.target!r} "
+                    f"downgrade must return a dict"
+                )
+                raise InvalidMigrationError(msg)
+            payload = migrated
+
+    if (
+        requested != compiled.current_version
+        and compiled.version_metadata is not None
+        and compiled.version_metadata.owner == "family"
+    ):
+        payload = dict(payload)
+        _set_version_field(payload, compiled.version_metadata.path, requested)
+
+    target_model = target.model.model_validate(_to_version_names(target, payload), by_name=True)
+    if "mode" in dump_kwargs:
+        dumped = target_model.model_dump(**dump_kwargs)
+    else:
+        dumped = target_model.model_dump(mode="json", **dump_kwargs)
+    if compiled.nested:
+        for nested in compiled.nested:
+            collection_kind = _nested_family_collection_kind(
+                model=compiled.model,
+                path=nested.path,
+            )
+            if collection_kind != "list":
+                continue
+            _prune_nested_family_metadata_at_path(
+                payload=dumped,
+                path=nested.path,
+                family=nested.family,
+            )
     if compiled.version_metadata is not None:
         if include_version:
             _set_version_field(dumped, compiled.version_metadata.path, requested)
         else:
             _remove_version_field(dumped, compiled.version_metadata.path)
     return dumped
+
+
+def _apply_nested_family_migrations(
+    *,
+    payload: dict[str, Any],
+    compiled: _CompiledFamily,
+    source_label: str,
+    target_label: str,
+) -> dict[str, Any]:
+    if not compiled.nested:
+        return payload
+    current_payload: dict[str, Any] = payload
+    if source_label == target_label:
+        return current_payload
+    for nested in compiled.nested:
+        nested_source = nested.child_label(source_label)
+        nested_target = nested.child_label(target_label)
+        if nested_source == nested_target:
+            continue
+        current_payload = _convert_nested_child_family(
+            payload=current_payload,
+            path=nested.path,
+            family=nested.family,
+            source_label=nested_source,
+            target_label=nested_target,
+            collection_kind=_nested_family_collection_kind(
+                model=compiled.model,
+                path=nested.path,
+            ),
+        )
+    return current_payload
+
+
+def _nested_family_collection_kind(
+    *,
+    model: type[BaseModel],
+    path: tuple[str, ...],
+) -> Literal["list", "tuple", "set", "frozenset"] | None:
+    annotation: Any = model
+    for index, key in enumerate(path):
+        if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+            return None
+        field_info = annotation.model_fields.get(key)
+        if field_info is None:
+            return None
+        annotation = _strip_annotated(field_info.annotation)
+        kind = _collection_kind(annotation)
+        if index == len(path) - 1:
+            return kind
+        if kind is None:
+            continue
+        args = get_args(annotation)
+        if not args:
+            return None
+        annotation = args[0]
+    return None
+
+
+def _collection_kind(
+    annotation: Any,
+) -> Literal["list", "tuple", "set", "frozenset"] | None:
+    origin = get_origin(annotation)
+    if origin is list:
+        return "list"
+    if origin is tuple:
+        return "tuple"
+    if origin is set:
+        return "set"
+    if origin is frozenset:
+        return "frozenset"
+    return None
+
+
+def _strip_annotated(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        args = get_args(annotation)
+        if not args:
+            return annotation
+        return args[0]
+    return annotation
+
+
+def _has_duplicate_payload(payload: list[Any]) -> bool:
+    for index, item in enumerate(payload):
+        if item in payload[:index]:
+            return True
+    return False
+
+
+def _prune_nested_family_metadata(
+    *,
+    payload: dict[str, Any],
+    compiled: _CompiledFamily,
+) -> None:
+    for nested in compiled.nested:
+        _prune_nested_family_metadata_at_path(
+            payload=payload,
+            path=nested.path,
+            family=nested.family,
+        )
+
+
+def _prune_nested_family_metadata_payload(
+    payload: Any,
+    family: _CompiledFamily,
+) -> None:
+    metadata = family.version_metadata
+    if metadata is not None and metadata.owner == "family" and isinstance(payload, Mapping):
+        _remove_version_field(payload, metadata.path)
+
+    if not family.nested:
+        return
+
+    for child in family.nested:
+        _prune_nested_family_metadata_at_path(
+            payload=payload,
+            path=child.path,
+            family=child.family,
+        )
+
+
+def _prune_nested_family_metadata_at_path(
+    *,
+    payload: Any,
+    path: tuple[str, ...],
+    family: SchemaFamily[Any],
+) -> None:
+    if not path:
+        compiled_family = family._compiled_family()
+        if isinstance(payload, Mapping | list | tuple | set | frozenset):
+            if isinstance(payload, list):
+                for item in payload:
+                    _prune_nested_family_metadata_payload(item, compiled_family)
+                return
+            if isinstance(payload, tuple):
+                for item in payload:
+                    _prune_nested_family_metadata_payload(item, compiled_family)
+                return
+            if isinstance(payload, set):
+                for item in payload:
+                    _prune_nested_family_metadata_payload(item, compiled_family)
+                return
+            if isinstance(payload, frozenset):
+                for item in payload:
+                    _prune_nested_family_metadata_payload(item, compiled_family)
+                return
+            _prune_nested_family_metadata_payload(payload, compiled_family)
+        return
+
+    key, *remaining = path
+    if isinstance(payload, Mapping):
+        if key in payload:
+            _prune_nested_family_metadata_at_path(
+                payload=payload[key],
+                path=tuple(remaining),
+                family=family,
+            )
+            return
+        for field_value in payload.values():
+            _prune_nested_family_metadata_at_path(
+                payload=field_value,
+                path=path,
+                family=family,
+            )
+        return
+
+    if isinstance(payload, list):
+        for field_value in payload:
+            _prune_nested_family_metadata_at_path(
+                payload=field_value,
+                path=path,
+                family=family,
+            )
+        return
+
+    if isinstance(payload, tuple):
+        for field_value in payload:
+            _prune_nested_family_metadata_at_path(
+                payload=field_value,
+                path=path,
+                family=family,
+            )
+        return
+
+    if isinstance(payload, set):
+        for field_value in payload:
+            _prune_nested_family_metadata_at_path(
+                payload=field_value,
+                path=path,
+                family=family,
+            )
+        return
+
+    if isinstance(payload, frozenset):
+        for field_value in payload:
+            _prune_nested_family_metadata_at_path(
+                payload=field_value,
+                path=path,
+                family=family,
+            )
+
+
+def _convert_nested_child_family(
+    *,
+    payload: Any,
+    path: tuple[str, ...],
+    family: SchemaFamily[Any],
+    source_label: str,
+    target_label: str,
+    collection_kind: Literal["list", "tuple", "set", "frozenset"] | None = None,
+) -> Any:
+    if not path:
+        return _convert_nested_family_payload(
+            family=family,
+            payload=payload,
+            source_label=source_label,
+            target_label=target_label,
+            collection_kind=collection_kind,
+        )
+    key, *remaining = path
+    if isinstance(payload, Mapping):
+        if key in payload:
+            nested_payload = payload[key]
+            converted = _convert_nested_child_family(
+                payload=nested_payload,
+                path=tuple(remaining),
+                family=family,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            if converted is nested_payload:
+                return payload
+            updated = dict(payload)
+            updated[key] = converted
+            return updated
+        converted_children = {
+            field_name: _convert_nested_child_family(
+                payload=field_value,
+                path=path,
+                family=family,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for field_name, field_value in payload.items()
+        }
+        if any(
+            converted_children[field_name] is not field_value
+            for field_name, field_value in payload.items()
+        ):
+            return converted_children
+        return payload
+    if isinstance(payload, list):
+        converted_items = [
+            _convert_nested_child_family(
+                payload=item,
+                path=path,
+                family=family,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        ]
+        if all(converted is item for converted, item in zip(converted_items, payload, strict=True)):
+            return payload
+        return converted_items
+    if isinstance(payload, tuple):
+        converted_items = tuple(
+            _convert_nested_child_family(
+                payload=item,
+                path=path,
+                family=family,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        )
+        if all(converted is item for converted, item in zip(converted_items, payload, strict=True)):
+            return payload
+        return converted_items
+    if isinstance(payload, set):
+        converted_items = {
+            _convert_nested_child_family(
+                payload=item,
+                path=path,
+                family=family,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        }
+        if len(converted_items) != len(payload):
+            msg = (
+                f"Nested migration for family {family.name!r} "
+                "cannot preserve set cardinality while converting mixed payload values"
+            )
+            raise InvalidMigrationError(msg)
+        return converted_items
+    if isinstance(payload, frozenset):
+        converted_items = frozenset(
+            _convert_nested_child_family(
+                payload=item,
+                path=path,
+                family=family,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        )
+        if len(converted_items) != len(payload):
+            msg = (
+                f"Nested migration for family {family.name!r} "
+                "cannot preserve set cardinality while converting mixed payload values"
+            )
+            raise InvalidMigrationError(msg)
+        return converted_items
+    return payload
+
+
+def _convert_nested_family_payload(
+    family: SchemaFamily[Any],
+    payload: Any,
+    source_label: str,
+    target_label: str,
+    collection_kind: Literal["list", "tuple", "set", "frozenset"] | None = None,
+) -> Any:
+    if payload is None:
+        return payload
+    if isinstance(payload, list):
+        converted = [
+            _convert_nested_family_payload(
+                family=family,
+                payload=item,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        ]
+        if any(
+            converted_item is not item
+            for converted_item, item in zip(converted, payload, strict=True)
+        ):
+            if collection_kind in ("set", "frozenset") and _has_duplicate_payload(converted):
+                msg = (
+                    f"Nested migration for family {family.name!r} "
+                    "cannot preserve set cardinality while converting mixed payload values"
+                )
+                raise InvalidMigrationError(msg)
+            return converted
+        return payload
+    if isinstance(payload, tuple):
+        converted = tuple(
+            _convert_nested_family_payload(
+                family=family,
+                payload=item,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        )
+        if any(
+            converted_item is not item
+            for converted_item, item in zip(converted, payload, strict=True)
+        ):
+            return converted
+        return payload
+    if isinstance(payload, set):
+        converted = {
+            _convert_nested_family_payload(
+                family=family,
+                payload=item,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        }
+        if len(converted) != len(payload):
+            msg = (
+                f"Nested migration for family {family.name!r} "
+                "cannot preserve set cardinality while converting mixed payload values"
+            )
+            raise InvalidMigrationError(msg)
+        return converted
+    if isinstance(payload, frozenset):
+        converted = frozenset(
+            _convert_nested_family_payload(
+                family=family,
+                payload=item,
+                source_label=source_label,
+                target_label=target_label,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        )
+        if len(converted) != len(payload):
+            msg = (
+                f"Nested migration for family {family.name!r} "
+                "cannot preserve set cardinality while converting mixed payload values"
+            )
+            raise InvalidMigrationError(msg)
+        return converted
+    if not isinstance(payload, Mapping):
+        return payload
+    compiled = family._compiled_family()
+    source_index = compiled.index(source_label)
+    target_index = compiled.index(target_label)
+    if source_index == target_index:
+        return dict(payload)
+    source_version = compiled.version(source_label)
+    source_model = source_version.model
+    source_data = source_model.model_validate(payload, by_name=True)
+    current_payload = dict(
+        _to_current_names(
+            compiled,
+            source_version,
+            source_data.model_dump(by_alias=False, mode="json"),
+        )
+    )
+    if source_index < target_index:
+        for edge_index in range(source_index, target_index):
+            transition = compiled.transitions[edge_index]
+            if transition.upgrade is None:
+                continue
+            migrated = transition.upgrade(dict(current_payload))
+            if not isinstance(migrated, dict):
+                msg = (
+                    f"Nested migration {source_label!r} -> {target_label!r} for family "
+                    f"{family.name!r} must return a dict"
+                )
+                raise InvalidMigrationError(msg)
+            current_payload = migrated
+    else:
+        for edge_index in range(source_index - 1, target_index - 1, -1):
+            transition = compiled.transitions[edge_index]
+            if transition.downgrade is None:
+                continue
+            migrated = transition.downgrade(dict(current_payload))
+            if not isinstance(migrated, dict):
+                msg = (
+                    f"Nested migration {source_label!r} -> {target_label!r} for family "
+                    f"{family.name!r} must return a dict"
+                )
+                raise InvalidMigrationError(msg)
+            current_payload = migrated
+    if compiled.version_metadata is not None and compiled.version_metadata.owner == "family":
+        if collection_kind in ("set", "tuple", "frozenset"):
+            _set_version_field(current_payload, compiled.version_metadata.path, target_label)
+        else:
+            _remove_version_field(current_payload, compiled.version_metadata.path)
+    return current_payload
 
 
 def _infer_metadata_owner(

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -47,6 +47,7 @@ from pydantic_core import PydanticUndefined
 from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
 
 from pydantic_versions._compiler import (
+    _CompiledNestedFamily,
     _generated_model_name,
     _identifier_component,
     _stable_digest,
@@ -208,6 +209,7 @@ _CUSTOM_MODEL_HOOKS = (
     "__get_pydantic_json_schema__",
     "model_json_schema",
 )
+_HASHABLE_MODEL_CACHE: dict[type[BaseModel], type[BaseModel]] = {}
 
 
 def _validate_automatic_wire_model(family: SchemaFamily[Any]) -> None:
@@ -242,9 +244,17 @@ def _validate_automatic_wire_model(family: SchemaFamily[Any]) -> None:
 def _build_model_for_projection(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
+    wire_model: type[BaseModel] | None,
+    nested: tuple[_CompiledNestedFamily, ...] = (),
 ) -> type[BaseModel]:
+    if wire_model is not None:
+        return _validate_explicit_wire_model(family, projection, wire_model)
     try:
-        return _build_model_for_projection_unchecked(family, projection)
+        return _build_model_for_projection_unchecked(
+            family,
+            projection,
+            nested=nested,
+        )
     except UnsupportedWireModelError:
         raise
     except Exception as exc:
@@ -256,11 +266,85 @@ def _build_model_for_projection(
         raise UnsupportedWireModelError(msg) from exc
 
 
+def _validate_explicit_wire_model(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    wire_model: type[BaseModel],
+) -> type[BaseModel]:
+    _validate_explicit_wire_model_metadata(family, projection, wire_model)
+    _validate_object_schema(
+        family,
+        projection,
+        wire_model,
+        mode="validation",
+    )
+    _validate_object_schema(
+        family,
+        projection,
+        wire_model,
+        mode="serialization",
+    )
+    return wire_model
+
+
+def _validate_explicit_wire_model_metadata(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    wire_model: type[BaseModel],
+) -> None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "model":
+        return
+
+    metadata_field = _model_metadata_field(family)
+    if metadata_field is None:
+        _raise_projection_unsupported(
+            family,
+            projection,
+            "explicit wire models do not yet support nested model-owned metadata",
+        )
+    if metadata_field not in wire_model.model_fields:
+        _raise_projection_unsupported(
+            family,
+            projection,
+            "explicit wire model for model-owned metadata must declare the same "
+            f"model metadata field {metadata_field!r}",
+        )
+
+    field_info = wire_model.model_fields[metadata_field]
+    model_label_type = _literal_type(projection.label)
+    model_field_type = field_info.annotation
+    if get_origin(model_field_type) is Annotated:
+        model_field_type = get_args(model_field_type)[0]
+
+    if model_field_type != model_label_type:
+        msg = (
+            "explicit wire model for model-owned metadata must annotate "
+            f"field {metadata_field!r} as {model_label_type!r}"
+        )
+        _raise_projection_unsupported(
+            family,
+            projection,
+            msg,
+        )
+    if field_info.default is PydanticUndefined or field_info.default != projection.label:
+        _raise_projection_unsupported(
+            family,
+            projection,
+            "explicit wire model for model-owned metadata must provide "
+            f"the exact default {projection.label!r}",
+        )
+
+
 def _build_model_for_projection_unchecked(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
+    nested: tuple[_CompiledNestedFamily, ...] = (),
 ) -> type[BaseModel]:
     model_metadata_field = _model_metadata_field(family)
+    used_nested: set[tuple[str, ...]] = set()
+    nested_projection_cache: dict[tuple[int, tuple[str, ...], str], type[BaseModel] | None] = {}
+    nested_projection_stack: set[tuple[int, tuple[str, ...], str]] = set()
     fields: dict[str, Any] = {}
     for compiled_field in projection.fields:
         if compiled_field.version_name is None:
@@ -295,8 +379,13 @@ def _build_model_for_projection_unchecked(
             field_dict["annotation"],
             projection.label,
             family,
+            nested=nested,
+            field_path=(compiled_field.current_name,),
+            used_nested=used_nested,
             field_name=compiled_field.current_name,
             allow_child_projection=True,
+            nested_projection_cache=nested_projection_cache,
+            nested_projection_stack=nested_projection_stack,
         )
         attributes = _wire_field_attributes(
             family,
@@ -329,6 +418,9 @@ def _build_model_for_projection_unchecked(
             field_dict["annotation"],
             annotation,
             family,
+            nested=nested,
+            field_path=(compiled_field.current_name,),
+            used_nested=used_nested,
             field_name=compiled_field.current_name,
             version=projection.label,
         )
@@ -354,6 +446,7 @@ def _build_model_for_projection_unchecked(
         ]
 
     _validate_metadata_field_name_collision(family, projection, fields)
+    _validate_nested_projection_coverage(family, projection, nested, used_nested)
     _add_family_metadata_field(family, projection.label, fields)
 
     generated = create_model(
@@ -1280,6 +1373,82 @@ def _model_display(model: type[BaseModel]) -> str:
     return f"{model.__module__}.{model.__qualname__}"
 
 
+def _find_nested_family_for_path(
+    nested: tuple[_CompiledNestedFamily, ...],
+    field_path: tuple[str, ...],
+) -> _CompiledNestedFamily | None:
+    for family in nested:
+        if family.path == field_path:
+            return family
+    return None
+
+
+def _find_nested_families_under_path(
+    nested: tuple[_CompiledNestedFamily, ...],
+    field_path: tuple[str, ...],
+) -> tuple[_CompiledNestedFamily, ...]:
+    if not nested:
+        return ()
+    return tuple(
+        family
+        for family in nested
+        if len(family.path) > len(field_path) and family.path[: len(field_path)] == field_path
+    )
+
+
+def _nested_projection_cache_key(
+    nested_model: type[BaseModel],
+    field_path: tuple[str, ...],
+    version: str,
+) -> tuple[int, tuple[str, ...], str]:
+    return (id(nested_model), field_path, version)
+
+
+def _nested_model_name(
+    parent: SchemaFamily[Any],
+    nested_model: type[BaseModel],
+    field_path: tuple[str, ...],
+    version: str,
+) -> str:
+    components = (
+        parent.model.__module__,
+        parent.model.__qualname__,
+        parent.name,
+        version,
+        "nested",
+        nested_model.__qualname__,
+        *field_path,
+    )
+    suffix = _stable_digest(components)[:10]
+    return f"{_generated_model_name(parent.model, parent.name, version)}_Nested_{suffix}"
+
+
+def _nested_wire_model_config(model: type[BaseModel]) -> ConfigDict:
+    config: dict[str, Any] = {
+        key: value for key, value in model.model_config.items() if key in _WIRE_CONFIG_KEYS
+    }
+    schema_extra = model.model_config.get("json_schema_extra")
+    if isinstance(schema_extra, Mapping):
+        config["json_schema_extra"] = schema_extra
+    return ConfigDict(**config)
+
+
+def _validate_nested_projection_coverage(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    nested: tuple[_CompiledNestedFamily, ...],
+    used_nested: set[tuple[str, ...]],
+) -> None:
+    unused = tuple(family_path for family_path in nested if family_path.path not in used_nested)
+    if unused:
+        first = unused[0].path
+        if len(unused) == 1:
+            msg = f"nested declaration path {first!r} does not match any rewritable field path"
+        else:
+            msg = f"{len(unused)} nested declarations do not match any rewritable field path"
+        _raise_projection_unsupported(family, projection, msg)
+
+
 def _compat_child_family(
     owner: SchemaFamily[Any],
     annotation: Any,
@@ -1304,22 +1473,77 @@ def _compat_child_family(
     return child
 
 
+def _set_element_wire_model(model: type[BaseModel]) -> type[BaseModel]:
+    if model.model_config.get("frozen"):
+        return model
+    cached = _HASHABLE_MODEL_CACHE.get(model)
+    if cached is not None:
+        return cached
+    frozen_model = create_model(
+        f"{model.__name__}__HashableSetElement",
+        __base__=model,
+        __module__=model.__module__,
+        __config__=ConfigDict(frozen=True),
+    )
+    frozen_model.model_rebuild(force=True)
+    _HASHABLE_MODEL_CACHE[model] = frozen_model
+    return frozen_model
+
+
 def _rewrite_annotation(
     annotation: Any,
     version: str,
     family: SchemaFamily[Any],
     *,
+    nested: tuple[_CompiledNestedFamily, ...],
+    field_path: tuple[str, ...],
+    used_nested: set[tuple[str, ...]],
     field_name: str,
     allow_child_projection: bool,
+    nested_projection_cache: dict[tuple[int, tuple[str, ...], str], type[BaseModel] | None],
+    nested_projection_stack: set[tuple[int, tuple[str, ...], str]],
+    in_set_element: bool = False,
 ) -> Any:
+    child = _find_nested_family_for_path(nested, field_path)
+    if (
+        child is not None
+        and isinstance(annotation, type)
+        and issubclass(
+            annotation,
+            BaseModel,
+        )
+    ):
+        used_nested.add(child.path)
+        family_model = child.family.model_for(child.child_label(version))
+        return _set_element_wire_model(family_model) if in_set_element else family_model
     child = _compat_child_family(family, annotation) if allow_child_projection else None
     if child is not None:
-        return child.model_for(version)
+        family_model = child.model_for(version)
+        return _set_element_wire_model(family_model) if in_set_element else family_model
 
     if isinstance(annotation, _TYPE_ALIAS_TYPES):
         _validate_type_alias(family, field_name, annotation)
         return annotation
     _validate_annotation_behavior(family, field_name, annotation)
+    if (
+        allow_child_projection
+        and isinstance(annotation, type)
+        and issubclass(annotation, BaseModel)
+    ):
+        nested_families = _find_nested_families_under_path(nested, field_path)
+        if nested_families:
+            return _rewrite_nested_model(
+                annotation,
+                version,
+                family,
+                field_name=field_name,
+                field_path=field_path,
+                nested=nested_families,
+                in_set_element=in_set_element,
+                nested_projection_cache=nested_projection_cache,
+                nested_projection_stack=nested_projection_stack,
+                used_nested=used_nested,
+            )
 
     origin = get_origin(annotation)
     if isinstance(origin, _TYPE_ALIAS_TYPES):
@@ -1332,8 +1556,14 @@ def _rewrite_annotation(
             base,
             version,
             family,
+            nested=nested,
+            field_path=field_path,
+            used_nested=used_nested,
             field_name=field_name,
             allow_child_projection=allow_child_projection,
+            nested_projection_cache=nested_projection_cache,
+            nested_projection_stack=nested_projection_stack,
+            in_set_element=in_set_element,
         )
         metadata = _snapshot_wire_metadata(
             family,
@@ -1357,13 +1587,20 @@ def _rewrite_annotation(
         Union,
         UnionType,
     )
+    set_context = in_set_element or origin in (set, frozenset)
     args = tuple(
         _rewrite_annotation(
             arg,
             version,
             family,
             field_name=field_name,
+            field_path=field_path,
             allow_child_projection=allow_child_projection and legacy_container,
+            nested=nested,
+            used_nested=used_nested,
+            nested_projection_cache=nested_projection_cache,
+            nested_projection_stack=nested_projection_stack,
+            in_set_element=set_context,
         )
         for arg in source_args
     )
@@ -1385,6 +1622,93 @@ def _rewrite_annotation(
             f"for field {field_name!r}"
         )
         raise UnsupportedWireModelError(msg) from exc
+
+
+def _rewrite_nested_model(
+    annotation: type[BaseModel],
+    version: str,
+    owner: SchemaFamily[Any],
+    *,
+    field_name: str,
+    field_path: tuple[str, ...],
+    nested: tuple[_CompiledNestedFamily, ...],
+    nested_projection_cache: dict[tuple[int, tuple[str, ...], str], type[BaseModel] | None],
+    nested_projection_stack: set[tuple[int, tuple[str, ...], str]],
+    used_nested: set[tuple[str, ...]],
+    in_set_element: bool = False,
+) -> type[BaseModel]:
+    cache_key = _nested_projection_cache_key(annotation, field_path, version)
+    nested_projection = nested_projection_cache.get(cache_key)
+    if nested_projection is not None:
+        return nested_projection
+    if cache_key in nested_projection_stack:
+        msg = (
+            f"nested declaration path {field_path!r} on model {annotation.__qualname__!r} "
+            "is self-referential and cannot be projected safely"
+        )
+        _raise_unsupported(owner, msg)
+
+    placeholder = create_model(
+        _nested_model_name(owner, annotation, field_path, version),
+        __module__=annotation.__module__,
+    )
+    nested_projection_cache[cache_key] = placeholder
+    nested_projection_stack.add(cache_key)
+    try:
+        fields: dict[str, Any] = {}
+        for source_name, source_field_info in annotation.model_fields.items():
+            source = source_field_info.asdict()
+            rewritten_annotation = _rewrite_annotation(
+                source["annotation"],
+                version,
+                owner,
+                nested=nested,
+                field_path=field_path + (source_name,),
+                used_nested=used_nested,
+                field_name=source_name,
+                allow_child_projection=True,
+                in_set_element=in_set_element,
+                nested_projection_cache=nested_projection_cache,
+                nested_projection_stack=nested_projection_stack,
+            )
+            attributes = _wire_field_attributes(owner, source_name, source["attributes"])
+            metadata = _wire_field_metadata(owner, source_name, source["metadata"])
+            _rewrite_nested_default(
+                attributes,
+                source["annotation"],
+                rewritten_annotation,
+                owner,
+                nested=nested,
+                field_path=field_path + (source_name,),
+                used_nested=used_nested,
+                field_name=source_name,
+                version=version,
+            )
+            fields[source_name] = Annotated[
+                rewritten_annotation,
+                *metadata,
+                Field(**attributes),
+            ]
+        nested_projection = create_model(
+            _nested_model_name(owner, annotation, field_path, version),
+            __module__=annotation.__module__,
+            __config__=_nested_wire_model_config(annotation),
+            **fields,
+        )
+        nested_projection.model_rebuild(force=True)
+    except Exception as exc:
+        msg = (
+            f"Automatic wire model for family {owner.name!r}, version {version!r}, and model "
+            f"{_model_display(annotation)!r} cannot safely project nested model for path "
+            f"{field_path!r}"
+        )
+        raise UnsupportedWireModelError(msg) from exc
+    finally:
+        nested_projection_stack.remove(cache_key)
+    nested_projection_cache[cache_key] = nested_projection
+    if nested_projection is not None:
+        nested_projection_cache[cache_key] = nested_projection
+    return nested_projection
 
 
 def _validate_type_alias(
@@ -1475,12 +1799,21 @@ def _rewrite_nested_default(
     version_annotation: Any,
     family: SchemaFamily[Any],
     *,
+    nested: tuple[_CompiledNestedFamily, ...],
+    field_path: tuple[str, ...],
+    used_nested: set[tuple[str, ...]],
     field_name: str,
     version: str,
 ) -> None:
     if original_annotation == version_annotation:
         return
-    child = _compat_child_family(family, original_annotation)
+    declaration = _find_nested_family_for_path(nested, field_path)
+    if declaration is not None:
+        used_nested.add(declaration.path)
+        child = declaration.family
+        version_annotation = child.model_for(declaration.child_label(version))
+    else:
+        child = _compat_child_family(family, original_annotation)
     if child is None or not (
         isinstance(version_annotation, type) and issubclass(version_annotation, BaseModel)
     ):
@@ -1494,7 +1827,13 @@ def _rewrite_nested_default(
             f"field {field_name!r} uses an opaque factory for a projected nested model",
         )
     default = attributes.get("default", PydanticUndefined)
-    if isinstance(default, original_annotation):
+    if default is PydanticUndefined:
+        return
+    try:
+        is_default_from_source = isinstance(default, original_annotation)
+    except TypeError:
+        return
+    if is_default_from_source:
         attributes["default"] = _project_child_default_value(
             default,
             source_model=original_annotation,

--- a/src/pydantic_versions/core.py
+++ b/src/pydantic_versions/core.py
@@ -53,13 +53,28 @@ _PENDING_ATTR = "__pydantic_versions_pending__"
 class _VersionSpec:
     label: str
     patches: tuple[VersionPatch, ...] = ()
+    wire_model: type[BaseModel] | None = None
 
 
-def schema_version(version: str, *, patches: Sequence[VersionPatch] = ()):
-    return schema_versions((version,), patches=patches)
+def schema_version(
+    version: str,
+    *,
+    patches: Sequence[VersionPatch] = (),
+    wire_model: type[BaseModel] | None = None,
+):
+    return schema_versions(
+        (version,),
+        patches=patches,
+        wire_model=wire_model,
+    )
 
 
-def schema_versions(versions: Sequence[str], *, patches: Sequence[VersionPatch] = ()):
+def schema_versions(
+    versions: Sequence[str],
+    *,
+    patches: Sequence[VersionPatch] = (),
+    wire_model: type[BaseModel] | None = None,
+):
     version_order = _freeze_sequence(versions, parameter="schema_versions.versions")
     patch_order = _freeze_sequence(patches, parameter="schema_versions.patches")
     labels = tuple(
@@ -70,7 +85,10 @@ def schema_versions(versions: Sequence[str], *, patches: Sequence[VersionPatch] 
     def decorator[T: BaseModel](model_cls: type[T]) -> type[T]:
         _ensure_pydantic_v2_model(model_cls)
         pending: list[_VersionSpec] = list(model_cls.__dict__.get(_PENDING_ATTR, ()))
-        pending.extend(_VersionSpec(label=label, patches=patch_order) for label in labels)
+        pending.extend(
+            _VersionSpec(label=label, patches=patch_order, wire_model=wire_model)
+            for label in labels
+        )
         setattr(model_cls, _PENDING_ATTR, tuple(pending))
         return model_cls
 
@@ -111,7 +129,12 @@ def versioned_schema(
         _ensure_pydantic_v2_model(model_cls)
         pending = tuple(model_cls.__dict__.get(_PENDING_ATTR, ()))
         patches_by_label: dict[str, tuple[VersionPatch, ...]] = dict.fromkeys(labels, ())
+        wire_models_by_label: dict[str, type[BaseModel] | None] = dict.fromkeys(
+            labels,
+            None,
+        )
         declared_patch_labels: set[str] = set()
+        declared_wire_model_labels: set[str] = set()
         for spec in pending:
             if spec.label not in labels:
                 msg = f"Patch schema version {spec.label!r} is not in versions for {name!r}"
@@ -121,12 +144,26 @@ def versioned_schema(
                 raise DuplicateSchemaVersionError(msg)
             declared_patch_labels.add(spec.label)
             patches_by_label[spec.label] = spec.patches
+            if spec.wire_model is not None:
+                if spec.label in declared_wire_model_labels:
+                    msg = (
+                        f"Schema version {spec.label!r} has multiple wire-model declarations for "
+                        f"{name!r}"
+                    )
+                    raise DuplicateSchemaVersionError(msg)
+                declared_wire_model_labels.add(spec.label)
+                wire_models_by_label[spec.label] = spec.wire_model
 
         owner = metadata_owner
         if owner is None:
             owner = _infer_metadata_owner(model_cls, normalized_path)
         declarations = tuple(
-            SchemaVersion(label=label, patches=patches_by_label[label]) for label in labels
+            SchemaVersion(
+                label=label,
+                patches=patches_by_label[label],
+                wire_model=wire_models_by_label[label],
+            )
+            for label in labels
         )
         family = SchemaFamily(
             model=model_cls,

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -139,10 +139,10 @@ class SchemaFamily[T: BaseModel]:
             self._compiling = True
             try:
                 self._validate_declarations()
-                _validate_compilation_boundary(
+                nested = _validate_compilation_boundary(
                     name=self.name,
-                    versions=self.versions,
-                    transitions=self.transitions,
+                    model=self.model,
+                    labels=tuple(version.label for version in self.versions),
                     nested=self.nested,
                 )
                 _validate_automatic_wire_model(self)
@@ -158,7 +158,12 @@ class SchemaFamily[T: BaseModel]:
                 compiled_versions = tuple(
                     _CompiledVersion(
                         projection=projection,
-                        model=_build_model_for_projection(self, projection),
+                        model=_build_model_for_projection(
+                            self,
+                            projection,
+                            declaration.wire_model,
+                            nested=nested,
+                        ),
                         wire_model_kind=(
                             "current"
                             if index == len(projections) - 1
@@ -187,6 +192,7 @@ class SchemaFamily[T: BaseModel]:
                     self,
                     compiled_versions,
                     compiled_transitions,
+                    nested,
                 )
                 self._compiled = _CompiledFamily(
                     model=self.model,
@@ -196,6 +202,7 @@ class SchemaFamily[T: BaseModel]:
                     version_metadata=self.version_metadata,
                     missing_version=self.missing_version,
                     catalog=catalog,
+                    nested=nested,
                 )
             finally:
                 self._compiling = False

--- a/tests/typing/schema_family_contract.py
+++ b/tests/typing/schema_family_contract.py
@@ -46,7 +46,11 @@ family: SchemaFamily[AppConfig] = SchemaFamily(
         SchemaVersion("1", patches=(patch,)),
         SchemaVersion("2"),
     ),
-    transitions=(VersionTransition("1", "2", upgrade=upgrade_v1),),
+    transitions=(
+        VersionTransition(
+            "1", "2", upgrade=upgrade_v1, downgrade=lambda d: d, downgrade_semantics="exact"
+        ),
+    ),
 )
 
 assert_type(family.compile(), SchemaFamily[AppConfig])

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -51,6 +51,7 @@ from pydantic import (
 from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
 
 from pydantic_versions import (
+    NestedFamily,
     SchemaCompilationError,
     SchemaFamily,
     SchemaVersion,
@@ -59,6 +60,7 @@ from pydantic_versions import (
     VersionTransition,
     field_default,
     field_renamed,
+    matching_labels,
 )
 
 
@@ -1137,6 +1139,71 @@ def test_nested_family_owned_discriminator_is_an_exact_literal_document_wrapper(
             wire.model_validate(
                 {"meta": {"details": {"version": "wrong"}}},
             )
+
+
+def test_unused_nested_declarations_are_rejected() -> None:
+    class NestedPayload(BaseModel):
+        value: int = 1
+
+    nested_family = SchemaFamily(
+        model=NestedPayload,
+        name="unused_nested_payload",
+        versions=(SchemaVersion("1"),),
+    )
+
+    class RootPayload(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=RootPayload,
+        name="unused_nested_root",
+        versions=(SchemaVersion("1"),),
+        nested=(
+            NestedFamily("unused", nested_family, matching_labels()),
+            NestedFamily(("value", "also_unused"), nested_family, matching_labels()),
+        ),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="2 nested declarations do not match"):
+        family.model_for("1")
+
+
+def test_nested_projection_rewrites_deeply_nested_models() -> None:
+    class InnerPayload(BaseModel):
+        label: int
+
+    inner_family = SchemaFamily(
+        model=InnerPayload,
+        name="nested_projection_inner_family",
+        versions=(
+            SchemaVersion("legacy", patches=(field_renamed("label", "value"),)),
+            SchemaVersion("current"),
+        ),
+        missing_version="legacy",
+    )
+
+    class NestedPayload(BaseModel):
+        inner: InnerPayload
+
+    class RootPayload(BaseModel):
+        nested: NestedPayload
+
+    family = SchemaFamily(
+        model=RootPayload,
+        name="nested_projection_rewrite",
+        versions=(SchemaVersion("legacy"), SchemaVersion("current")),
+        nested=(NestedFamily(("nested", "inner"), inner_family, matching_labels()),),
+        missing_version="legacy",
+    )
+
+    legacy_wire = family.model_for("legacy")
+    current_wire = family.model_for("current")
+
+    legacy = legacy_wire.model_validate({"nested": {"inner": {"value": 1}}})
+    current = current_wire.model_validate({"nested": {"inner": {"label": 1}}})
+
+    assert legacy.model_dump()["nested"]["inner"]["value"] == 1
+    assert current.model_dump()["nested"]["inner"]["label"] == 1
 
 
 def test_single_segment_tuple_metadata_keeps_tuple_path_semantics() -> None:

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -1,0 +1,1640 @@
+from __future__ import annotations
+
+# Internal coverage gap unit tests for wire, runtime, and compiler modules.
+from collections.abc import Mapping
+from typing import Any, ForwardRef, TypeAliasType, TypeVar, cast
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, create_model
+
+from pydantic_versions import SchemaFamily, SchemaVersion, VersionTransition
+from pydantic_versions._compiler import (
+    _CompiledField,
+    _CompiledNestedFamily,
+    _validate_compilation_boundary,
+    _validate_family_declarations,
+    _validate_transition_declarations,
+    _VersionProjection,
+)
+from pydantic_versions._runtime import (
+    _infer_metadata_owner,
+    _nested_family_collection_kind,
+    _normalize_payload_field_aliases,
+    _prune_nested_family_metadata_at_path,
+    _runtime_label,
+    _set_version_field,
+)
+from pydantic_versions._wire import (
+    _snapshot_wire_metadata,
+    _validate_explicit_wire_model_metadata,
+    _validate_model_config,
+    _validate_type_alias,
+    _wire_field_attributes,
+)
+from pydantic_versions.declarations import (
+    NestedFamily,
+    VersionMetadata,
+    _freeze_sequence,
+    _freeze_version_path,
+    matching_labels,
+)
+from pydantic_versions.exceptions import (
+    DuplicateSchemaVersionError,
+    InvalidMigrationError,
+    SchemaCompilationError,
+    UnknownSchemaVersionError,
+    UnsupportedWireModelError,
+)
+
+
+class CopyError:
+    def __deepcopy__(self, _: Any) -> Any:  # pragma: no cover
+        msg = "cannot copy"
+        raise ValueError(msg)
+
+
+def test_compiler_private_paths_raise_expected_errors() -> None:
+    class Base(BaseModel):
+        value: int = 1
+
+    assert (
+        _freeze_version_path("schema_version", parameter="VersionMetadata.path") == "schema_version"
+    )
+
+    with pytest.raises(SchemaCompilationError, match="must be a non-empty string or tuple"):
+        _freeze_version_path((), parameter="NestedFamily.path")
+
+    with pytest.raises(SchemaCompilationError, match="must be a sequence"):
+        _freeze_sequence("v1", parameter="SchemaFamily.versions")
+
+    compiled_projection = _VersionProjection(
+        label="1.0",
+        fields=(
+            _CompiledField(
+                current_name="value",
+                version_name="value",
+                default=None,
+                patch_ordinal=None,
+            ),
+        ),
+    )
+    with pytest.raises(SchemaCompilationError, match="does not contain current field"):
+        compiled_projection.field("missing")
+
+    with pytest.raises(SchemaCompilationError, match="has no child label"):
+        _CompiledNestedFamily(path=("child",), family=cast(Any, object()), versions=()).child_label(
+            "legacy"
+        )
+
+    with pytest.raises(SchemaCompilationError, match="must declare at least one version"):
+        _validate_family_declarations(
+            model=Base,
+            name="empty",
+            versions=(),
+            transitions=(),
+            nested=(),
+            missing_version=None,
+        )
+
+    with pytest.raises(DuplicateSchemaVersionError, match="is declared more than once"):
+        _validate_transition_declarations(
+            "family",
+            ("1", "2"),
+            (
+                VersionTransition("1", "2", upgrade=lambda payload: payload),
+                VersionTransition("1", "2", upgrade=lambda payload: payload),
+            ),
+        )
+
+    with pytest.raises(SchemaCompilationError, match="must provide at least one callable"):
+        _validate_transition_declarations(
+            "family",
+            ("1", "2"),
+            (VersionTransition("1", "2"),),
+        )
+
+    with pytest.raises(SchemaCompilationError, match="cannot be patched"):
+        _validate_family_declarations(
+            model=Base,
+            name="current-with-patch",
+            versions=(SchemaVersion("1", patches=(cast(Any, object()),)),),
+            transitions=(),
+            nested=(),
+            missing_version=None,
+        )
+
+
+def test_compiler_validation_catches_nested_family_projection_errors() -> None:
+    class Parent(BaseModel):
+        value: int = 1
+
+    class Child(BaseModel):
+        value: int = 1
+
+    child = SchemaFamily(
+        model=Child,
+        name="child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+    )
+    parent = SchemaFamily(
+        model=Parent,
+        name="parent",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        nested=(
+            NestedFamily("value", child, matching_labels()),
+            NestedFamily("value", child, matching_labels()),
+        ),
+    )
+
+    with pytest.raises(SchemaCompilationError, match="Duplicate nested family declaration path"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Parent,
+            labels=("v1", "v2"),
+            nested=parent.nested,
+        )
+
+    with pytest.raises(SchemaCompilationError, match="must resolve to a SchemaFamily"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Parent,
+            labels=("v1", "v2"),
+            nested=(NestedFamily("value", lambda: cast(Any, "not_family"), matching_labels()),),
+        )
+
+    compiled_boundary = _validate_compilation_boundary(
+        name="parent",
+        model=Parent,
+        labels=("v1", "v2"),
+        nested=(NestedFamily("value", lambda: child, versions={"v1": "v1", "v2": "v2"}),),
+    )
+    assert len(compiled_boundary) == 1
+
+    comp_family = child._compiled_family()
+    assert comp_family.labels == ("v1", "v2")
+
+
+def test_runtime_private_edges() -> None:
+    class Base(BaseModel):
+        value: int = 1
+
+    assert _runtime_label("v1", family_name="runtime") == "v1"
+
+    with pytest.raises(UnknownSchemaVersionError, match="must be a non-empty string"):
+        _runtime_label(1, family_name="runtime")
+
+    assert _infer_metadata_owner(Base, "value") == "model"
+    assert _infer_metadata_owner(Base, ("meta", "schema_version")) == "family"
+
+    payload: dict[str, Any] = {"nested": []}
+    with pytest.raises(InvalidMigrationError, match="Cannot set version metadata"):
+        _set_version_field(payload, ("nested", "value"), "v1")
+
+    payload = {"nested": {"schema_version": "v2"}, "extra": 1}
+    _set_version_field(payload, ("schema_version",), "v1")
+    assert payload == {"nested": {"schema_version": "v2"}, "extra": 1, "schema_version": "v1"}
+
+    normalized = _normalize_payload_field_aliases(
+        Base,
+        {"value": 2, "legacy_value": 3},
+        prefer_aliases=False,
+    )
+    assert normalized["value"] == 2
+
+    parent = SchemaFamily(
+        model=Base,
+        name="runtime-parent",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+    )
+    payload = {"outer": {"value": {"schema_version": "v2"}}}
+    _prune_nested_family_metadata_at_path(
+        payload=payload,
+        path=("outer", "value"),
+        family=parent,
+    )
+    assert payload == {"outer": {"value": {}}}
+
+    assert _nested_family_collection_kind(model=Base, path=("value",)) is None
+
+
+def test_wire_private_paths() -> None:
+    bad_config = create_model("BadConfig", value=(int, 1), __config__=cast(ConfigDict, {1: True}))
+
+    bad_family = SchemaFamily(
+        model=bad_config,
+        name="bad-config",
+        versions=(SchemaVersion("1"),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="model configuration keys must be strings"):
+        _validate_model_config(bad_family)
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="uses unsupported attributes",
+    ):
+        _wire_field_attributes(
+            cast(Any, bad_family),
+            "value",
+            {"unknown": True},
+        )
+
+    with pytest.raises(UnsupportedWireModelError, match="callable discriminator"):
+        _snapshot_wire_metadata(
+            cast(Any, bad_family),
+            "value",
+            (Discriminator(lambda value: str(value)),),
+            detail="wire",
+        )
+
+    unresolved = ForwardRef("UndefinedAlias")
+    unresolved_alias: Any = unresolved
+    type custom[T_alias] = unresolved_alias
+
+    with pytest.raises(UnsupportedWireModelError, match="forward reference hidden in a type alias"):
+        _validate_type_alias(
+            cast(Any, bad_family),
+            "value",
+            cast(Any, custom),
+        )
+
+
+def test_runtime_and_wire_cross_product_helpers() -> None:
+    class ProjectionModel(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+
+        value: int = Field(validation_alias="payload")
+        schema_version: str = "1"
+
+    family = SchemaFamily(
+        model=ProjectionModel,
+        name="projection-helper",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    historical = family.model_for("1")
+    projection_alias = _runtime_label("1", family_name="projection-helper")
+    assert projection_alias == "1"
+
+    rendered = historical.model_json_schema()["properties"]
+    assert isinstance(rendered, Mapping)
+
+    assert _nested_family_collection_kind(model=ProjectionModel, path=("value",)) is None
+
+
+def test_more_compiler_validation_branches() -> None:
+    class Base(BaseModel):
+        value: int = 1
+
+    class ExtraFieldModel(BaseModel):
+        val: int = 1
+        other: int = 2
+
+    # SchemaFamily.versions containing non-SchemaVersion
+    with pytest.raises(SchemaCompilationError, match="must contain only SchemaVersion values"):
+        _validate_family_declarations(
+            model=Base,
+            name="invalid-version-item",
+            versions=(cast(Any, "1"),),
+            transitions=(),
+            nested=(),
+            missing_version=None,
+        )
+
+    # SchemaFamily.transitions containing non-VersionTransition
+    with pytest.raises(SchemaCompilationError, match="must contain only VersionTransition values"):
+        _validate_family_declarations(
+            model=Base,
+            name="invalid-transition-item",
+            versions=(SchemaVersion("1"),),
+            transitions=(cast(Any, "1->2"),),
+            nested=(),
+            missing_version=None,
+        )
+
+    # SchemaFamily.nested containing non-NestedFamily
+    with pytest.raises(SchemaCompilationError, match="must contain only NestedFamily values"):
+        _validate_family_declarations(
+            model=Base,
+            name="invalid-nested-item",
+            versions=(SchemaVersion("1"),),
+            transitions=(),
+            nested=(cast(Any, "nested"),),
+            missing_version=None,
+        )
+
+    # Downgrade not callable error in _validate_transition_declarations
+    with pytest.raises(SchemaCompilationError, match="must be callable"):
+        _validate_transition_declarations(
+            "family",
+            ("1", "2"),
+            (
+                VersionTransition(
+                    "1", "2", upgrade=lambda p: p, downgrade=cast(Any, "not_callable")
+                ),
+            ),
+        )
+
+    # downgrade_semantics forbidden without downgrade
+    with pytest.raises(SchemaCompilationError, match="forbidden when no downgrade is declared"):
+        _validate_transition_declarations(
+            "family",
+            ("1", "2"),
+            (VersionTransition("1", "2", upgrade=lambda p: p, downgrade_semantics="exact"),),
+        )
+
+    # downgrade_semantics invalid
+    with pytest.raises(SchemaCompilationError, match="must be 'exact' or 'lossy'"):
+        _validate_transition_declarations(
+            "family",
+            ("1", "2"),
+            (
+                VersionTransition(
+                    "1",
+                    "2",
+                    upgrade=lambda p: p,
+                    downgrade=lambda p: p,
+                    downgrade_semantics=cast(Any, "invalid"),
+                ),
+            ),
+        )
+
+    # NestedFamily callable provider returning non-SchemaFamily
+    with pytest.raises(SchemaCompilationError, match="must resolve to a SchemaFamily"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1",),
+            nested=(NestedFamily("value", lambda: cast(Any, "not_family"), matching_labels()),),
+        )
+
+    # NestedFamily pointing to same model
+    parent_family = SchemaFamily(model=Base, name="base", versions=(SchemaVersion("v1"),))
+    with pytest.raises(SchemaCompilationError, match="cannot reference the same owning model"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1",),
+            nested=(NestedFamily("value", parent_family, matching_labels()),),
+        )
+
+    # NestedFamily matching labels when child labels != parent labels
+    child_family = SchemaFamily(
+        model=ExtraFieldModel,
+        name="child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+    )
+    with pytest.raises(SchemaCompilationError, match="must use matching labels"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1",),
+            nested=(NestedFamily("val", child_family, matching_labels()),),
+        )
+
+    # NestedFamily versions not a Mapping
+    with pytest.raises(SchemaCompilationError, match="must be a mapping"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1",),
+            nested=(NestedFamily("val", child_family, versions=cast(Any, "not_a_mapping")),),
+        )
+
+    # NestedFamily versions missing mappings for parent labels
+    with pytest.raises(SchemaCompilationError, match="missing mappings"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1", "v2"),
+            nested=(NestedFamily("val", child_family, versions={"v1": "v1"}),),
+        )
+
+    # NestedFamily versions unknown parent label
+    with pytest.raises(SchemaCompilationError, match="unknown parent labels"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1",),
+            nested=(NestedFamily("val", child_family, versions={"v1": "v1", "v_unknown": "v1"}),),
+        )
+
+    # NestedFamily versions unknown child label
+    with pytest.raises(SchemaCompilationError, match="unknown child labels"):
+        _validate_compilation_boundary(
+            name="parent",
+            model=Base,
+            labels=("v1",),
+            nested=(NestedFamily("val", child_family, versions={"v1": "v_unknown"}),),
+        )
+
+
+def test_more_runtime_collection_and_migration_branches() -> None:
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    child_fam = SchemaFamily(
+        model=ChildModel,
+        name="runtime-child",
+        versions=(
+            SchemaVersion("v1"),
+            SchemaVersion("v2"),
+        ),
+        version_metadata=VersionMetadata("schema_version"),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: {"val": p.get("val", 1) + 1},
+                downgrade=lambda p: {"val": p.get("val", 2) - 1},
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    # test _prune_nested_family_metadata_at_path with family having version metadata
+    payload_dict = {"schema_version": "v1", "val": 1}
+    _prune_nested_family_metadata_at_path(
+        payload=payload_dict,
+        path=(),
+        family=child_fam,
+    )
+    assert payload_dict == {"val": 1}
+
+    # test upgrade returning non-dict raises InvalidMigrationError
+    bad_upgrade_fam = SchemaFamily(
+        model=ChildModel,
+        name="non-dict-upgrade",
+        versions=(
+            SchemaVersion("v1"),
+            SchemaVersion("v2"),
+        ),
+        version_metadata=VersionMetadata("schema_version"),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: cast(Any, "not_a_dict"),
+            ),
+        ),
+    )
+    with pytest.raises(InvalidMigrationError, match="must return a dict"):
+        bad_upgrade_fam.validate({"val": 1, "schema_version": "v1"})
+
+    # test downgrade returning non-dict raises InvalidMigrationError
+    bad_downgrade_fam = SchemaFamily(
+        model=ChildModel,
+        name="non-dict-downgrade",
+        versions=(
+            SchemaVersion("v1"),
+            SchemaVersion("v2"),
+        ),
+        version_metadata=None,
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: p,
+                downgrade=lambda p: cast(Any, "not_a_dict"),
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    with pytest.raises(InvalidMigrationError, match="must return a dict"):
+        bad_downgrade_fam.dump(version="v1", data=ChildModel(val=1))
+
+
+def test_explicit_wire_model_metadata_validation() -> None:
+    from typing import Literal
+
+    class WireMissingField(BaseModel):
+        val: int
+
+    class ModelWithMeta(BaseModel):
+        val: int = 1
+        schema_version: str = "v1"
+
+    fam = SchemaFamily(
+        model=ModelWithMeta,
+        name="meta-wire",
+        versions=(SchemaVersion("v1"),),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+    comp = fam._compiled_family()
+    proj = comp.version("v1").projection
+
+    with pytest.raises(
+        UnsupportedWireModelError, match="must declare the same model metadata field"
+    ):
+        _validate_explicit_wire_model_metadata(fam, proj, WireMissingField)
+
+    class WireWrongType(BaseModel):
+        val: int
+        schema_version: int = 1
+
+    with pytest.raises(UnsupportedWireModelError, match="must annotate field"):
+        _validate_explicit_wire_model_metadata(fam, proj, WireWrongType)
+
+    class WireWrongDefault(BaseModel):
+        val: int
+        schema_version: Literal["v1"] = cast(Any, "v2")
+
+    with pytest.raises(UnsupportedWireModelError, match="must provide the exact default"):
+        _validate_explicit_wire_model_metadata(fam, proj, WireWrongDefault)
+
+
+def test_declarations_family_and_core_coverage_gaps() -> None:
+    from pydantic_versions.core import schema_version, versioned_schema
+
+    with pytest.raises(
+        SchemaCompilationError, match="VersionMetadata.owner must be 'family' or 'model'"
+    ):
+        VersionMetadata(owner=cast(Any, "invalid"))
+
+    class ModelBase(BaseModel):
+        val: int = 1
+
+    class Wire1(BaseModel):
+        val: int = 1
+
+    class Wire2(BaseModel):
+        val: int = 1
+
+    with pytest.raises(
+        SchemaCompilationError, match="version_metadata must be VersionMetadata or None"
+    ):
+        SchemaFamily(
+            model=ModelBase,
+            name="bad-meta",
+            versions=(SchemaVersion("v1"),),
+            version_metadata=cast(Any, "invalid_str"),
+        )
+
+    # Core decorator duplicate wire model for same version label
+    with pytest.raises(DuplicateSchemaVersionError, match="declared more than once"):
+
+        @versioned_schema(name="test-dup-wire", versions=("v1",), current="v1")
+        @schema_version("v1", wire_model=Wire1)
+        @schema_version("v1", wire_model=Wire2)
+        class DupWireModel(BaseModel):
+            val: int = 1
+
+    fam = SchemaFamily(
+        model=ModelBase,
+        name="recursive-check",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+    )
+    with pytest.raises(UnknownSchemaVersionError, match="Unknown migration edge"):
+        fam._ensure_legacy_transition_allowed("v1", "v3")
+
+    fam._compiling = True
+    with pytest.raises(
+        SchemaCompilationError, match="Recursive schema-family compilation is not yet supported"
+    ):
+        fam.compile()
+
+
+def test_nested_family_container_collections_and_conversions() -> None:
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    child_fam = SchemaFamily(
+        model=ChildModel,
+        name="container-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        version_metadata=VersionMetadata("schema_version"),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: {"val": p.get("val", 1) + 10},
+                downgrade=lambda p: {"val": p.get("val", 11) - 10},
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    class Wrapper(BaseModel):
+        child: ChildModel
+
+    class ParentModel(BaseModel):
+        wrappers_list: list[Wrapper]
+        wrappers_tuple: tuple[Wrapper, ...]
+
+    parent_fam = SchemaFamily(
+        model=ParentModel,
+        name="container-parent",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        version_metadata=VersionMetadata("schema_version"),
+        nested=(
+            NestedFamily(("wrappers_list", "child"), child_fam, matching_labels()),
+            NestedFamily(("wrappers_tuple", "child"), child_fam, matching_labels()),
+        ),
+    )
+
+    # Validate v1 payload containing collections of wrapped v1 children
+    payload_v1 = {
+        "schema_version": "v1",
+        "wrappers_list": [{"child": {"schema_version": "v1", "val": 1}}],
+        "wrappers_tuple": ({"child": {"schema_version": "v1", "val": 2}},),
+    }
+
+    res = parent_fam.validate(payload_v1)
+    assert res.current_model.wrappers_list[0].child.val == 11
+    assert res.current_model.wrappers_tuple[0].child.val == 12
+
+    # Dump v1 payload from ParentModel instance
+    dumped = parent_fam.dump(version="v1", data=res.current_model)
+    assert dumped["wrappers_list"][0]["child"]["val"] == 1
+
+
+def test_wire_decorators_and_uncopyable_defaults() -> None:
+    from pydantic import field_validator
+
+    class ModelWithValidator(BaseModel):
+        val: int
+
+        @field_validator("val")
+        @classmethod
+        def validate_val(cls, v: int) -> int:
+            return v
+
+    fam_val = SchemaFamily(
+        model=ModelWithValidator,
+        name="validator-family",
+        versions=(SchemaVersion("v1"),),
+    )
+    assert fam_val.model_for("v1") is not None
+
+    class UncopyableDefaultModel(BaseModel):
+        val: Any = Field(default=CopyError())
+
+    bad_fam = SchemaFamily(
+        model=UncopyableDefaultModel,
+        name="uncopyable-family",
+        versions=(SchemaVersion("v1"),),
+    )
+    with pytest.raises(UnsupportedWireModelError, match="cannot safely copy"):
+        bad_fam.model_for("v1")
+
+
+def test_more_runtime_alias_and_prune_edge_cases() -> None:
+    class Base(BaseModel):
+        val: int = Field(default=1, validation_alias="legacy_val")
+
+    normalized = _normalize_payload_field_aliases(
+        Base,
+        {"legacy_val": 5},
+        prefer_aliases=True,
+    )
+    assert normalized["val"] == 5
+
+    child_fam = SchemaFamily(
+        model=Base,
+        name="edge-child",
+        versions=(SchemaVersion("v1"),),
+    )
+    # _prune_nested_family_metadata_at_path with missing key in dict
+    payload_missing_key = {"other": 1}
+    _prune_nested_family_metadata_at_path(
+        payload=payload_missing_key,
+        path=("missing_key",),
+        family=child_fam,
+    )
+    assert payload_missing_key == {"other": 1}
+
+    # _prune_nested_family_metadata_at_path with list, tuple, set, frozenset
+    p_list = [{"schema_version": "v1", "val": 1}]
+    _prune_nested_family_metadata_at_path(payload=p_list, path=("item",), family=child_fam)
+
+    p_tuple = ({"schema_version": "v1", "val": 1},)
+    _prune_nested_family_metadata_at_path(payload=p_tuple, path=("item",), family=child_fam)
+
+    p_set = set()
+    _prune_nested_family_metadata_at_path(payload=p_set, path=("item",), family=child_fam)
+
+    p_frozenset = frozenset()
+    _prune_nested_family_metadata_at_path(payload=p_frozenset, path=("item",), family=child_fam)
+
+    # family.defaults_for and dump with mode="json"
+    assert child_fam.defaults_for(version="v1") is not None
+    assert child_fam.dump(version="v1", data=Base(legacy_val=1), mode="json") is not None
+
+    # top-level dump downgrade returning non-dict
+    downgrade_bad_top = SchemaFamily(
+        model=Base,
+        name="downgrade-bad-top",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: p,
+                downgrade=lambda p: cast(Any, "not_a_dict"),
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    with pytest.raises(InvalidMigrationError, match="downgrade must return a dict"):
+        downgrade_bad_top.dump(version="v1", data=Base(legacy_val=1))
+
+
+def test_type_alias_unsupported_metadata() -> None:
+    from typing import Annotated, Literal
+
+    from pydantic import Discriminator, WithJsonSchema
+
+    class ModelA(BaseModel):
+        kind: Literal["a"] = "a"
+
+    class ModelB(BaseModel):
+        kind: Literal["b"] = "b"
+
+    disc_alias: Any = Annotated[ModelA | ModelB, Discriminator("kind")]
+    AliasDisc = TypeAliasType("AliasDisc", disc_alias)  # noqa: N806, UP040
+
+    class ModelAliasDisc(BaseModel):
+        val: AliasDisc
+
+    fam_disc = SchemaFamily(
+        model=ModelAliasDisc,
+        name="alias-disc",
+        versions=(SchemaVersion("v1"),),
+    )
+    with pytest.raises(UnsupportedWireModelError, match="hidden in a type alias"):
+        fam_disc.model_for("v1")
+
+    json_alias: Any = Annotated[int, WithJsonSchema({})]
+    AliasJson = TypeAliasType("AliasJson", json_alias)  # noqa: N806, UP040
+
+    class ModelAliasJson(BaseModel):
+        val: AliasJson
+
+    fam_json = SchemaFamily(
+        model=ModelAliasJson,
+        name="alias-json",
+        versions=(SchemaVersion("v1"),),
+    )
+    with pytest.raises(UnsupportedWireModelError, match="hidden in a type alias"):
+        fam_json.model_for("v1")
+
+
+def test_runtime_helper_functions() -> None:
+    from typing import Annotated
+
+    from pydantic_versions._runtime import (
+        _collection_kind,
+        _has_duplicate_payload,
+        _strip_annotated,
+    )
+
+    assert _collection_kind(list[int]) == "list"
+    assert _collection_kind(tuple[int, ...]) == "tuple"
+    assert _collection_kind(set[int]) == "set"
+    assert _collection_kind(frozenset[int]) == "frozenset"
+
+    assert _strip_annotated(Annotated[int, "meta"]) is int
+    assert _has_duplicate_payload([1, 1]) is True
+    assert _has_duplicate_payload([1, 2]) is False
+
+    from pydantic_versions._runtime import _nested_family_collection_kind
+
+    class Child(BaseModel):
+        val: int
+
+    class Parent(BaseModel):
+        items: list[Child]
+
+    assert _nested_family_collection_kind(model=Parent, path=("items", "val")) is None
+    assert _nested_family_collection_kind(model=Parent, path=("missing",)) is None
+    assert _nested_family_collection_kind(model=cast(Any, int), path=("val",)) is None
+
+
+def test_runtime_alias_choices_and_payload_paths() -> None:
+    from pydantic import AliasChoices, AliasPath
+
+    from pydantic_versions._runtime import (
+        _field_alias_paths,
+        _remove_payload_path,
+        _set_payload_path,
+        _to_version_names,
+    )
+
+    class ModelAlias(BaseModel):
+        f1: int = Field(validation_alias=AliasChoices("a", AliasPath("b", "c")))
+        f2: int = Field(validation_alias=AliasPath("d", "e"))
+
+    paths1 = _field_alias_paths(ModelAlias.model_fields["f1"])
+    assert paths1 == (("a",), ("b", "c"))
+
+    paths2 = _field_alias_paths(ModelAlias.model_fields["f2"])
+    assert paths2 == (("d", "e"),)
+
+    # _remove_payload_path edge cases
+    _remove_payload_path({}, ())
+    d1 = {"a": 1}
+    _remove_payload_path(d1, ("a", "b"))
+    assert d1 == {"a": 1}
+    _remove_payload_path(cast(Any, "scalar"), ("a",))
+
+    # _set_payload_path edge cases
+    _set_payload_path({}, (), 1)
+    _set_payload_path(cast(Any, "scalar"), ("a",), 1)
+    d2 = {"a": 1}
+    _set_payload_path(d2, ("a", "b"), 2)
+    assert d2 == {"a": 1}
+
+    # _to_version_names edge cases
+    assert _to_version_names(cast(Any, None), "scalar") == "scalar"
+
+
+def test_runtime_nested_child_and_family_payload_conversions() -> None:
+    from pydantic_versions._runtime import (
+        _convert_nested_child_family,
+        _convert_nested_family_payload,
+    )
+
+    class HashableDict(dict[str, Any]):
+        def __hash__(self) -> int:
+            return hash(
+                tuple(
+                    sorted(
+                        (k, hash(v) if isinstance(v, HashableDict) else v) for k, v in self.items()
+                    )
+                )
+            )
+
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    child_fam = SchemaFamily(
+        model=ChildModel,
+        name="nested-conv-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        version_metadata=VersionMetadata("schema_version"),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: HashableDict({"val": p.get("val", 1) + 10}),
+                downgrade=lambda p: HashableDict({"val": p.get("val", 11) - 10}),
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    # _convert_nested_child_family direct tests with tuple, set, frozenset
+    item_v1 = HashableDict({"schema_version": "v1", "val": 1})
+
+    res_tuple = _convert_nested_child_family(
+        payload=({"sub": item_v1},),
+        path=("sub",),
+        family=child_fam,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert res_tuple[0]["sub"]["val"] == 11
+
+    res_set = _convert_nested_child_family(
+        payload={1, 2},
+        path=("sub",),
+        family=child_fam,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert len(res_set) == 2
+
+    res_frozenset = _convert_nested_child_family(
+        payload=frozenset([1, 2]),
+        path=("sub",),
+        family=child_fam,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert len(res_frozenset) == 2
+
+    # _convert_nested_family_payload direct tests with tuple, set, frozenset
+    payload_tuple = (item_v1,)
+    conv_tuple = _convert_nested_family_payload(
+        family=child_fam,
+        payload=payload_tuple,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert conv_tuple[0]["val"] == 11
+
+    payload_set = {item_v1}
+    conv_set = _convert_nested_family_payload(
+        family=child_fam,
+        payload=payload_set,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert len(conv_set) == 1
+
+    payload_frozenset = frozenset([item_v1])
+    conv_frozenset = _convert_nested_family_payload(
+        family=child_fam,
+        payload=payload_frozenset,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert len(conv_frozenset) == 1
+
+
+def test_wire_annotation_behavior_and_type_parameter_values() -> None:
+    from typing import Annotated
+
+    from pydantic import Discriminator, WithJsonSchema
+
+    from pydantic_versions._wire import (
+        _annotation_contains_runtime_behavior,
+        _type_parameter_values,
+    )
+
+    class CustomJsonSchema(WithJsonSchema):
+        pass
+
+    assert (
+        _annotation_contains_runtime_behavior(
+            Annotated[int, Discriminator(lambda x: "a")],
+            seen=set(),
+        )
+        is True
+    )
+    assert (
+        _annotation_contains_runtime_behavior(
+            Annotated[int, CustomJsonSchema({})],
+            seen=set(),
+        )
+        is True
+    )
+
+    T = TypeVar("T", int, str)
+    values = _type_parameter_values(T)
+    assert int in values
+    assert str in values
+
+
+def test_wire_validate_object_schema_edge_cases() -> None:
+    from pydantic_versions._wire import _validate_object_schema
+
+    class DummyModel(BaseModel):
+        val: int
+
+    fam = SchemaFamily(model=DummyModel, name="json-schema-test", versions=(SchemaVersion("v1"),))
+    proj = fam._compiled_family().version("v1").projection
+
+    # non-serializable schema
+    class NonSerializableModel(BaseModel):
+        @classmethod
+        def model_json_schema(
+            cls,
+            by_alias: bool = True,
+            ref_template: str = "",
+            schema_generator: Any = None,
+            mode: str = "validation",
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            return {"bad": cast(Any, object())}
+
+    with pytest.raises(UnsupportedWireModelError, match="non-JSON-serializable"):
+        _validate_object_schema(fam, proj, NonSerializableModel, mode="validation")
+
+    # $ref resolution
+    class RefModel(BaseModel):
+        @classmethod
+        def model_json_schema(
+            cls,
+            by_alias: bool = True,
+            ref_template: str = "",
+            schema_generator: Any = None,
+            mode: str = "validation",
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            return {
+                "$ref": "#/$defs/Target",
+                "$defs": {"Target": {"type": "object"}},
+            }
+
+    _validate_object_schema(fam, proj, RefModel, mode="validation")
+
+    # non-object schema
+    class NonObjectModel(BaseModel):
+        @classmethod
+        def model_json_schema(
+            cls,
+            by_alias: bool = True,
+            ref_template: str = "",
+            schema_generator: Any = None,
+            mode: str = "validation",
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            return {"type": "string"}
+
+    with pytest.raises(UnsupportedWireModelError, match="has a non-object"):
+        _validate_object_schema(fam, proj, NonObjectModel, mode="validation")
+
+
+def test_wire_generic_type_alias() -> None:
+
+    T = TypeVar("T", bound=int)
+    GenericAlias = TypeAliasType("GenericAlias", list[T], type_params=(T,))  # noqa: N806, UP040
+
+    class ModelGen(BaseModel):
+        val: GenericAlias[int]
+
+    fam = SchemaFamily(model=ModelGen, name="gen-alias", versions=(SchemaVersion("v1"),))
+    assert fam.model_for("v1") is not None
+
+
+def test_wire_metadata_validation_edge_cases() -> None:
+    from typing import Annotated, NewType
+
+    from pydantic import Discriminator
+
+    from pydantic_versions._wire import (
+        _model_metadata_field,
+        _validate_annotation_behavior,
+        _validate_family_metadata_collision,
+    )
+
+    class DummyModel(BaseModel):
+        ver: str
+
+    fam = SchemaFamily(model=DummyModel, name="dummy", versions=(SchemaVersion("v1"),))
+
+    # NewType with behavior
+    NT = NewType("NT", Annotated[int, Discriminator(lambda x: "a")])  # noqa: N806
+    with pytest.raises(UnsupportedWireModelError, match="behavioral NewType target"):
+        _validate_annotation_behavior(fam, "f", NT)
+
+    # model-owned metadata path non-str tuple
+    fam_non_str = SchemaFamily(
+        model=DummyModel,
+        name="non-str-meta",
+        versions=(SchemaVersion("v1"),),
+        version_metadata=VersionMetadata(("ver", "sub"), owner="model"),
+    )
+    with pytest.raises(
+        UnsupportedWireModelError, match="requires the top-level conversion compiler"
+    ):
+        _model_metadata_field(fam_non_str)
+
+    # model-owned metadata path matches 0 fields
+    fam_no_match = SchemaFamily(
+        model=DummyModel,
+        name="no-match-meta",
+        versions=(SchemaVersion("v1"),),
+        version_metadata=VersionMetadata("unknown_field", owner="model"),
+    )
+    with pytest.raises(UnsupportedWireModelError, match="must resolve to exactly one direct field"):
+        _model_metadata_field(fam_no_match)
+
+    # family-owned version metadata collides with model field
+    fam_collision = SchemaFamily(
+        model=DummyModel,
+        name="collision-meta",
+        versions=(SchemaVersion("v1"),),
+        version_metadata=VersionMetadata("ver", owner="family"),
+    )
+    with pytest.raises(UnsupportedWireModelError, match="family-owned version metadata collides"):
+        _validate_family_metadata_collision(fam_collision)
+
+
+def test_wire_module_reflection_helpers() -> None:
+    from pydantic_versions._wire import _is_exact_module_member, _is_typing_reflection_owner
+
+    assert _is_exact_module_member(int, module="builtins") is True
+    assert _is_exact_module_member(int, module="typing") is False
+    assert _is_typing_reflection_owner(int) is True
+
+    class LocalModel(BaseModel):
+        pass
+
+    assert _is_typing_reflection_owner(LocalModel) is False
+
+
+def test_runtime_more_nested_family_migration_errors_and_conversions() -> None:
+    from pydantic_versions._runtime import (
+        _convert_nested_child_family,
+        _convert_nested_family_payload,
+    )
+
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    bad_upgrade_fam = SchemaFamily(
+        model=ChildModel,
+        name="bad-up-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: cast(Any, "not_dict"),
+                downgrade=lambda p: p,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    with pytest.raises(InvalidMigrationError, match="must return a dict"):
+        _convert_nested_family_payload(
+            family=bad_upgrade_fam,
+            payload={"schema_version": "v1", "val": 1},
+            source_label="v1",
+            target_label="v2",
+        )
+
+    bad_downgrade_fam = SchemaFamily(
+        model=ChildModel,
+        name="bad-down-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: p,
+                downgrade=lambda p: cast(Any, "not_dict"),
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    with pytest.raises(InvalidMigrationError, match="must return a dict"):
+        _convert_nested_family_payload(
+            family=bad_downgrade_fam,
+            payload={"schema_version": "v2", "val": 1},
+            source_label="v2",
+            target_label="v1",
+        )
+
+    # _convert_nested_child_family multi-level dict conversion
+    item_v1 = {"schema_version": "v1", "val": 1}
+    res_dict = _convert_nested_child_family(
+        payload={"a": {"sub": item_v1}},
+        path=("sub", "val"),
+        family=bad_upgrade_fam,
+        source_label="v1",
+        target_label="v2",
+    )
+    assert res_dict["a"]["sub"]["val"] == 1
+
+
+def test_wire_decorator_child_label_mismatch() -> None:
+    from pydantic_versions import versioned_schema
+    from pydantic_versions.family import _default_family_for_model
+
+    @versioned_schema(name="mismatch-child", versions=("v1", "v2"), current="v2")
+    class MismatchChild(BaseModel):
+        val: int = 1
+
+    @versioned_schema(name="mismatch-parent", versions=("v1",), current="v1")
+    class MismatchParent(BaseModel):
+        child: MismatchChild
+
+    fam = _default_family_for_model(MismatchParent)
+    assert fam is not None
+    with pytest.raises(UnsupportedWireModelError, match="could not be built safely"):
+        fam.model_for("v1")
+
+
+def test_wire_more_annotation_behavior_and_forward_refs() -> None:
+    from dataclasses import dataclass
+
+    from pydantic_versions._wire import (
+        _annotation_contains_runtime_behavior,
+        _has_behavioral_structured_annotation,
+        _owner_annotations,
+    )
+
+    @dataclass
+    class PostInitDataclass:
+        val: int
+
+        def __post_init__(self) -> None:
+            pass
+
+    assert _has_behavioral_structured_annotation(PostInitDataclass) is True
+
+    UndefinedClass = Any  # noqa: N806
+
+    class UndefinedRefModel(BaseModel):
+        val: UndefinedClass
+
+    resolved = _owner_annotations(UndefinedRefModel)
+    assert "val" in resolved
+
+    assert _annotation_contains_runtime_behavior("UndefinedClass", seen=set()) is True
+
+
+def test_runtime_nested_cardinality_and_prune_coverage() -> None:
+    from pydantic_versions._runtime import (
+        _convert_nested_child_family,
+        _convert_nested_family_payload,
+        _prune_nested_family_metadata_at_path,
+    )
+
+    class HashableDict(dict[str, Any]):
+        def __hash__(self) -> int:
+            return hash(frozenset(self.items()))
+
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    fam = SchemaFamily(
+        model=ChildModel,
+        name="cardinality-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=lambda p: HashableDict({"schema_version": "v2", "val": 0}),
+                downgrade=lambda p: p,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    item1 = HashableDict({"schema_version": "v1", "val": 1})
+    item2 = HashableDict({"schema_version": "v1", "val": 2})
+
+    # _convert_nested_child_family set & frozenset
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        _convert_nested_child_family(
+            payload={item1, item2},
+            path=(),
+            family=fam,
+            source_label="v1",
+            target_label="v2",
+        )
+
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        _convert_nested_child_family(
+            payload=frozenset({item1, item2}),
+            path=(),
+            family=fam,
+            source_label="v1",
+            target_label="v2",
+        )
+
+    # _convert_nested_family_payload set & frozenset
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        _convert_nested_family_payload(
+            family=fam,
+            payload={item1, item2},
+            source_label="v1",
+            target_label="v2",
+        )
+
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        _convert_nested_family_payload(
+            family=fam,
+            payload=frozenset({item1, item2}),
+            source_label="v1",
+            target_label="v2",
+        )
+
+    # _prune_nested_family_metadata_at_path with tuple, set, frozenset
+    item_meta = HashableDict({"schema_version": "v1", "val": 1})
+    _prune_nested_family_metadata_at_path(
+        payload=(item_meta,),
+        path=(),
+        family=fam,
+    )
+    _prune_nested_family_metadata_at_path(
+        payload={item_meta},
+        path=(),
+        family=fam,
+    )
+
+
+def test_runtime_more_pruning_and_nested_collection_kinds() -> None:
+    from pydantic_versions._runtime import (
+        _apply_nested_family_migrations,
+        _nested_family_collection_kind,
+        _prune_nested_family_metadata,
+        _prune_nested_family_metadata_at_path,
+        _prune_nested_family_metadata_payload,
+    )
+
+    class HashableDict(dict[str, Any]):
+        def __hash__(self) -> int:
+            return hash(frozenset(self.items()))
+
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    child_fam = SchemaFamily(
+        model=ChildModel,
+        name="prune-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+    )
+
+    class ParentModel(BaseModel):
+        items: list[ChildModel]
+
+    parent_fam = SchemaFamily(
+        model=ParentModel,
+        name="prune-parent",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2")),
+        nested=(NestedFamily("items", lambda: child_fam, matching_labels()),),
+    )
+
+    parent_compiled = parent_fam._compiled_family()
+
+    # _apply_nested_family_migrations same source and target label
+    res = _apply_nested_family_migrations(
+        payload={"items": []},
+        compiled=parent_compiled,
+        source_label="v1",
+        target_label="v1",
+    )
+    assert res == {"items": []}
+
+    # _nested_family_collection_kind 2-level path
+    kind = _nested_family_collection_kind(
+        model=ParentModel,
+        path=("items", "val"),
+    )
+    assert kind is None
+
+    # _prune_nested_family_metadata with nested
+    payload = {"items": [{"schema_version": "v1", "val": 1}]}
+    _prune_nested_family_metadata(payload=payload, compiled=parent_compiled)
+
+    # _prune_nested_family_metadata_payload with nested
+    _prune_nested_family_metadata_payload(payload, parent_compiled)
+
+    # _prune_nested_family_metadata_at_path set & frozenset multi-level path
+    item = HashableDict({"val": 1})
+    _prune_nested_family_metadata_at_path(
+        payload={item},
+        path=("wrapper", "val"),
+        family=child_fam,
+    )
+    _prune_nested_family_metadata_at_path(
+        payload=frozenset({item}),
+        path=("wrapper", "val"),
+        family=child_fam,
+    )
+
+
+def test_wire_decorators_have_behavior() -> None:
+    from pydantic import field_serializer, field_validator, model_validator
+
+    from pydantic_versions._wire import _decorators_have_behavior
+
+    class ValModel(BaseModel):
+        val: int
+
+        @field_validator("val")
+        @classmethod
+        def check_val(cls, v: int) -> int:
+            return v
+
+    class SerModel(BaseModel):
+        val: int
+
+        @field_serializer("val")
+        def ser_val(self, v: int) -> int:
+            return v
+
+    class ModValModel(BaseModel):
+        val: int
+
+        @model_validator(mode="after")
+        def check_model(self) -> Any:
+            return self
+
+    assert _decorators_have_behavior(ValModel) is True
+    assert _decorators_have_behavior(SerModel) is True
+    assert _decorators_have_behavior(ModValModel) is True
+    assert _decorators_have_behavior(int) is False
+
+
+def test_compiler_nested_family_declaration_validation_errors() -> None:
+
+    from pydantic_versions._compiler import _validate_compilation_boundary
+
+    class ModelA(BaseModel):
+        val: int = 1
+
+    class ModelB(BaseModel):
+        child: ModelA
+
+    fam_a = SchemaFamily(model=ModelA, name="fam-a", versions=(SchemaVersion("v1"),))
+
+    # Invalid provider
+    with pytest.raises(
+        SchemaCompilationError,
+        match="must use a SchemaFamily or callable provider",
+    ):
+        _validate_compilation_boundary(
+            model=ModelB,
+            name="fam-b",
+            labels=("v1",),
+            nested=(NestedFamily("child", cast(Any, "invalid_provider"), matching_labels()),),
+        )
+
+    # Invalid versions mapping
+    decl = NestedFamily("child", fam_a, matching_labels())
+    object.__setattr__(decl, "versions", "not_mapping")
+    with pytest.raises(SchemaCompilationError, match="must be a mapping"):
+        _validate_compilation_boundary(
+            model=ModelB,
+            name="fam-b",
+            labels=("v1",),
+            nested=(decl,),
+        )
+
+
+def test_runtime_list_tuple_unchanged_conversions() -> None:
+    from pydantic_versions._runtime import (
+        _convert_nested_child_family,
+        _convert_nested_family_payload,
+    )
+
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    fam = SchemaFamily(
+        model=ChildModel,
+        name="unchanged-child",
+        versions=(SchemaVersion("v1"),),
+    )
+
+    item = {"schema_version": "v1", "val": 1}
+
+    # list unchanged
+    res_list1 = _convert_nested_child_family(
+        payload=[item],
+        path=(),
+        family=fam,
+        source_label="v1",
+        target_label="v1",
+    )
+    assert res_list1 == [item]
+
+    res_list2 = _convert_nested_family_payload(
+        family=fam,
+        payload=[item],
+        source_label="v1",
+        target_label="v1",
+    )
+    assert res_list2 == [item]
+
+    # tuple unchanged
+    res_tup1 = _convert_nested_child_family(
+        payload=(item,),
+        path=(),
+        family=fam,
+        source_label="v1",
+        target_label="v1",
+    )
+    assert res_tup1 == (item,)
+    res_tup2 = _convert_nested_family_payload(
+        family=fam,
+        payload=(item,),
+        source_label="v1",
+        target_label="v1",
+    )
+    assert res_tup2 == (item,)
+
+
+def test_runtime_nested_migration_none_transitions_and_metadata_alias() -> None:
+    from pydantic import Field
+
+    from pydantic_versions._runtime import (
+        _convert_nested_family_payload,
+        _infer_metadata_owner,
+    )
+
+    class ModelWithAlias(BaseModel):
+        my_field: str = Field(alias="ver")
+
+    assert _infer_metadata_owner(ModelWithAlias, "ver") == "model"
+
+    class ChildModel(BaseModel):
+        val: int = 1
+
+    fam = SchemaFamily(
+        model=ChildModel,
+        name="none-trans-child",
+        versions=(SchemaVersion("v1"), SchemaVersion("v2"), SchemaVersion("v3")),
+        transitions=(
+            VersionTransition(
+                "v1",
+                "v2",
+                upgrade=None,
+                downgrade=lambda p: p,
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "v2",
+                "v3",
+                upgrade=lambda p: p,
+                downgrade=None,
+                downgrade_semantics=None,
+            ),
+        ),
+    )
+
+    item = {"schema_version": "v1", "val": 1}
+
+    # upgrade v1 -> v3 with None upgrade
+    res_up = _convert_nested_family_payload(
+        family=fam,
+        payload=item,
+        source_label="v1",
+        target_label="v3",
+    )
+    assert res_up is not None
+
+    item3 = {"schema_version": "v3", "val": 1}
+    # downgrade v3 -> v1 with None downgrade
+    res_down = _convert_nested_family_payload(
+        family=fam,
+        payload=item3,
+        source_label="v3",
+        target_label="v1",
+    )
+    assert res_down is not None
+
+
+def test_compiler_patch_validation_errors() -> None:
+
+    from pydantic_versions._compiler import _snapshot_field_default, _validate_patches
+    from pydantic_versions.patches import FieldDefault
+
+    class Base(BaseModel):
+        val: int = 1
+
+    with pytest.raises(SchemaCompilationError, match="Unsupported patch declaration"):
+        _validate_patches(Base, "v1", (cast(Any, "not_a_patch"),))
+
+    with pytest.raises(SchemaCompilationError, match="Patch field names for version"):
+        _validate_patches(Base, "v1", (FieldDefault(name="", default=1),))
+
+    with pytest.raises(SchemaCompilationError, match="cannot be copied into the compiled plan"):
+        _snapshot_field_default(FieldDefault(name="val", default=CopyError()), version="v1")
+
+
+def test_wire_grouped_metadata_and_schema_hook_type_alias() -> None:
+    from typing import Annotated
+
+    from annotated_types import GroupedMetadata
+
+    class CustomGroupedMetadata(GroupedMetadata):
+        def __iter__(self) -> Any:
+            yield self
+
+    GroupedAlias = TypeAliasType(  # noqa: N806, UP040
+        "GroupedAlias", Annotated[int, CustomGroupedMetadata()]
+    )
+
+    class ModelGrouped(BaseModel):
+        val: GroupedAlias
+
+    fam_grouped = SchemaFamily(
+        model=ModelGrouped,
+        name="grouped-alias",
+        versions=(SchemaVersion("v1"),),
+    )
+    with pytest.raises(
+        UnsupportedWireModelError, match="executable metadata hidden in a type alias"
+    ):
+        fam_grouped.model_for("v1")
+
+    class CustomSchemaHook:
+        def __get_pydantic_core_schema__(self, source_type: Any, handler: Any) -> Any:
+            return handler(source_type)
+
+    HookAlias = TypeAliasType(  # noqa: N806, UP040
+        "HookAlias", Annotated[int, CustomSchemaHook()]
+    )
+
+    class ModelHook(BaseModel):
+        val: HookAlias
+
+    fam_hook = SchemaFamily(
+        model=ModelHook,
+        name="hook-alias",
+        versions=(SchemaVersion("v1"),),
+    )
+    with pytest.raises(
+        UnsupportedWireModelError, match="custom schema metadata hidden in a type alias"
+    ):
+        fam_hook.model_for("v1")
+
+
+def test_wire_decorator_child_mismatch_and_set_element() -> None:
+    from pydantic_versions._wire import _set_element_wire_model
+
+    class FrozenModel(BaseModel):
+        model_config = ConfigDict(frozen=True)
+        val: int
+
+    assert _set_element_wire_model(FrozenModel) is FrozenModel

--- a/tests/unit/test_schema_family.py
+++ b/tests/unit/test_schema_family.py
@@ -464,10 +464,6 @@ def test_compatibility_declarations_reject_coercion_and_nonterminal_current() ->
             VersionTransition("1", "2", upgrade=_identity, downgrade_semantics="exact"),
             SchemaCompilationError,
         ),
-        (
-            VersionTransition("1", "2", downgrade=_identity),
-            SchemaCompilationError,
-        ),
     ],
 )
 def test_transition_topology_is_validated(
@@ -484,6 +480,28 @@ def test_transition_topology_is_validated(
             versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
             transitions=(transition,),
         )
+
+
+def test_downgrade_only_transitions_are_accepted_when_declared_explicitly() -> None:
+    class DowngradeConfig(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=DowngradeConfig,
+        name="downgrade_only",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=_identity,
+                downgrade_semantics="lossy",
+            ),
+        ),
+    )
+
+    assert family.describe().transitions[0].downgrade == "custom"
+    assert family.plan_render("1").semantics == "lossy"
 
 
 def test_duplicate_transition_edge_is_rejected() -> None:
@@ -540,12 +558,13 @@ def test_future_declarations_are_rejected_instead_of_ignored() -> None:
         ),
     )
 
-    with pytest.raises(SchemaCompilationError, match="Explicit wire models"):
-        wire_family.compile()
-    with pytest.raises(SchemaCompilationError, match="nested family"):
+    wire_family.compile()
+    with pytest.raises(SchemaCompilationError, match="same owning model"):
         nested_family.compile()
-    with pytest.raises(SchemaCompilationError, match="Downgrade execution"):
-        downgrade_family.compile()
+    downgrade_family.compile()
+
+    assert wire_family.describe().versions[0].wire_model == "explicit"
+    assert wire_family.model_for("1") is HistoricalConfig
 
 
 def test_current_and_mutually_exclusive_wire_declarations_are_rejected() -> None:

--- a/tests/unit/test_versioned_schema.py
+++ b/tests/unit/test_versioned_schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Mapping
 from typing import Any, cast
 
 import pytest
@@ -17,14 +18,20 @@ from pydantic import (
 from pydantic_versions import (
     DuplicateSchemaVersionError,
     InvalidMigrationError,
+    IrreversibleTransitionError,
     MissingSchemaVersionError,
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
     SchemaVersionError,
     UnknownSchemaVersionError,
     UnsupportedWireModelError,
+    VersionTransition,
     dump_versioned,
     field_default,
     field_removed,
     field_renamed,
+    matching_labels,
     migration,
     model_for_version,
     schema_version,
@@ -60,6 +67,10 @@ class AppConfig(BaseModel):
 def migrate_v1_to_v2(data: dict) -> dict:
     data["new_feature"] = data["retries"] > 1
     return data
+
+
+def _to_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+    return dict(data)
 
 
 class PlainModel(BaseModel):
@@ -176,33 +187,177 @@ def test_validate_versioned_normalizes_alias_paths_in_upgrade_output() -> None:
 
 
 def test_dump_versioned_renders_defaults_for_requested_schema() -> None:
-    assert dump_versioned(AppConfig, version="1") == {
-        "timeout": 5.0,
-        "attempts": 3,
-        "schema_version": "1",
-    }
+    with pytest.raises(IrreversibleTransitionError):
+        dump_versioned(AppConfig, version="1")
+
+
+def test_dump_versioned_executes_explicit_downgrades_in_reverse_edge_order() -> None:
+    order: list[str] = []
+
+    def downgrade_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        order.append("3->2")
+        return {"value": data["value"], "marker": data["marker"]}
+
+    def downgrade_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        order.append("2->1")
+        return {"value": data["value"] * 2, "marker": data["marker"]}
+
+    @versioned_schema(
+        name="downgrade_chain_render",
+        versions=["1", "2", "3"],
+        current="3",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade_to_one,
+                downgrade_semantics="lossy",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                downgrade=downgrade_to_two,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    @schema_version("1", patches=[field_renamed("value", "legacy_value")])
+    class DowngradeChainRender(BaseModel):
+        value: int = 10
+        marker: int = 4
+
+    result = dump_versioned(
+        DowngradeChainRender,
+        version="1",
+        data=DowngradeChainRender(value=2, marker=5),
+    )
+
+    assert result["legacy_value"] == 4
+    assert result["marker"] == 5
+    assert result["schema_version"] == "1"
+    assert order == ["2->1", "3->2"]
+
+
+def test_dump_versioned_rejects_irreversible_render_routes() -> None:
+    @versioned_schema(
+        name="irreversible_chain_render",
+        versions=["1", "2"],
+        current="2",
+    )
+    class IrreversibleRenderConfig(BaseModel):
+        value: int
+
+    @migration(IrreversibleRenderConfig, "1", "2")
+    def migrate_value_up(data: dict[str, Any]) -> dict[str, Any]:
+        return {"value": data["value"]}
+
+    with pytest.raises(IrreversibleTransitionError):
+        dump_versioned(
+            IrreversibleRenderConfig,
+            version="1",
+            data=IrreversibleRenderConfig(value=1),
+        )
+
+
+def test_explicit_wire_model_enables_typeful_historical_rendering_and_validation() -> None:
+    class HistoricalTimeoutConfig(BaseModel):
+        timeout: str
+
+    def upgrade_timeout(data: dict[str, Any]) -> dict[str, Any]:
+        return {"timeout": float(data["timeout"])}
+
+    def downgrade_timeout(data: dict[str, Any]) -> dict[str, Any]:
+        return {"timeout": str(data["timeout"])}
+
+    @versioned_schema(
+        name="historical_wire_type_change",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=upgrade_timeout,
+                downgrade=downgrade_timeout,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    @schema_version("1", wire_model=HistoricalTimeoutConfig)
+    class HistoricalTypeConfig(BaseModel):
+        timeout: float = 2.5
+
+    validated = validate_versioned(
+        HistoricalTypeConfig,
+        {"schema_version": "1", "timeout": "12.75"},
+    )
+    assert validated.source_model.model_dump()["timeout"] == "12.75"
+    assert validated.current_model.timeout == 12.75
+
+    rendered = dump_versioned(
+        HistoricalTypeConfig,
+        version="1",
+        data=HistoricalTypeConfig(timeout=9.5),
+    )
+
+    assert rendered == {"timeout": "9.5", "schema_version": "1"}
+    assert model_for_version(HistoricalTypeConfig, "1") is HistoricalTimeoutConfig
 
 
 def test_dump_versioned_accepts_current_model_data_for_historical_schema() -> None:
+    @versioned_schema(
+        name="historical_dump_accepts_current_model_data",
+        versions=["1", "2"],
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    @schema_version("1")
+    class ReversibleHistorical(BaseModel):
+        value: int = 10
+
     dumped = dump_versioned(
-        AppConfig,
+        ReversibleHistorical,
         version="1",
-        data=AppConfig(timeout=7.5, retries=6, new_feature=True),
+        data=ReversibleHistorical(value=7),
         include_version=False,
     )
 
-    assert dumped == {"timeout": 7.5, "attempts": 6}
+    assert dumped == {"value": 7}
 
 
 def test_dump_versioned_accepts_mapping_data_for_historical_schema() -> None:
+    @versioned_schema(
+        name="historical_dump_accepts_mapping_data",
+        versions=["1", "2"],
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    @schema_version("1")
+    class ReversibleHistorical(BaseModel):
+        value: int = 10
+
     dumped = dump_versioned(
-        AppConfig,
+        ReversibleHistorical,
         version="1",
-        data={"timeout": 6.5, "retries": 5, "new_feature": True},
+        data={"value": 6},
         include_version=False,
     )
 
-    assert dumped == {"timeout": 6.5, "attempts": 5}
+    assert dumped == {"value": 6}
 
 
 def test_dump_versioned_normalizes_alias_paths_and_choices_in_input() -> None:
@@ -226,9 +381,26 @@ def test_dump_versioned_normalizes_alias_paths_and_choices_in_input() -> None:
 
 
 def test_dump_versioned_rejects_non_mapping_data() -> None:
-    with pytest.raises(ValidationError):
+    @versioned_schema(
+        name="historical_dump_rejects_non_mapping",
+        versions=["1", "2"],
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    @schema_version("1")
+    class ReversibleHistorical(BaseModel):
+        value: int = 10
+
+    with pytest.raises((TypeError, ValueError)):
         dump_versioned(
-            AppConfig,
+            ReversibleHistorical,
             version="1",
             data=cast(Any, ["not", "a", "mapping"]),
         )
@@ -747,3 +919,296 @@ def test_nested_family_metadata_defaults_are_normalized_without_user_factories()
         "child": {"value": 1, "meta": {"version": "1"}},
         "schema_version": "1",
     }
+
+
+def test_nested_runtime_migrations_execute_before_parent_migrations_for_validation() -> None:
+    events: list[str] = []
+
+    def child_migrate_up_from_one_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child 1->2 0")
+        return {"value": data["value"] + 1}
+
+    def child_migrate_up_from_two_to_three(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child 2->3 0")
+        return {"value": data["value"] + 10}
+
+    def parent_migrate_up_from_one_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent 1->2")
+        return {**data, "value": data["value"] + 100}
+
+    def parent_migrate_up_from_two_to_three(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent 2->3")
+        return {**data, "value": data["value"] + 1000}
+
+    class NestedChild(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=NestedChild,
+        name="nested_issue11_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition("1", "2", upgrade=child_migrate_up_from_one_to_two),
+            VersionTransition("2", "3", upgrade=child_migrate_up_from_two_to_three),
+        ),
+        missing_version="1",
+    )
+
+    class NestedParent(BaseModel):
+        value: int
+        children: list[NestedChild]
+
+    parent_family = SchemaFamily(
+        model=NestedParent,
+        name="nested_issue11_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition("1", "2", upgrade=parent_migrate_up_from_one_to_two),
+            VersionTransition("2", "3", upgrade=parent_migrate_up_from_two_to_three),
+        ),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+        missing_version="1",
+    )
+
+    result = validate_versioned(
+        parent_family,
+        {"schema_version": "1", "value": 1, "children": [{"value": 1}, {"value": 2}]},
+    )
+
+    assert result.current_model.value == 1101
+    assert [child.value for child in result.current_model.children] == [12, 13]
+    assert events == [
+        "child 1->2 0",
+        "child 1->2 0",
+        "parent 1->2",
+        "child 2->3 0",
+        "child 2->3 0",
+        "parent 2->3",
+    ]
+
+
+def test_nested_runtime_migrations_execute_before_parent_migrations_for_rendering() -> None:
+    events: list[str] = []
+
+    def child_migrate_up_from_one_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        return {"value": data["value"] + 1}
+
+    def child_migrate_up_from_two_to_three(data: dict[str, Any]) -> dict[str, Any]:
+        return {"value": data["value"] + 10}
+
+    def parent_migrate_up_from_one_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 100}
+
+    def parent_migrate_up_from_two_to_three(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 1000}
+
+    def child_migrate_down_from_two_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child 2->1 0")
+        return {"value": data["value"] - 1}
+
+    def child_migrate_down_from_three_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child 3->2 0")
+        return {"value": data["value"] - 10}
+
+    def parent_migrate_down_from_two_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent 2->1")
+        return {**data, "value": data["value"] - 100}
+
+    def parent_migrate_down_from_three_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent 3->2")
+        return {**data, "value": data["value"] - 1000}
+
+    class NestedChild(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=NestedChild,
+        name="nested_issue11_child_downgrade",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=child_migrate_up_from_one_to_two,
+                downgrade=child_migrate_down_from_two_to_one,
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                upgrade=child_migrate_up_from_two_to_three,
+                downgrade=child_migrate_down_from_three_to_two,
+                downgrade_semantics="exact",
+            ),
+        ),
+        missing_version="1",
+    )
+
+    class NestedParent(BaseModel):
+        value: int
+        children: list[NestedChild]
+
+    parent_family = SchemaFamily(
+        model=NestedParent,
+        name="nested_issue11_parent_downgrade",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=parent_migrate_up_from_one_to_two,
+                downgrade=parent_migrate_down_from_two_to_one,
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                upgrade=parent_migrate_up_from_two_to_three,
+                downgrade=parent_migrate_down_from_three_to_two,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+        missing_version="1",
+    )
+    current_payload = parent_family.model_for("3").model_validate(
+        {"value": 111, "children": [{"value": 12}, {"value": 13}]},
+    )
+    rendered = dump_versioned(cast(Any, parent_family), version="1", data=current_payload)
+
+    assert rendered == {
+        "value": -989,
+        "children": [{"value": 1}, {"value": 2}],
+        "schema_version": "1",
+    }
+    assert events == [
+        "child 3->2 0",
+        "child 3->2 0",
+        "parent 3->2",
+        "child 2->1 0",
+        "child 2->1 0",
+        "parent 2->1",
+    ]
+
+
+def test_nested_runtime_handles_set_tuple_and_frozenset_payloads() -> None:
+    def child_migrate_to_current(data: dict[str, Any]) -> dict[str, Any]:
+        return {"value": data["value"] + 1}
+
+    def child_migrate_to_historical(data: dict[str, Any]) -> dict[str, Any]:
+        return {"value": data["value"] - 1}
+
+    class NestedCollectionChild(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=NestedCollectionChild,
+        name="nested_collection_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=child_migrate_to_current,
+                downgrade=child_migrate_to_historical,
+                downgrade_semantics="exact",
+            ),
+        ),
+        missing_version="1",
+    )
+
+    class NestedCollectionParent(BaseModel):
+        values: set[NestedCollectionChild]
+        tuple_values: tuple[NestedCollectionChild, ...]
+        frozenset_values: frozenset[NestedCollectionChild]
+        value: int = 2
+
+    parent_family = SchemaFamily(
+        model=NestedCollectionParent,
+        name="nested_collection_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=lambda data: {**data, "value": data["value"] + 10},
+                downgrade=lambda data: {**data, "value": data["value"] - 10},
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(
+            NestedFamily("values", child_family, matching_labels()),
+            NestedFamily("tuple_values", child_family, matching_labels()),
+            NestedFamily("frozenset_values", child_family, matching_labels()),
+        ),
+        missing_version="1",
+    )
+
+    current_payload = parent_family.model_for("2").model_validate(
+        {
+            "schema_version": "2",
+            "values": [
+                {"schema_version": "2", "value": 2},
+                {"schema_version": "2", "value": 3},
+            ],
+            "tuple_values": [
+                {"schema_version": "2", "value": 4},
+                {"schema_version": "2", "value": 5},
+            ],
+            "frozenset_values": [
+                {"schema_version": "2", "value": 6},
+            ],
+            "value": 20,
+        },
+    )
+
+    rendered = dump_versioned(cast(Any, parent_family), version="1", data=current_payload)
+
+    assert rendered["value"] == 10
+    assert len(rendered["values"]) == 2
+    assert len(rendered["tuple_values"]) == 2
+    assert len(rendered["frozenset_values"]) == 1
+    assert all(item["schema_version"] == "1" for item in rendered["values"])
+    assert all(item["schema_version"] == "1" for item in rendered["tuple_values"])
+    assert all(item["schema_version"] == "1" for item in rendered["frozenset_values"])
+
+
+def test_nested_runtime_set_conversion_preserves_collection_membership_or_raises() -> None:
+    def child_migrate_down(data: dict[str, Any]) -> dict[str, Any]:
+        return {"value": 1}
+
+    def parent_migrate_down(data: dict[str, Any]) -> dict[str, Any]:
+        return data
+
+    class DuplicateNestedChild(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=DuplicateNestedChild,
+        name="nested_set_collision_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition("1", "2", downgrade=child_migrate_down, downgrade_semantics="exact"),
+        ),
+        missing_version="1",
+    )
+
+    class DuplicateNestedParent(BaseModel):
+        items: set[DuplicateNestedChild]
+
+    parent_family = SchemaFamily(
+        model=DuplicateNestedParent,
+        name="nested_set_collision_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition("1", "2", downgrade=parent_migrate_down, downgrade_semantics="exact"),
+        ),
+        nested=(NestedFamily("items", child_family, matching_labels()),),
+        missing_version="1",
+    )
+
+    current_payload = parent_family.model_for("2").model_validate(
+        {"schema_version": "2", "items": [{"value": 3}, {"value": 4}]},
+    )
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        dump_versioned(cast(Any, parent_family), version="1", data=current_payload)


### PR DESCRIPTION
## Summary

Align nested runtime and wire behavior for deterministic parent/child migration ordering across parent and child families.

Key changes:
- Ensure child family runtime migrations execute prior to parent family migrations during validation and rendering.
- Apply explicit downgrade and irreversibility semantics when rendering historical target versions.
- Support explicit historical wire models for complex type changes across schema versions.
- Handle and validate container payload types including list, tuple, set, and frozenset collections.
- Add conventional commit message CI validation workflow.
- Expand unit test coverage to 95.15% across wire, runtime, and compiler modules.

Branch: feat/issue-8-nested-plans

## Related

Closes #8
Closes #9
Closes #10
Closes #11
Closes #12

Note: Umbrella issue #2 remains open until #13 (prerelease hardening) is complete.

## Validation

- uv run make ci: passed (235 unit tests, 95.15% statement coverage)
- All 10 GitHub Actions CI jobs green