### PR TITLE
docs(compat): publish the Pydantic wire matrix

### DIFF
--- a/docs/guide/pydantic-compatibility-matrix.md
+++ b/docs/guide/pydantic-compatibility-matrix.md
@@ -1,0 +1,53 @@
+# Pydantic Compatibility Matrix
+
+This matrix is the generated-wire policy for the supported Pydantic range
+`>=2.12.3,<3.0`. It classifies settings by whether they can be copied into an
+object-shaped document contract without running application behavior or
+silently changing validation and serialization semantics.
+
+## Field declarations
+
+| Classification | Settings and behavior |
+| --- | --- |
+| Preserved | `alias`, `alias_priority`, `validation_alias`, `serialization_alias`, direct defaults, zero-argument default factories, `title`, `description`, `examples`, `deprecated`, `validate_default`, string discriminators, and mapping-valued `json_schema_extra` |
+| Preserved | Declarative constraints and metadata represented by supported Pydantic or `annotated-types` metadata, including numeric/string bounds, patterns, length, multiples, decimal constraints, union mode, and fail-fast behavior |
+| Omitted | `exclude=True` and effective `exclude_if`; the field is absent from generated projections, including nested automatic projections |
+| Omitted | `frozen`, `init`, `init_var`, `kw_only`, and `repr`; these describe application-object construction or representation rather than the wire document |
+| Omitted | Field validators, field serializers, and other executable `Annotated` behavior; the authoritative current model remains responsible for runtime behavior |
+| Rejected | `field_title_generator`, callable discriminators, callable field `json_schema_extra`, custom annotation schema hooks, and custom executable metadata |
+| Rejected | Default factories that consume validated data, because generated models intentionally do not run the authoritative model's validation behavior |
+
+Historical patches operate after this field classification. A removed field is
+absent by declaration; an excluded field is absent because it is application
+state; and a renamed field retains the historical wire name.
+
+## Model configuration
+
+| Classification | `ConfigDict` settings |
+| --- | --- |
+| Preserved | `extra`, `strict`, `populate_by_name`, `validate_by_alias`, `validate_by_name`, `serialize_by_alias`, `loc_by_alias`, `use_enum_values`, `alias_generator`, `allow_inf_nan`, `coerce_numbers_to_str`, `regex_engine`, string length/case/whitespace settings, `ser_json_bytes`, `ser_json_inf_nan`, `ser_json_temporal`, `ser_json_timedelta`, `val_json_bytes`, `val_temporal_unit`, `json_schema_mode_override`, `json_schema_serialization_defaults_required`, `title`, and `url_preserve_empty_path` |
+| Preserved conditionally | Mapping-valued `json_schema_extra`; structural schema keys and callable mutation are rejected |
+| Omitted | `cache_strings`, `defer_build`, `from_attributes`, `frozen`, `hide_input_in_errors`, `ignored_types`, `protected_namespaces`, `revalidate_instances`, `use_attribute_docstrings`, `validate_assignment`, `validate_return`, and `validation_error_cause` |
+| Rejected | Effective `arbitrary_types_allowed`, `field_title_generator`, `json_encoders`, `model_title_generator`, `plugin_settings`, `polymorphic_serialization`, and `schema_generator` |
+
+The generated model is a document validator and serializer, not a behavioral
+copy of the application model. Omitted lifecycle settings therefore do not
+mean that the setting is unsupported on the authoritative model; they mean it
+does not belong in the generated wire contract.
+
+## Cross-cutting boundaries
+
+- Unresolved generic bases, behavioral dataclasses, typed extras, and custom
+  type-alias or annotation hooks are rejected. Concrete generic
+  specializations are supported.
+- Nested families must be declared at the paths whose child schema histories
+  need independent projection. Nested automatic projections apply the same
+  field matrix as root projections.
+- String content discriminators are preserved in generated JSON Schema and
+  validation. Callable discriminators are rejected.
+- Validators and serializers are omitted from generated models; use the family
+  validation API when authoritative application behavior is required.
+
+The focused unit and integration tests exercise each supported category and
+the principal interactions between aliases, nested projections, exclusions,
+generic specializations, validators, and discriminators.

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -195,7 +195,8 @@ _WIRE_FIELD_ATTRIBUTES = frozenset(
     }
 )
 _DROPPED_FIELD_ATTRIBUTES = frozenset({"frozen", "init", "init_var", "kw_only", "repr"})
-_REJECTED_FIELD_ATTRIBUTES = frozenset({"exclude", "exclude_if", "field_title_generator"})
+_OMITTED_FIELD_ATTRIBUTES = frozenset({"exclude", "exclude_if"})
+_REJECTED_FIELD_ATTRIBUTES = frozenset({"field_title_generator"})
 _FUNCTIONAL_FIELD_BEHAVIOR = (
     AfterValidator,
     BeforeValidator,
@@ -359,7 +360,7 @@ def _build_model_for_projection_unchecked(
         field_dict = field_info.asdict()
         excluded = any(
             key in field_dict["attributes"] and _has_effect(field_dict["attributes"][key])
-            for key in ("exclude", "exclude_if")
+            for key in _OMITTED_FIELD_ATTRIBUTES
         )
         if excluded:
             if compiled_field.current_name == model_metadata_field:
@@ -558,6 +559,7 @@ def _wire_field_attributes(
         set(source)
         - _WIRE_FIELD_ATTRIBUTES
         - _DROPPED_FIELD_ATTRIBUTES
+        - _OMITTED_FIELD_ATTRIBUTES
         - _REJECTED_FIELD_ATTRIBUTES
     )
     if unknown:
@@ -1673,6 +1675,12 @@ def _rewrite_nested_model(
         fields: dict[str, Any] = {}
         for source_name, source_field_info in annotation.model_fields.items():
             source = source_field_info.asdict()
+            excluded = any(
+                key in source["attributes"] and _has_effect(source["attributes"][key])
+                for key in _OMITTED_FIELD_ATTRIBUTES
+            )
+            if excluded:
+                continue
             rewritten_annotation = _rewrite_annotation(
                 source["annotation"],
                 version,

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -1206,6 +1206,47 @@ def test_nested_projection_rewrites_deeply_nested_models() -> None:
     assert current.model_dump()["nested"]["inner"]["label"] == 1
 
 
+def test_nested_projection_omits_excluded_application_fields() -> None:
+    class LeafPayload(BaseModel):
+        label: int
+
+    class InnerPayload(BaseModel):
+        value: int
+        object_store: dict[str, str] = Field(default_factory=dict, exclude=True)
+        cache_key: str = Field(default="", exclude_if=lambda value: not value)
+        child: LeafPayload
+
+    class RootPayload(BaseModel):
+        inner: InnerPayload
+
+    family = SchemaFamily(
+        model=RootPayload,
+        name="nested_excluded_fields",
+        versions=(SchemaVersion("1"),),
+        nested=(
+            NestedFamily(
+                ("inner", "child"),
+                SchemaFamily(
+                    model=LeafPayload,
+                    name="nested_excluded_leaf",
+                    versions=(SchemaVersion("1"),),
+                    version_metadata=None,
+                ),
+                matching_labels(),
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    wire = family.model_for("1")
+    nested_wire = wire.model_fields["inner"].annotation
+
+    assert set(nested_wire.model_fields) == {"value", "child"}
+    assert wire.model_validate({"inner": {"value": 3, "child": {"label": 4}}}).model_dump() == {
+        "inner": {"value": 3, "child": {"label": 4}},
+    }
+
+
 def test_single_segment_tuple_metadata_keeps_tuple_path_semantics() -> None:
     class TupleMetadataPayload(BaseModel):
         value: int = 1

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,6 +16,7 @@ nav = [
     { "Getting Started" = "guide/getting-started.md" },
     { "Concepts" = "guide/concepts.md" },
     { "Generated Wire Contracts" = "guide/generated-wire-contracts.md" },
+    { "Pydantic Compatibility Matrix" = "guide/pydantic-compatibility-matrix.md" },
     { "External Schema Families" = "guide/external-families.md" },
     { "Complex Config Example" = "guide/complex-config-example.md" },
     { "Django Ninja" = "guide/django-ninja.md" },


### PR DESCRIPTION
## Summary

- publish a Pydantic 2.12+ preserve/omit/reject compatibility matrix
- apply excluded-field omission consistently to nested automatic projections
- add regression coverage for nested exclusions and child-family rewriting
- add the matrix to the documentation navigation

## Validation

- uv run make ci
- uv run make docs-build-strict
- uv run make build
- 247 tests passed
- 95.12% coverage

Closes #29
