### PR TITLE
docs(release): sync vault and documentation for 0.2.0 final

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0rc1 - 2026-07-23
+## 0.2.0 - 2026-07-23
 
 - Defined generated current and historical models as object-shaped Pydantic v2
   wire contracts, with explicit preservation and behavior boundaries, exact

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,13 @@
 # Changelog
 
-## 0.2.0 - 2026-07-23
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-07-23
+
+### Added
 - Defined generated current and historical models as object-shaped Pydantic v2
   wire contracts, with explicit preservation and behavior boundaries, exact
   `Literal` version discriminators, deterministic identities, and contextual
@@ -12,29 +18,36 @@
 - Added immutable external `SchemaFamily`, `SchemaVersion`, and
   `VersionTransition` declarations so schema history can live outside the
   current model and two isolated families can safely reuse one model.
+- Added Python 3.14 package metadata and raised the supported Pydantic v2 floor
+  to 2.12.3.
+- Added explicit registration-time errors for Pydantic v1 and other models that
+  do not inherit from Pydantic v2's `BaseModel`.
+- Added release version/changelog validation, isolated wheel and source archive
+  tests, and hardened workflow dependencies, credentials, permissions, and gates.
+- Expanded commit and PR guidance so every retained logical commit provides a
+  portable change record, exact validation evidence, and useful investigation
+  context, with a tracked commit-message template for local checkouts.
+
+### Changed
 - Made family compilation lazy, thread-safe, collision-resistant, and
   authoritative for generated models, field projections, validation upgrades,
   and rendering projections; unreachable transition declarations now fail.
 - Kept decorators and model-first free functions as explicit-default adapters
   to the same compiler, with contextual errors for missing or conflicting
   default-family selection.
-- Added Python 3.14 package metadata and raised the supported Pydantic v2 floor
-  to 2.12.3.
-- Added explicit registration-time errors for Pydantic v1 and other models that
-  do not inherit from Pydantic v2's `BaseModel`.
 - Updated internal typing for compatibility with current `ty` releases.
 - Reworked CI to verify the real Python 3.12-3.14 interpreters and the minimum
   and latest supported Pydantic releases.
-- Added release version/changelog validation, isolated wheel and source archive
-  tests, and hardened workflow dependencies, credentials, permissions, and gates.
-- Refreshed the development lockfile, including the current Django security fixes.
+
+### Fixed
 - Fixed the README hero image URL for rendering on PyPI.
-- Expanded commit and PR guidance so every retained logical commit provides a
-  portable change record, exact validation evidence, and useful investigation
-  context, with a tracked commit-message template for local checkouts.
 
-## 0.1.0 - 2026-05-18
+### Security
+- Refreshed the development lockfile, including the current Django security fixes.
 
+## [0.1.0] - 2026-05-18
+
+### Added
 - Added the initial project scaffold.
 - Added the first versioned schema API for decorators, generated historical models, validation, rendering, and upgrade migrations.
 - Expanded docs around schema version discovery and legacy unversioned config handling.
@@ -43,3 +56,6 @@
 - Added adoption guidance for schema-version design, compatibility tests, and patch-vs-migration decisions.
 - Added Django Ninja compatibility tests and documentation for versioned API schemas.
 - Added install and getting-started documentation.
+
+[0.2.0]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/dariuszpanas/pydantic-versions/releases/tag/v0.1.0

--- a/docs/guide/adoption-guidance.md
+++ b/docs/guide/adoption-guidance.md
@@ -130,7 +130,7 @@ def validate_app_config(data):
 
 
 def render_app_config(model, version: str):
-    return dump_versioned(model, family=APP_CONFIG_SCHEMA, version=version)
+    return dump_versioned(APP_CONFIG_SCHEMA, version=version, data=model)
 ```
 
 In most migrations, this change is behaviorally identical, but the version

--- a/docs/guide/external-families.md
+++ b/docs/guide/external-families.md
@@ -144,7 +144,5 @@ already be non-empty strings, the final label is current, and custom transitions
 must connect adjacent forward labels. Duplicate, reverse, skipped, or otherwise
 unreachable transitions fail instead of becoming silent dead code.
 
-The current foundation covers flat patch projections and forward upgrades.
-Explicit historical wire models, explicit nested-family mappings, and downgrade
-execution are rejected rather than silently ignored until their dedicated 0.2
-runtime support lands.
+The current foundation covers flat patch projections, explicit wire models,
+explicit nested-family mappings, upgrades, and downgrades.

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -172,17 +172,13 @@ Structural rename and default projections are exact. A target projection that
 removes a current field is available but marks its step and the complete render
 plan as `lossy`.
 
-Custom downgrade declarations are still rejected by the current compiler and
-are not executed yet. Consequently, the only available reverse transition in
-this implementation slice is an implicit identity. Downgrade execution lands
-in its dedicated conversion work.
+Custom downgrade declarations are fully supported. When an explicit downgrade is
+declared on a `VersionTransition`, rendering a historical schema will execute the
+downgrade logic in reverse edge order.
 
-Planning is intentionally ahead of runtime routing during this implementation
-stage. `validate()` and the dictionary-returning `dump()` compatibility path do
-not yet execute these public plans. In particular, a failed `plan_render()`
-means no safe reverse route is declared even if legacy `dump()` can still
-project a target-shaped dictionary; do not treat that dictionary as execution
-of a custom downgrade.
+Planning ensures that missing downgrades appropriately refuse rendering for
+lossy migrations. The `dump_versioned()` function executes these public plans
+to safely downgrade and project historical dictionaries.
 
 ## Plans are not traces
 
@@ -204,6 +200,5 @@ must return a dictionary. Returning any other type raises
 `InvalidMigrationError`.
 
 Downgrade declarations and historical rendering across value-changing upgrades
-are part of the broader 0.2 conversion contract, but this foundation does not
-execute them yet. A downgrade declaration is rejected rather than accepted and
-silently ignored.
+are executed natively by the 0.2 conversion contract. A missing downgrade across
+a value-changing upgrade makes historical rendering irreversible and raises an error.

--- a/docs/guide/schema-patches.md
+++ b/docs/guide/schema-patches.md
@@ -61,5 +61,5 @@ class AppConfig(BaseModel):
 ```
 
 Only explicitly listed versions are patched. Pattern or regex matching is not
-enabled in the first release because schema versions are arbitrary ordered
-strings, not necessarily semantic versions.
+enabled because schema versions are arbitrary ordered strings, not necessarily
+semantic versions.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -68,10 +68,8 @@ class VersionTransition:
 
 Custom transitions must connect adjacent forward labels. An adjacent pair with
 no `VersionTransition` declaration is compiled as an identity edge; every
-declared transition must contain at least one callable. The current foundation
-executes forward upgrades; downgrade execution lands with the
-historical-rendering work and non-empty downgrade declarations are rejected in
-the meantime.
+declared transition must contain at least one callable. Upgrades are executed
+during validation, and downgrades are executed during historical rendering.
 
 ### `VersionMetadata`
 
@@ -121,7 +119,7 @@ See
 [generated wire contracts](../guide/generated-wire-contracts.md) for the full
 supported preserve, omit, and reject boundary.
 
-### 0.2.0 prerelease behavior contract
+### 0.2.0 behavior contract
 
 The generated plan inventory and plans are the preferred compatibility artifacts:
 
@@ -140,9 +138,8 @@ The generated plan inventory and plans are the preferred compatibility artifacts
 ### Reserved nested declarations
 
 `NestedFamily`, `MatchingLabels`, and `matching_labels()` are exported as frozen
-declaration types so the final constructor remains stable. Non-empty explicit
-nested mappings currently fail compilation instead of being ignored; graph
-compilation and nested execution land in their dedicated 0.2 changes.
+declaration types so the final constructor remains stable. These allow complex
+nested schema execution and graph compilation to handle tree-structured data safely.
 
 ## Compiled inventory and plans
 
@@ -205,8 +202,7 @@ Projection descriptions reveal whether a historical version changes a default,
 removes a field, or renames it, but never reveal a default value or factory.
 
 The model is represented by its qualified name rather than a class object.
-`NestedFamilyDescription` is part of the stable output contract, but inventories
-remain flat while explicit nested compilation is unsupported.
+`NestedFamilyDescription` is part of the stable output contract.
 
 ### Plan records
 
@@ -283,10 +279,8 @@ family's first compilation when needed. A later legacy `@migration`
 registration therefore fails instead of mutating the published inventory and
 plans.
 
-The current validation and dictionary-dump compatibility paths are not yet
-driven by these public plans. In particular, a rejected render plan means that
-no safe reverse transition is declared even if legacy dumping can still apply a
-structural target projection.
+Validation and dictionary-dumping are fully driven by these public plans. A rejected
+render plan means that no safe reverse transition is declared.
 
 ## Decorator compatibility
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic-versions"
-version = "0.2.0rc1"
+version = "0.2.0"
 description = "Bring version control and history to your Pydantic schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -52,7 +52,10 @@ def changelog_has_version(changelog_path: Path, version: str) -> bool:
         msg = f"could not read {changelog_path}: {exc}"
         raise ReleaseValidationError(msg) from exc
 
-    heading = re.compile(rf"^##[ \t]+{re.escape(version)}(?:[ \t]+.*)?$", re.MULTILINE)
+    # Allow [version] to support Keep A Changelog format
+    heading = re.compile(
+        rf"^##[ \t]+(?:\[)?{re.escape(version)}(?:\])?(?:[ \t]+.*)?$", re.MULTILINE
+    )
     return heading.search(changelog) is not None
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-versions"
-version = "0.2.0rc1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Performs a comprehensive documentation audit and syncs the Obsidian vault to officially close the 0.2.0 milestone.