### PR TITLE
docs(compat): lock validator and wire boundary semantics

### DIFF
--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -105,6 +105,35 @@ describes the post-coercion wire shape. Consumers should validate against the
 generated model for the document contract and use the family API when they need
 the authoritative model's runtime behavior.
 
+Family validation has two deliberate stages: it validates the source document
+against the generated wire model first, then runs the authoritative current
+model after migrations. Consequently, raw input accepted only by an omitted
+validator is not automatically accepted as a wire document. Once the payload
+has the generated wire shape, authoritative validators can still normalize it
+or enforce application invariants at the final boundary.
+
+The boundary applies consistently to every Pydantic validator mode:
+
+| Validator behavior | Authoritative model | Generated wire model and schema |
+| --- | --- | --- |
+| `mode="before"` | May coerce or reshape raw input before annotation validation once the wire document has passed. | Accepts the declared annotation shape only; the schema does not advertise raw values accepted only by the validator. |
+| `mode="after"` | May normalize or enforce invariants after annotation validation. | Keeps the declarative annotation validation but does not run the normalization or invariant check. |
+| `mode="plain"` | Replaces Pydantic's normal annotation validation at the authoritative boundary. | Retains the annotation's generated wire schema and core validation; inputs accepted only by the plain validator are not wire inputs. |
+| `mode="wrap"` | May preprocess input, delegate to core validation, or replace its result after wire validation. | Does not copy the wrapper; direct validation follows the generated annotation and constraints. |
+
+Model-level `before`, `after`, and `wrap` validators follow the same rule. They
+are authoritative application behavior, not generated wire behavior. Field and
+model serializers are also omitted: a generated `model_dump()` represents the
+wire contract, while serialization of the authoritative model may still apply
+the application's serializer. `model_post_init` is omitted for the same reason.
+
+For example, a `mode="before"` validator that turns `"1,2"` into `[1, 2]`
+does not make the generated model accept the string, and `SchemaFamily.validate`
+also rejects it at the source wire boundary. A wire-shaped `[1, 2]` payload can
+then be normalized by the authoritative validator before the final current
+model is returned. This keeps framework/OpenAPI consumers on the wire contract
+while preserving application behavior at the final boundary.
+
 ## Unsupported Models
 
 `UnsupportedWireModelError` is a `SchemaCompilationError`. It is raised during

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -96,7 +96,11 @@ cannot replace generated object properties, requirements, or composition.
 They do not copy model or field validators, field serializers, computed fields,
 private attributes, methods, `model_post_init`, or lifecycle-only configuration.
 The authoritative current model remains responsible for final application
-validation.
+validation. `model_for(...).model_validate(...)` is the direct source-wire
+check; `SchemaFamily.validate(...)` performs that wire check first and then
+validates the migrated payload with the authoritative current model. Neither
+API treats a validator-only raw input shape as part of the generated wire
+contract.
 
 When version metadata is family-owned, the complete generated document adapter
 has an exact `Literal[label]` discriminator for every version, including

--- a/tests/integration/test_validator_boundary_scenario.py
+++ b/tests/integration/test_validator_boundary_scenario.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any, Self, cast
+
+import pytest
+from pydantic import BaseModel, ValidationError, field_validator, model_validator
+
+from pydantic_versions import SchemaFamily, SchemaVersion
+
+
+def test_generated_wire_validation_is_separate_from_authoritative_validator_behavior() -> None:
+    events: list[str] = []
+
+    class BoundaryPayload(BaseModel):
+        values: list[int]
+        plain_value: int
+        wrapped_value: int
+        seed: int
+        after_marker: int = 0
+
+        @field_validator("values", mode="before")
+        @classmethod
+        def split_values(cls, value: Any) -> Any:
+            events.append("before")
+            if isinstance(value, str):
+                return [int(item) for item in value.split(",")]
+            return list(reversed(value))
+
+        @field_validator("plain_value", mode="plain")
+        @classmethod
+        def parse_plain_value(cls, value: Any) -> int:
+            events.append("plain")
+            if value == "seven":
+                return 7
+            return int(value) + 1
+
+        @field_validator("wrapped_value", mode="wrap")
+        @classmethod
+        def parse_wrapped_value(cls, value: Any, handler: Any) -> int:
+            events.append("wrap")
+            return handler(value) + 1
+
+        @field_validator("after_marker", mode="after")
+        @classmethod
+        def mark_after_validation(cls, value: int) -> int:
+            events.append("after")
+            return value + 1
+
+        @model_validator(mode="before")
+        @classmethod
+        def add_missing_seed(cls, value: Any) -> Any:
+            events.append("model-before")
+            return value
+
+        @model_validator(mode="after")
+        def require_matching_seed(self) -> Self:
+            events.append("model-after")
+            if self.seed != 42:
+                raise ValueError("seed must be 42")
+            return self
+
+    family = SchemaFamily(
+        model=BoundaryPayload,
+        name="validator_boundary",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    wire = family.model_for("1")
+
+    schema = wire.model_json_schema()
+    assert schema["properties"]["values"] == {
+        "items": {"type": "integer"},
+        "title": "Values",
+        "type": "array",
+    }
+    assert schema["properties"]["plain_value"]["type"] == "integer"
+    assert schema["properties"]["wrapped_value"]["type"] == "integer"
+    assert "seed" in schema["required"]
+
+    raw_payload = {
+        "values": "1,2",
+        "plain_value": "seven",
+        "wrapped_value": "eight",
+        "seed": 42,
+    }
+    with pytest.raises(ValidationError):
+        wire.model_validate(raw_payload)
+    with pytest.raises(ValidationError):
+        family.validate(raw_payload, version="1")
+    assert events == []
+
+    direct_wire = cast(
+        Any,
+        wire.model_validate(
+            {
+                "values": [1, 2],
+                "plain_value": 7,
+                "wrapped_value": 8,
+                "seed": 42,
+            }
+        ),
+    )
+    assert direct_wire.values == [1, 2]
+    assert direct_wire.plain_value == 7
+    assert direct_wire.wrapped_value == 8
+    assert direct_wire.after_marker == 0
+    assert events == []
+
+    result = family.validate(
+        {
+            "values": [1, 2],
+            "plain_value": 7,
+            "wrapped_value": 8,
+            "seed": 42,
+        },
+        version="1",
+    )
+
+    source_model = cast(Any, result.source_model)
+    current_model = cast(Any, result.current_model)
+    assert source_model.values == [1, 2]
+    assert source_model.plain_value == 7
+    assert source_model.wrapped_value == 8
+    assert source_model.seed == 42
+    assert source_model.after_marker == 0
+    assert current_model.values == [2, 1]
+    assert current_model.plain_value == 8
+    assert current_model.wrapped_value == 9
+    assert current_model.after_marker == 1
+    assert events == ["model-before", "before", "plain", "wrap", "after", "model-after"]


### PR DESCRIPTION
## Summary

Closes #30.

- document the two-stage source-wire and authoritative-current validation boundary
- classify `before`, `after`, `plain`, and `wrap` validators, model validators, serializers, and `model_post_init`
- add a consumer scenario covering nested reshaping/coercion, direct generated validation, JSON Schema, and `SchemaFamily.validate()` side by side
- clarify that validator-only raw input is not a wire shape and that authoritative normalization occurs after wire validation

## Validation

- `uv run make ci` — 248 passed, 95.12% coverage
- `uv run make docs-build-strict`
- `uv run make build`
- `git diff --check`
