### PR TITLE
docs(architecture): define the 1.0 stability boundary

### DIFF
--- a/architecture/decisions/0003-1.0-stability-boundary.md
+++ b/architecture/decisions/0003-1.0-stability-boundary.md
@@ -1,0 +1,142 @@
+# ADR 0003: 1.0 stability boundary
+
+- **Status:** Accepted
+- **Target:** 1.0.0
+- **Decision date:** 2026-08-20
+- **Tracking issues:** [#54](https://github.com/dariuszpanas/pydantic-versions/issues/54), [#55](https://github.com/dariuszpanas/pydantic-versions/issues/55), [#56](https://github.com/dariuszpanas/pydantic-versions/issues/56), [#57](https://github.com/dariuszpanas/pydantic-versions/issues/57)
+
+## Context
+
+Version 0.3.0 demonstrates the project's original use case: independently
+deployed applications can validate older Pydantic-backed configuration files,
+materialize their historical defaults, and exchange a mutually supported wire
+version under an explicit exact-or-lossy policy. The package already has broad
+unit, integration, typing, documentation, build, security, and supported-runtime
+coverage.
+
+The remaining question is not which new operating modes would make the project
+feature-complete. No useful library is complete in that sense. The question is
+whether the contract that already exists is deliberate, observable, and tested
+well enough that a user can depend on compatible 1.x releases.
+
+The audit found two concrete stability gaps:
+
+1. the exported Python surface and compatibility policy are documented in
+   pieces but are not frozen by one explicit policy and regression gate; and
+2. persisted payload behavior and documented inventory/plan serialization are
+   tested within one checkout but not against artifacts from a released package
+   baseline.
+
+It also confirmed that the historical structured-trace proposal is not part of
+the shipped contract. `VersionedValidationError` remains as an unused exported
+placeholder, while one rendered reference sentence still describes contextual
+wrapping that the runtime does not perform. Adding a trace/result/error system
+would expand the product rather than prove the existing product stable.
+
+## Decision
+
+### Meaning of 1.0.0
+
+Version 1.0.0 means the current useful contract has been inventoried, corrected,
+documented, and protected by executable compatibility evidence. It does not
+mean every conceivable Pydantic feature, transport, or observability facility
+has been implemented.
+
+Stability is demonstrated when:
+
+- every deliberate public export, signature, frozen record field, exception
+  relationship, and typing contract is covered by a compatibility gate;
+- documented wire behavior, schema-label immutability, version discovery,
+  defaults, upgrades, downgrades, nesting, and exact/lossy semantics agree with
+  executable tests;
+- persisted examples produced from a tagged pre-1.0 release remain usable;
+- JSON-safe inventory and conversion-plan output cannot change silently where
+  the documentation promises stability;
+- supported Python and Pydantic endpoints remain explicit and green;
+- the documentation makes the public/private and compatibility boundaries
+  unambiguous; and
+- the exact release candidate passes the complete source, documentation,
+  security, wheel, and source-distribution gates.
+
+These are technical and maintainer-judgment criteria. External adoption counts,
+waiting periods, release candidates, and a prescribed number of releases are
+not evidence requirements.
+
+### Pre-1.0 delivery
+
+Version 1.0.0 is a destination criterion, not necessarily the next release.
+The required work may ship through as many coherent 0.x minor or patch releases
+as prove useful. This ADR does not predict their version numbers, count, or
+dates.
+
+Pre-1.0 releases remain the appropriate place to remove an accidental public
+placeholder, correct a mismatched documented guarantee, and refine the exact
+compatibility policy before it becomes the 1.x promise.
+
+### Required work
+
+The stability program has two implementation tracks:
+
+1. [#55](https://github.com/dariuszpanas/pydantic-versions/issues/55)
+   inventories and freezes the deliberate public surface, removes accidental
+   placeholders, reconciles the API reference with runtime behavior, publishes
+   the Semantic Versioning/support policy, and adds API and typing regression
+   tests.
+2. [#56](https://github.com/dariuszpanas/pydantic-versions/issues/56)
+   commits human-readable compatibility artifacts produced by an immutable
+   tagged baseline and verifies persisted payload, inventory, and plan behavior
+   deterministically under current code.
+
+The milestone tracker in
+[#57](https://github.com/dariuszpanas/pydantic-versions/issues/57) remains open
+until both tracks are complete and their evidence has accumulated through
+whatever pre-1.0 releases the maintainer considers useful. Only then is a
+focused 1.0.0 metadata and release issue created.
+
+### Explicit non-goals
+
+The 1.0.0 program does not require:
+
+- a transport, registry, capability-manifest, negotiation, or fingerprint API;
+- structured execution traces or a new validation/rendering result hierarchy;
+- opaque extension preservation for multi-writer documents;
+- automatic projection of every Pydantic customization;
+- Pydantic 3 support before Pydantic 3 exists as a supported dependency;
+- performance service-level objectives;
+- a release-candidate or TestPyPI schedule; or
+- a roadmap for versions after 1.0.0.
+
+Issue [#12](https://github.com/dariuszpanas/pydantic-versions/issues/12) is
+closed as an abandoned design direction rather than deferred into an undefined
+future milestone. New feature proposals can be evaluated if concrete needs
+arise, but they are not current commitments.
+
+### Maintenance posture, not a product roadmap
+
+Once the library solves its defined problem and the current contract has enough
+evidence for 1.0.0, development becomes maintenance-led. Concrete bug reports,
+user feedback, dependency and runtime updates, current ecosystem standards,
+security needs, and bounded polish can justify changes as they arise.
+
+Those triggers are not scheduled deliverables and do not imply a feature
+backlog beyond 1.0.0. A future change is evaluated against the real need and
+the stable compatibility promise at that time. The project does not invent
+distant milestones merely to keep a roadmap populated.
+
+### Release decision
+
+Closing the two implementation tracks is necessary but does not automatically
+publish 1.0.0. The maintainer decides when the accumulated 0.x evidence is
+sufficient. At that point, a freshly fetched exact candidate must pass the
+established release workflow, and tagging and publication still require
+explicit authorization.
+
+## Consequences
+
+The 1.0 milestone stays small and falsifiable. Work either strengthens a
+documented current contract or it does not block 1.0.0. The project can use
+additional 0.x releases whenever they provide real feedback without inventing
+a calendar or feature ladder.
+
+The eventual 1.x compatibility promise will be based on tested behavior rather
+than maturity optics. No post-1.0 work is scheduled by this decision.


### PR DESCRIPTION
## Summary

- define 1.0.0 as proof and freeze of the current useful contract rather than feature completeness
- allow any number of coherent 0.x releases to build the required evidence without predicting versions or dates
- identify API/support-policy freeze and cross-release compatibility fixtures as the only current implementation tracks
- define post-solution work as feedback-, maintenance-, standards-, dependency-, and security-driven rather than a distant product roadmap
- explicitly exclude speculative transport, negotiation, trace, and post-1.0 planning
- preserve objective exit criteria and final maintainer judgment

## Tracking

- #55 freezes and documents the deliberate current public contract
- #56 adds cross-release payload and serialized-contract evidence
- #57 remains the 1.0 milestone tracker until those criteria are satisfied
- #12 was closed as an abandoned design direction rather than deferred

## Validation

- uv run make ci: passed (252 tests, 95.12% coverage)
- uv run make docs-build-strict: passed
- conventional-commit validation: passed

Closes #54
Refs #55
Refs #56
Refs #57
