### PR TITLE
docs(release): define the 0.3 application exchange boundary

### DIFF
--- a/architecture/decisions/0001-schema-family-and-conversion-contract.md
+++ b/architecture/decisions/0001-schema-family-and-conversion-contract.md
@@ -1,10 +1,19 @@
 # ADR 0001: Schema-family and conversion contract
 
-- **Status:** Accepted
+- **Status:** Historical target; partially implemented
 - **Target:** 0.2.0
 - **Decision date:** 2026-07-22
 - **Tracking issue:** [#3](https://github.com/dariuszpanas/pydantic-versions/issues/3)
 - **Parent roadmap:** [#2](https://github.com/dariuszpanas/pydantic-versions/issues/2)
+
+> [!IMPORTANT]
+> This ADR records the target design used to guide the 0.2.0 work. It is not the
+> authoritative reference for the shipped package. External schema families,
+> generated wire contracts, inventories, plans, downgrade execution, explicit
+> wire models, and nested conversion were delivered. The proposed execution
+> traces, rendering result API, and contextual error hierarchy were not.
+> User-facing guides, the API reference, exported symbols, and tests define the
+> implemented contract.
 
 This record defines the target 0.2.0 contract. It is not a claim that the API is
 already implemented in 0.1. Implementation is split across the linked roadmap

--- a/architecture/decisions/0002-0.3-beta-and-application-exchange-boundary.md
+++ b/architecture/decisions/0002-0.3-beta-and-application-exchange-boundary.md
@@ -1,0 +1,134 @@
+# ADR 0002: 0.3 Beta and application-exchange boundary
+
+- **Status:** Accepted
+- **Target:** 0.3.0
+- **Decision date:** 2026-08-20
+- **Tracking issues:** [#49](https://github.com/dariuszpanas/pydantic-versions/issues/49), [#50](https://github.com/dariuszpanas/pydantic-versions/issues/50)
+
+## Context
+
+`pydantic-versions` began with a file-based configuration problem involving
+more than one application. One application could write a configuration that a
+second application also validated with Pydantic, while users could retain files
+created against older schema versions. The applications needed predictable
+rules for version discovery, historical defaults, upgrades, and output for an
+older consumer.
+
+The 0.2 implementation provides the required conversion primitives: external
+schema families, generated historical wire models, validation into an
+authoritative current model, explicit upgrades and downgrades, nested family
+execution, and payload-free inventories and plans. The accepted 0.2 target ADR
+also proposed execution traces and a larger contextual error hierarchy. Those
+observability APIs were not implemented and are not required for the original
+configuration-exchange problem.
+
+The project is maintained and currently consumed by one developer. Release
+readiness is therefore based on a coherent supported contract, executable
+integration evidence, and maintainer judgment rather than an artificial number
+of external adopters or a multi-stage prerelease schedule.
+
+## Decision
+
+### Release identity
+
+The next release is `0.3.0`, tagged `v0.3.0`, with the PyPI classifier
+`Development Status :: 4 - Beta`. It is a normal PEP 440 release, not a
+`0.3.0bN` prerelease. No release-candidate or TestPyPI rehearsal is required
+when the exact release commit passes the established package gates and the
+maintainer authorizes publication.
+
+### Authoritative shipped contract
+
+User-facing guides, the API reference, exported symbols, and executable tests
+define the shipped contract. Architecture decision records preserve design
+history and future intent but are not rendered as end-user documentation.
+
+ADR 0001 remains available to maintainers as the 0.2 target design and is
+explicitly marked partially implemented. Its proposed `ConversionTrace`,
+`VersionedRendering`, `render_versioned()`, specialized conflict/transition/
+rendering errors, and trace-bearing validation result are not part of 0.3.0.
+They will not be implemented merely to make the historical target document
+literal.
+
+### Application-to-application exchange
+
+Version negotiation remains an application concern in 0.3.0. The library
+provides the primitives needed to implement it without owning a transport:
+
+1. the consumer advertises the schema versions it accepts;
+2. the producer considers versions it can render and their exact or lossy
+   semantics;
+3. the applications select a mutually supported version under an explicit
+   lossiness policy;
+4. the producer validates its input into its current model and renders the
+   selected historical contract; and
+5. the consumer validates that document into its own current model.
+
+Applications may exchange capabilities through an API, message metadata,
+deployment configuration, or a sidecar file. The document may carry its schema
+version directly or the transport may supply it through the existing explicit
+`version=` boundary.
+
+Schema labels are immutable shared contracts. A producer must not guess when
+there is no mutually supported label, and lossy output requires explicit
+application policy. Boundary normalization should validate and then render
+rather than forwarding an unvalidated dictionary, so historical defaults are
+materialized consistently.
+
+Unknown-field preservation is also explicit application policy. A partial
+consumer must use an authoritative owner, namespaced sections, or tested
+Pydantic extra-field behavior; schema conversion does not by itself provide an
+opaque multi-writer merge protocol.
+
+### 0.3.0 scope
+
+The 0.3.0 release includes:
+
+- the compatibility and generated-wire behavior already present on `main`;
+- accurate API and behavior documentation;
+- an application-to-application exchange guide;
+- an executable integration scenario with independent producer and consumer
+  models exchanging a serialized configuration; and
+- normal release metadata, changelog, and classifier updates.
+
+The release does not add a capability-manifest or negotiation API. A future API
+must be justified by repeated application code demonstrated by the integration
+scenario rather than designed speculatively before release.
+
+### Release-readiness evidence
+
+The exact candidate must pass:
+
+- formatting, lint, and static type checking;
+- the complete unit and integration test suite with the configured coverage
+  threshold;
+- the supported Python and Pydantic endpoint matrix in CI;
+- strict documentation rendering;
+- dependency auditing; and
+- isolated wheel and source-distribution installation checks.
+
+Any tracked change after the candidate gate invalidates that evidence. Tagging,
+publishing, or creating the GitHub release still requires explicit maintainer
+authorization.
+
+## Deferred decisions
+
+The following remain possible post-0.3 work rather than release commitments:
+
+- a serializable `SchemaCapabilities` record;
+- a transport-neutral version-negotiation helper;
+- protocol identifiers or conservative contract fingerprints;
+- structured execution traces and contextual conversion errors; and
+- an opaque-extension preservation mechanism for partial-schema relays.
+
+These features should be evaluated against real integration needs. They are not
+requirements for calling 0.3 Beta or, by themselves, for a future 1.0 release.
+
+## Consequences
+
+The public documentation becomes smaller and more trustworthy because it no
+longer presents an aspirational ADR as shipped API reference. The two-
+application scenario demonstrates the library's original purpose without
+expanding the public surface immediately before release. Future negotiation or
+observability work can start from executable evidence and a focused decision
+record.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Added dark-mode documentation support and theme-aware project artwork.
+- Added compatibility coverage for nested concrete generics, content
+  discriminators, nested exclusions, and validator-to-wire-schema boundaries.
+- Added a published Pydantic compatibility matrix.
+- Added an application-to-application schema exchange guide and integration
+  scenario covering compatibility selection, historical defaults, and version
+  metadata ownership.
+
+### Changed
+- Omit fields marked with `Field(exclude=True)` or `exclude_if` from generated
+  wire projections.
+- Refreshed development dependencies and GitHub Actions.
+
+### Security
+- Added weekly Dependabot updates and a strict dependency vulnerability audit
+  to CI.
+
 ## [0.2.0] - 2026-07-23
 
 ### Added
@@ -57,5 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Django Ninja compatibility tests and documentation for versioned API schemas.
 - Added install and getting-started documentation.
 
+[Unreleased]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dariuszpanas/pydantic-versions/releases/tag/v0.1.0

--- a/docs/guide/application-exchange.md
+++ b/docs/guide/application-exchange.md
@@ -1,0 +1,260 @@
+# Application-to-Application Exchange
+
+`pydantic-versions` can sit at the boundary between applications that share a
+configuration contract but deploy different software releases. The schema
+version describes the exchanged document; it is independent from either
+application's package version.
+
+Consider a producer that understands schema versions `1`, `2`, and `3`, while a
+consumer still accepts only `1` and `2`. The producer can validate old input
+into its current model and render version `2` for the consumer. The applications
+exchange serialized data, not Python models or schema-family objects.
+
+## Give the shared contract an identity
+
+Both applications need an agreed protocol identity and immutable version
+labels:
+
+```python
+PIPELINE_CONFIG_SCHEMA = "com.example.pipeline-config"
+```
+
+`SchemaFamily.name` can carry that value, but the library does not register or
+resolve names globally. The applications establish the identity through their
+own API, deployment configuration, message metadata, or file convention.
+
+Once published, a label such as `2` must keep the same fields, aliases,
+constraints, and defaults. An incompatible contract change receives a new
+schema label.
+
+## Declare independent application models
+
+The producer owns its current application model and history:
+
+```python
+from pydantic import BaseModel
+from pydantic_versions import (
+    SchemaFamily,
+    SchemaVersion,
+    field_default,
+    field_removed,
+    field_renamed,
+)
+
+
+class ProducerConfig(BaseModel):
+    endpoint: str
+    timeout: int = 30
+    retry_limit: int = 3
+    telemetry: bool = True
+
+
+PRODUCER_SCHEMA = SchemaFamily(
+    model=ProducerConfig,
+    name="com.example.pipeline-config",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5),
+                field_renamed("retry_limit", "attempts"),
+                field_removed("telemetry"),
+            ),
+        ),
+        SchemaVersion(
+            "2",
+            patches=(
+                field_default("timeout", 10),
+                field_renamed("retry_limit", "retries"),
+            ),
+        ),
+        SchemaVersion("3"),
+    ),
+)
+```
+
+The consumer declares the same shared wire versions against its own model. It
+does not import `ProducerConfig` or `PRODUCER_SCHEMA`:
+
+```python
+class ConsumerConfig(BaseModel):
+    endpoint: str
+    timeout: int = 10
+    retries: int = 3
+    telemetry: bool = True
+
+
+CONSUMER_SCHEMA = SchemaFamily(
+    model=ConsumerConfig,
+    name="com.example.pipeline-config",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5),
+                field_renamed("retries", "attempts"),
+                field_removed("telemetry"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
+)
+```
+
+The declarations for each shared label must describe the same wire contract,
+even though the applications' current Python field names can differ.
+
+## Advertise accepted versions
+
+The consumer can publish a small application-owned capability document:
+
+```json
+{
+  "schema": "com.example.pipeline-config",
+  "accepts": ["1", "2"]
+}
+```
+
+This is deliberately not a `pydantic-versions` transport API. It can be an HTTP
+response, message header, sidecar file, command-line setting, or deployment
+contract.
+
+## Select an exact common version
+
+The producer already has the primitives needed to select a target. Declared
+versions give its preference order, and `plan_render()` reports whether a
+target is exact, lossy, or unavailable:
+
+```python
+from collections.abc import Iterable
+
+from pydantic_versions import IrreversibleTransitionError, SchemaFamily
+
+
+class NoCompatibleSchemaVersionError(RuntimeError):
+    pass
+
+
+def select_target_version(
+    producer: SchemaFamily,
+    accepted: Iterable[str],
+    *,
+    allow_lossy: bool = False,
+) -> str:
+    accepted_labels = set(accepted)
+    for declaration in reversed(producer.versions):
+        if declaration.label not in accepted_labels:
+            continue
+        try:
+            plan = producer.plan_render(declaration.label)
+        except IrreversibleTransitionError:
+            continue
+        if plan.semantics == "exact" or allow_lossy:
+            return declaration.label
+    raise NoCompatibleSchemaVersionError
+```
+
+For the example above, version `2` is the newest exact common version. Version
+`1` is lossy because it omits `telemetry`. A deployment may permit that loss,
+but it must opt in rather than discovering it after data has been discarded.
+
+Version labels are opaque strings. “Newest” here means the producer's declared
+order, not lexical or numeric sorting.
+
+## Normalize before sending
+
+Do not forward the original dictionary directly. Validate it into the
+producer's authoritative current model, then render the selected target:
+
+```python
+historical_input = {
+    "schema_version": "1",
+    "endpoint": "https://worker.example",
+    "attempts": 4,
+}
+
+normalized = PRODUCER_SCHEMA.validate(historical_input).current_model
+target = select_target_version(PRODUCER_SCHEMA, ("1", "2"))
+outgoing = PRODUCER_SCHEMA.dump(version=target, data=normalized)
+```
+
+The outgoing version `2` document contains the effective historical timeout of
+`5`, the `retries` wire name, and the current value of `telemetry`. Validation
+followed by rendering makes defaults explicit under the selected contract
+instead of letting two applications independently guess what an omitted value
+means.
+
+The consumer reads only serialized data:
+
+```python
+received = CONSUMER_SCHEMA.validate(outgoing)
+config = received.current_model
+
+assert config.timeout == 5
+assert config.retries == 4
+assert config.telemetry is True
+```
+
+## Carry version metadata in one place
+
+The default document includes `schema_version`. If the transport already owns
+that metadata, render without it and supply the selected version explicitly at
+the consumer boundary:
+
+```python
+payload = PRODUCER_SCHEMA.dump(
+    version=target,
+    data=normalized,
+    include_version=False,
+)
+received = CONSUMER_SCHEMA.validate(payload, version=target)
+```
+
+When both transport and document metadata are present, they must agree. The
+library validates the selected wire contract rather than silently replacing a
+conflicting embedded label.
+
+## Fail when there is no safe overlap
+
+A producer must not guess when the applications share no usable version.
+Return a compatibility error, stop the deployment, or require an explicit
+upgrade. Do not substitute the producer's current version or use
+`missing_version` as negotiation fallback.
+
+`missing_version` is only for a known legacy document population whose absent
+metadata has one deliberate meaning.
+
+## Decide who owns unknown fields
+
+Version conversion does not define a multi-writer merge protocol. A consumer
+that ignores unknown fields can destroy another application's data if it reads,
+modifies, and rewrites a larger shared document.
+
+Choose an explicit ownership model:
+
+- one application owns the complete configuration and others consume it;
+- each application owns a namespaced section;
+- every partial consumer uses and tests suitable Pydantic extra-field behavior;
+  or
+- a separate envelope preserves opaque application extensions.
+
+Do not claim transparent relay behavior without a round-trip test for the exact
+models and Pydantic configuration in use.
+
+## Useful operating modes
+
+The same primitives support several deployments:
+
+- **File import:** a new application validates and upgrades an old user file.
+- **Compatibility output:** a new producer renders a format accepted by an old
+  application.
+- **Translator:** a gateway validates any supported input and renders a chosen
+  target version.
+- **Fan-out:** one current model is rendered separately for consumers with
+  different supported windows.
+- **Rolling deployment:** old and new instances exchange the newest exact
+  version shared during the rollout.
+
+The integration suite exercises the independent producer/consumer file exchange
+as executable documentation. A future capability or negotiation API should be
+based on repeated real application code rather than required for this workflow.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -116,8 +116,8 @@ Automatic projection raises `UnsupportedWireModelError` for a `RootModel`,
 unresolved generic, model-level serializer, overridden model core/JSON Schema
 hook, application-defined annotation hook, behavioral dataclass, callable or
 non-JSON schema mutation, structural model schema override, validated-data
-factory, legacy `json_encoders`, arbitrary-type escape hatch, serialization
-exclusion, or non-object validation or serialization shape. Pydantic v1 models
+factory, legacy `json_encoders`, arbitrary-type escape hatch, or non-object
+validation or serialization shape. Pydantic v1 models
 instead fail registration with `SchemaVersionError`.
 See
 [generated wire contracts](../guide/generated-wire-contracts.md) for the full
@@ -275,8 +275,9 @@ contain payload-derived indices or keys.
 Inventories and plans never contain payloads, model objects, callable objects,
 default values, exception messages, tracebacks, timing, or host/user
 identifiers, and creating them does not log. A plan describes a possible
-operation; it is not an execution trace. Structured per-payload traces are a
-separate API.
+operation; it is not an execution trace. The package does not currently expose
+structured per-payload traces; `VersionedValidation.migrations_applied` remains
+the compatibility view of completed top-level custom upgrades.
 
 Calling `describe()`, `plan_validation()`, or `plan_render()` performs the
 family's first compilation when needed. A later legacy `@migration`

--- a/tests/integration/test_application_exchange_scenario.py
+++ b/tests/integration/test_application_exchange_scenario.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_versions import (
+    IrreversibleTransitionError,
+    SchemaFamily,
+    SchemaVersion,
+    field_default,
+    field_removed,
+    field_renamed,
+)
+
+SCHEMA_ID = "com.example.pipeline-config"
+
+
+class ProducerConfig(BaseModel):
+    endpoint: str
+    timeout: int = 30
+    retry_limit: int = 3
+    telemetry: bool = True
+
+
+PRODUCER_SCHEMA = SchemaFamily(
+    model=ProducerConfig,
+    name=SCHEMA_ID,
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5),
+                field_renamed("retry_limit", "attempts"),
+                field_removed("telemetry"),
+            ),
+        ),
+        SchemaVersion(
+            "2",
+            patches=(
+                field_default("timeout", 10),
+                field_renamed("retry_limit", "retries"),
+            ),
+        ),
+        SchemaVersion("3"),
+    ),
+)
+
+
+class ConsumerConfig(BaseModel):
+    endpoint: str
+    timeout: int = 10
+    retries: int = 3
+    telemetry: bool = True
+
+
+CONSUMER_SCHEMA = SchemaFamily(
+    model=ConsumerConfig,
+    name=SCHEMA_ID,
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_default("timeout", 5),
+                field_renamed("retries", "attempts"),
+                field_removed("telemetry"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ConsumerCapabilities:
+    schema: str
+    accepts: tuple[str, ...]
+
+
+class NoCompatibleSchemaVersionError(RuntimeError):
+    pass
+
+
+def _select_target_version(
+    producer: SchemaFamily[ProducerConfig],
+    consumer: ConsumerCapabilities,
+    *,
+    allow_lossy: bool = False,
+) -> str:
+    if consumer.schema != producer.name:
+        raise NoCompatibleSchemaVersionError
+
+    accepted = set(consumer.accepts)
+    for declaration in reversed(producer.versions):
+        if declaration.label not in accepted:
+            continue
+        try:
+            plan = producer.plan_render(declaration.label)
+        except IrreversibleTransitionError:
+            continue
+        if plan.semantics == "exact" or allow_lossy:
+            return declaration.label
+    raise NoCompatibleSchemaVersionError
+
+
+def _consumer_capabilities(accepts: Iterable[str] = ("1", "2")) -> ConsumerCapabilities:
+    return ConsumerCapabilities(schema=CONSUMER_SCHEMA.name, accepts=tuple(accepts))
+
+
+def test_independent_applications_exchange_the_newest_exact_common_version(tmp_path) -> None:
+    historical_input = {
+        "schema_version": "1",
+        "endpoint": "https://worker.example",
+        "attempts": 4,
+    }
+    normalized = PRODUCER_SCHEMA.validate(historical_input).current_model
+    target = _select_target_version(PRODUCER_SCHEMA, _consumer_capabilities())
+
+    assert target == "2"
+    assert PRODUCER_SCHEMA.plan_render(target).semantics == "exact"
+    assert normalized.timeout == 5
+    assert normalized.retry_limit == 4
+    assert normalized.telemetry is True
+
+    outgoing = PRODUCER_SCHEMA.dump(version=target, data=normalized)
+    exchange_path = tmp_path / "pipeline-config.json"
+    exchange_path.write_text(json.dumps(outgoing), encoding="utf-8")
+
+    serialized = json.loads(exchange_path.read_text(encoding="utf-8"))
+    received = CONSUMER_SCHEMA.validate(serialized)
+
+    assert serialized == {
+        "endpoint": "https://worker.example",
+        "timeout": 5,
+        "retries": 4,
+        "telemetry": True,
+        "schema_version": "2",
+    }
+    assert type(received.current_model) is ConsumerConfig
+    assert received.current_model == ConsumerConfig(
+        endpoint="https://worker.example",
+        timeout=5,
+        retries=4,
+        telemetry=True,
+    )
+
+
+def test_exchange_refuses_no_overlap_and_requires_opt_in_for_lossy_output() -> None:
+    with pytest.raises(NoCompatibleSchemaVersionError):
+        _select_target_version(PRODUCER_SCHEMA, _consumer_capabilities(("legacy",)))
+
+    version_one_only = _consumer_capabilities(("1",))
+    assert PRODUCER_SCHEMA.plan_render("1").semantics == "lossy"
+
+    with pytest.raises(NoCompatibleSchemaVersionError):
+        _select_target_version(PRODUCER_SCHEMA, version_one_only)
+
+    assert _select_target_version(PRODUCER_SCHEMA, version_one_only, allow_lossy=True) == "1"
+
+
+def test_exchange_supports_transport_owned_version_metadata() -> None:
+    normalized = ProducerConfig(
+        endpoint="https://worker.example",
+        timeout=12,
+        retry_limit=6,
+    )
+    payload = PRODUCER_SCHEMA.dump(
+        version="2",
+        data=normalized,
+        include_version=False,
+    )
+
+    assert "schema_version" not in payload
+    received = CONSUMER_SCHEMA.validate(payload, version="2")
+    assert received.current_model.retries == 6
+    assert received.current_model.timeout == 12

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,7 @@ nav = [
     { "Generated Wire Contracts" = "guide/generated-wire-contracts.md" },
     { "Pydantic Compatibility Matrix" = "guide/pydantic-compatibility-matrix.md" },
     { "External Schema Families" = "guide/external-families.md" },
+    { "Application-to-Application Exchange" = "guide/application-exchange.md" },
     { "Complex Config Example" = "guide/complex-config-example.md" },
     { "Django Ninja" = "guide/django-ninja.md" },
     { "Version Discovery" = "guide/version-discovery.md" },
@@ -25,9 +26,6 @@ nav = [
     { "Migrations" = "guide/migrations.md" },
     { "Rendering Configs" = "guide/rendering.md" },
     { "Adoption Guidance" = "guide/adoption-guidance.md" },
-  ] },
-  { "Architecture Decisions" = [
-    { "Schema-family and conversion contract" = "decisions/0001-schema-family-and-conversion-contract.md" },
   ] },
   { "Reference" = [
     { "API" = "reference/api.md" },


### PR DESCRIPTION
## Summary

- add and populate the Keep a Changelog 1.1.0 Unreleased section, including a comparison link
- move the historical target ADR out of the rendered user documentation and label its implementation status accurately
- record the direct 0.3.0 Beta release boundary and defer unshipped trace/error APIs
- add an application-to-application exchange guide covering supported-version selection, exact versus lossy output, defaults, metadata ownership, and failure modes
- add an integration scenario with independent producer and consumer models exchanging a serialized configuration file

## Compatibility

This changes documentation and integration coverage only. It does not change the public Python API, package version, release classifier, or runtime behavior.

## Validation

- uv run make ci (252 passed, 95.12% coverage)
- uv run make docs-build-strict
- uv build
- uv run pip-audit --strict
- uvx --from twine twine check dist/*
- uvx check-wheel-contents dist/*.whl
- local conventional-commit validation

Closes #49
Closes #50
Refs #12
