### PR TITLE
chore(release): prepare 0.3.0 Beta metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
           uv sync --frozen --python 3.12
 
       - name: Audit installed dependencies
-        run: uv run pip-audit --strict
+        run: |
+          uv export --frozen --no-emit-project \
+            --output-file "$RUNNER_TEMP/audit-requirements.txt"
+          uv run pip-audit --strict \
+            --requirement "$RUNNER_TEMP/audit-requirements.txt"
 
   test:
     name: Test (Python ${{ matrix.python-version }}, Pydantic ${{ matrix.pydantic-profile }})

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-20
+
 ### Added
 - Added dark-mode documentation support and theme-aware project artwork.
 - Added compatibility coverage for nested concrete generics, content
@@ -77,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Django Ninja compatibility tests and documentation for versioned API schemas.
 - Added install and getting-started documentation.
 
-[Unreleased]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dariuszpanas/pydantic-versions/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dariuszpanas/pydantic-versions/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic-versions"
-version = "0.2.0"
+version = "0.3.0"
 description = "Bring version control and history to your Pydantic schemas"
 readme = "README.md"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ keywords = [
     "migrations",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-versions"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- set the package and lockfile version to 0.3.0
- change the PyPI development-status classifier from Alpha to Beta
- cut the Unreleased notes into the dated 0.3.0 changelog entry and advance comparison links
- keep strict dependency auditing operational before the new project version exists on PyPI by auditing the frozen dependency export without the editable project itself

## Release boundary

This prepares release metadata only. It does not create a tag, GitHub Release, TestPyPI upload, or PyPI upload.

## Validation

- uv run make ci: passed (252 tests, 95.12% coverage)
- uv run make docs-build-strict: passed
- scripts/validate_release.py 0.3.0: passed
- strict frozen dependency audit: passed
- isolated Python 3.12 wheel install and runtime smoke: passed
- twine and wheel-content checks: passed

Closes #52
