### PR TITLE
build(release): prepare 0.2.0rc1 for prerelease testing

### DIFF
--- a/.gemini/rules/agents.md
+++ b/.gemini/rules/agents.md
@@ -1,0 +1,102 @@
+# Git Commit Message Rules
+
+## Critical: How to Create Commit Messages
+
+**NEVER use multiple `-m` flags** to build multi-line commit messages. Each `-m`
+creates a separate paragraph with a blank line before it, producing malformed
+messages with double-spacing between every line.
+
+**ALWAYS write the commit message to a temporary file** and use `git commit -F <path>`:
+
+```bash
+# Write message to a temp file first
+cat > /tmp/commit_msg.txt << 'EOF'
+feat(scope): short imperative summary
+
+Body paragraph that explains the change. Wrap prose at 72 characters
+so terminal history stays readable.
+
+Key changes:
+- First change description, wrapped at 72 chars if needed to keep
+  lines from running too long.
+- Second change description.
+
+Validation: uv run make ci: passed
+EOF
+
+# Then commit using the file
+git commit -F /tmp/commit_msg.txt
+# Or amend:
+git commit --amend -F /tmp/commit_msg.txt
+```
+
+## Format
+
+Follow Conventional Commits. The header format is:
+
+```
+<type>(<optional scope>): <imperative summary>
+```
+
+Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+`refactor`, `revert`, `style`, `test`.
+
+## Structure
+
+```
+<type>(<scope>): <summary, <=72 chars>
+                                          <- blank line
+Body prose explaining the change and why it is needed. Wrap at 72
+characters. No blank lines between continuation lines of the same
+paragraph.
+                                          <- blank line
+Key changes:                              <- optional structured list
+- First item, can wrap to the next line
+  with 2-space indent.
+- Second item.
+                                          <- blank line
+Validation: uv run make ci: passed        <- required
+```
+
+## Rules Enforced by CI
+
+The script `scripts/check_conventional_commits.py` runs in CI and checks:
+
+1. **Header**: Must match `<type>(<scope>): <summary>` or `<type>: <summary>`.
+2. **Line length**: All prose lines must be **<= 72 characters**.
+3. **Body**: Must contain at least **8 prose words** (excluding headings,
+   validation lines, metadata, and trailers).
+4. **Validation line**: Must include validation evidence such as
+   `uv run make ci: passed` or `Validation: not run because <reason>`.
+
+Run locally before pushing:
+
+```bash
+python scripts/check_conventional_commits.py --range origin/main..HEAD
+```
+
+## Self-Documenting Commits
+
+Commit messages must be **self-documenting** and portable. A reader of
+`git log` must understand what the commit does without accessing GitHub.
+
+- **Do NOT** put `Closes #N` or issue references in commit messages.
+  Those belong in the **PR description only** (a GitHub construct).
+- **Do** describe the actual changes in plain English in the body.
+- **Do NOT** repeat the subject line as the body.
+- **Do NOT** leave template tokens or placeholder text.
+
+## Squashing
+
+When a PR contains fixups, CI repairs, or review iterations, squash them
+into the logical commit they belong to before merge. Use:
+
+```bash
+git reset --soft origin/main
+git commit -F /tmp/commit_msg.txt
+```
+
+Or interactive rebase for multi-commit PRs.
+
+Push rewritten history with `--force-with-lease`, never unconditional
+`--force`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,10 @@ jobs:
           VENV_DIR="$RUNNER_TEMP/built-package-typing-venv"
           CONSUMER_DIR="$RUNNER_TEMP/built-package-typing-consumer"
           uv venv --python 3.12 "$VENV_DIR"
-          uv pip install --python "$VENV_DIR/bin/python" "${WHEELS[0]}"
+          uv pip install --python "$VENV_DIR/bin/python" "${WHEELS[0]}" pytest
           mkdir -p "$CONSUMER_DIR"
           cp tests/typing/schema_family_contract.py "$CONSUMER_DIR/"
+          cp tests/integration/test_consumer_scenario.py "$CONSUMER_DIR/"
 
           cd "$RUNNER_TEMP"
           "$GITHUB_WORKSPACE/.venv/bin/ty" check \
@@ -221,6 +222,7 @@ jobs:
             --project "$CONSUMER_DIR" \
             "$CONSUMER_DIR/schema_family_contract.py"
           "$VENV_DIR/bin/python" "$CONSUMER_DIR/schema_family_contract.py"
+          "$VENV_DIR/bin/python" -m pytest "$CONSUMER_DIR/test_consumer_scenario.py"
           "$VENV_DIR/bin/python" - <<'PY'
           import os
           from pathlib import Path

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0rc1 - 2026-07-23
 
 - Defined generated current and historical models as object-shaped Pydantic v2
   wire contracts, with explicit preservation and behavior boundaries, exact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic-versions"
-version = "0.1.0"
+version = "0.2.0rc1"
 description = "Bring version control and history to your Pydantic schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/integration/test_consumer_scenario.py
+++ b/tests/integration/test_consumer_scenario.py
@@ -1,0 +1,74 @@
+import pytest
+from pydantic import BaseModel
+
+from pydantic_versions import (
+    SchemaFamily,
+    SchemaVersion,
+    VersionTransition,
+    dump_versioned,
+    field_default,
+    validate_versioned,
+)
+
+
+class AppConfig(BaseModel):
+    timeout: float = 10.0
+
+
+def upgrade_v1_to_v2(data: dict) -> dict:
+    data.setdefault("timeout", 5.0)
+    return data
+
+
+def downgrade_v2_to_v1(data: dict) -> dict:
+    return data
+
+
+APP_CONFIG_SCHEMA = SchemaFamily(
+    model=AppConfig,
+    name="app_config",
+    versions=(
+        SchemaVersion("1", patches=(field_default("timeout", 5.0),)),
+        SchemaVersion("2"),
+    ),
+    transitions=(
+        VersionTransition(
+            "1",
+            "2",
+            upgrade=upgrade_v1_to_v2,
+            downgrade=downgrade_v2_to_v1,
+            downgrade_semantics="exact",
+        ),
+    ),
+)
+
+
+def test_consumer_scenario_validate_current_version() -> None:
+    data = {"schema_version": "2", "timeout": 15.5}
+    validated = validate_versioned(APP_CONFIG_SCHEMA, data)
+    assert validated.current_model.timeout == 15.5
+    assert validated.source_version == "2"
+
+
+def test_consumer_scenario_validate_historical_version() -> None:
+    # Notice that v1 is missing "timeout" and we expect our upgrade_v1_to_v2
+    # to add a default of 5.0 if it's missing (though Pydantic does that too
+    # due to field_default). Let's test the explicit upgrade logic.
+    data = {"schema_version": "1"}
+    validated = validate_versioned(APP_CONFIG_SCHEMA, data)
+    assert validated.current_model.timeout == 5.0
+    assert validated.source_version == "1"
+
+
+def test_consumer_scenario_dump_historical_version() -> None:
+    current_config = AppConfig(timeout=25.0)
+    rendered = dump_versioned(APP_CONFIG_SCHEMA, version="1", data=current_config)
+    assert rendered == {"schema_version": "1", "timeout": 25.0}
+
+
+def test_consumer_scenario_missing_version_raises_error() -> None:
+    # If the payload lacks schema_version, it should raise
+    from pydantic_versions.exceptions import MissingSchemaVersionError
+
+    with pytest.raises(MissingSchemaVersionError):
+        validate_versioned(APP_CONFIG_SCHEMA, {"timeout": 10.0})

--- a/tests/unit/test_django_ninja_compat.py
+++ b/tests/unit/test_django_ninja_compat.py
@@ -29,6 +29,9 @@ from pydantic import BaseModel
 django.setup()
 
 from pydantic_versions import (  # noqa: E402
+    SchemaFamily,
+    SchemaVersion,
+    VersionTransition,
     dump_versioned,
     field_default,
     field_renamed,
@@ -365,9 +368,6 @@ create_model_task_v1.__annotations__["payload"] = TaskModelPayloadV1
 api.post("/v1/model-tasks")(create_model_task_v1)
 
 
-urlpatterns = [path("api/", api.urls)]
-
-
 def test_generated_model_schema_works_as_real_ninja_request_body() -> None:
     response = Client().post(
         "/api/v1/model-tasks",
@@ -395,3 +395,80 @@ def test_ninja_openapi_uses_generated_historical_model_schema() -> None:
     assert payload_schema["properties"]["title"]["maxLength"] == 100
     assert "completed" in payload_schema["properties"]
     assert "is_done" not in payload_schema["properties"]
+
+
+class ExternalFamilyConfig(BaseModel):
+    timeout: float = 10.0
+
+
+def upgrade_v1_to_v2_external(data: dict) -> dict:
+    data.setdefault("timeout", 5.0)
+    return data
+
+
+def downgrade_v2_to_v1_external(data: dict) -> dict:
+    return data
+
+
+EXTERNAL_FAMILY_SCHEMA = SchemaFamily(
+    model=ExternalFamilyConfig,
+    name="ninja_external_payload",
+    versions=(
+        SchemaVersion("1", patches=(field_default("timeout", 5.0),)),
+        SchemaVersion("2"),
+    ),
+    transitions=(
+        VersionTransition(
+            "1",
+            "2",
+            upgrade=upgrade_v1_to_v2_external,
+            downgrade=downgrade_v2_to_v1_external,
+            downgrade_semantics="exact",
+        ),
+    ),
+)
+
+
+ExternalPayloadV1 = EXTERNAL_FAMILY_SCHEMA.model_for("1")
+
+
+def create_external_task_v1(request, payload):
+    result = validate_versioned(EXTERNAL_FAMILY_SCHEMA, payload.model_dump(), version="1")
+    return {
+        "version": result.source_version,
+        "timeout": result.current_model.timeout,
+    }
+
+
+create_external_task_v1.__annotations__["payload"] = ExternalPayloadV1
+api.post("/v1/external-tasks")(create_external_task_v1)
+
+
+def test_ninja_openapi_uses_external_family_historical_schema() -> None:
+    openapi = api.get_openapi_schema()
+    request_schema = openapi["paths"]["/api/v1/external-tasks"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    ref_name = request_schema["$ref"].split("/")[-1]
+    payload_schema = openapi["components"]["schemas"][ref_name]
+
+    assert payload_schema["properties"]["timeout"]["default"] == 5.0
+    assert "schema_version" in payload_schema["properties"]
+    assert payload_schema["properties"]["schema_version"]["const"] == "1"
+
+
+def test_external_family_schema_works_as_real_ninja_request_body() -> None:
+    response = Client().post(
+        "/api/v1/external-tasks",
+        data=json.dumps({"schema_version": "1"}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "version": "1",
+        "timeout": 5.0,
+    }
+
+
+urlpatterns = [path("api/", api.urls)]

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-versions"
-version = "0.1.0"
+version = "0.2.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
This PR implements the final required release hardening steps before the 0.2.0rc1 prerelease.

### Key Changes
- **Consumer Integration Tests**: Created 	est_consumer_scenario.py using SchemaFamily to match our adoption guide, verified against the built package wheel in CI.
- **Django Ninja Integration**: Verified that explicitly generated models from SchemaFamily are seamlessly supported as Django Ninja request schemas and OpenAPI types.
- **Version Bump**: Bumped to 