### PR TITLE
feat(wire): omit excluded fields from projections

### DIFF
--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -25,12 +25,21 @@ Pydantic's declarative handling of that shape:
 | Omitted | Lifecycle-only configuration such as assignment validation and frozen instances | Generated models describe documents rather than application-object lifecycle behavior. |
 | Rejected | `RootModel`, an incomplete or unresolved generic model, or another non-object validation or serialization shape | Compilation raises `UnsupportedWireModelError`; resolve and rebuild an incomplete model, or wrap a root or scalar value in a named object field. |
 | Rejected | A model-level serializer, application-defined annotation or model schema hooks, behavioral dataclasses, callable schema/title mutation, non-JSON schema metadata, model schema metadata that replaces generated structure, legacy `json_encoders`, or arbitrary-type escape hatches | Automatic projection cannot safely reproduce that custom behavior and raises `UnsupportedWireModelError`. |
-| Rejected | Serialization exclusions such as `exclude`/`exclude_if`, callable discriminators, and unknown behavior-changing model or field settings | The automatic compiler fails closed instead of silently changing the wire document. |
+| Omitted | Server-internal fields marked with `Field(exclude=True)` or `Field(exclude_if=...)` | The field is absent from every generated wire projection; it remains available on the authoritative application model. |
+| Rejected | Callable discriminators and unknown behavior-changing model or field settings | The automatic compiler fails closed instead of silently changing the wire document. |
 | Rejected at registration | Pydantic v1 compatibility models | The family raises `SchemaVersionError` before automatic projection; wire models must inherit from Pydantic v2's `BaseModel`. |
 
 Historical patches are applied to this preserved declaration state. A removed
 field is absent, a renamed field uses its historical Python name, and a default
 patch replaces the projected field's required/default/factory state.
+
+An excluded field is also absent from the generated wire model. This is the
+supported way to keep server-internal state on the authoritative model while
+using that model as the source for a document contract. The exclusion is not
+copied as a Pydantic serialization option because doing so would leave the
+field present during wire validation. Conditional exclusions are treated the
+same way: the field is omitted unconditionally from generated projections.
+The configured model-owned version field may not be excluded.
 
 Zero-argument factories remain safe when the field annotation is unchanged. A
 decorator-owned child annotation can replace the child class itself as a
@@ -71,6 +80,13 @@ This is a statement about the generated Pydantic and JSON Schema shape.
 Conversion-time version discovery, conflict handling, and metadata mutation are
 separate runtime concerns.
 
+Content discriminators are separate from schema-version metadata. A supported
+string discriminator declared on a field remains part of the generated wire
+contract, and its discriminator mapping and literal branch values are preserved
+across version projections. Callable discriminators remain unsupported because
+their runtime selection behavior cannot be reproduced safely by automatic
+projection.
+
 ## Current-Model Validation
 
 The current application model remains authoritative. Its validators, methods,
@@ -81,6 +97,13 @@ Directly validating a generated model exercises only that wire contract and
 raises Pydantic's native `ValidationError` on invalid input. Use the family
 validation API when the desired result is an instance of the authoritative
 current model.
+
+Field and model validators follow the same boundary. They are intentionally not
+copied to generated wire models, so a `mode="before"` validator may coerce or
+reshape input for the authoritative model while the generated JSON Schema
+describes the post-coercion wire shape. Consumers should validate against the
+generated model for the document contract and use the family API when they need
+the authoritative model's runtime behavior.
 
 ## Unsupported Models
 

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -356,6 +356,22 @@ def _build_model_for_projection_unchecked(
             continue
 
         field_info = family.model.model_fields[compiled_field.current_name]
+        field_dict = field_info.asdict()
+        excluded = any(
+            key in field_dict["attributes"] and _has_effect(field_dict["attributes"][key])
+            for key in ("exclude", "exclude_if")
+        )
+        if excluded:
+            if compiled_field.current_name == model_metadata_field:
+                _raise_projection_unsupported(
+                    family,
+                    projection,
+                    "model-owned version metadata cannot be excluded from the wire model",
+                )
+            # These fields are application/server state, not part of the document
+            # contract.  Omit them from every generated projection rather than
+            # pretending that Pydantic's serialization-only exclusion is wire-safe.
+            continue
         if (
             compiled_field.current_name == model_metadata_field
             and compiled_field.default is not None
@@ -374,7 +390,6 @@ def _build_model_for_projection_unchecked(
                 f"validated-data default factory for field {compiled_field.current_name!r} "
                 "cannot be projected without materializing current-model behavior",
             )
-        field_dict = field_info.asdict()
         annotation = _rewrite_annotation(
             field_dict["annotation"],
             projection.label,

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -1431,19 +1431,42 @@ def test_legacy_json_encoders_fail_automatic_projection() -> None:
     assert encoder_calls == 0
 
 
-def test_serialization_exclusions_fail_automatic_projection() -> None:
+def test_serialization_exclusions_are_omitted_from_automatic_projection() -> None:
     class ExcludedPayload(BaseModel):
         value: int = Field(default=1, exclude=True)
 
     class ConditionalExclusionPayload(BaseModel):
         value: int = Field(default=1, exclude_if=lambda value: value == 0)
 
-    unsupported = (
+    for suffix, model in (
         ("exclude", ExcludedPayload),
         ("exclude_if", ConditionalExclusionPayload),
+    ):
+        family = SchemaFamily(
+            model=model,
+            name=f"excluded_{suffix}",
+            versions=(SchemaVersion("1"),),
+            version_metadata=None,
+        )
+        wire = family.model_for("1")
+        assert "value" not in wire.model_fields
+        assert wire.model_validate({}).model_dump() == {}
+
+
+def test_model_owned_version_field_cannot_be_excluded() -> None:
+    class ExcludedVersionPayload(BaseModel):
+        schema_version: Literal["1"] = Field("1", exclude=True)
+        value: int
+
+    family = SchemaFamily(
+        model=ExcludedVersionPayload,
+        name="excluded_version_metadata",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
     )
-    for suffix, model in unsupported:
-        _assert_unsupported(model, family_name=f"unsupported_{suffix}")
+
+    with pytest.raises(UnsupportedWireModelError, match="cannot be excluded"):
+        family.compile()
 
 
 def test_callable_discriminators_fail_in_field_and_annotated_forms() -> None:


### PR DESCRIPTION
## Summary

- omit effective Field(exclude=True) and Field(exclude_if=...) fields from generated wire projections
- reject excluded model-owned version metadata
- document the generated-wire contract and add regression coverage

## Validation

- uv run make ci
- 242 tests passed
- 95.11% coverage

Closes #26