### PR TITLE
feat(api): freeze the public compatibility contract

### DIFF
--- a/architecture/decisions/0003-1.0-stability-boundary.md
+++ b/architecture/decisions/0003-1.0-stability-boundary.md
@@ -28,10 +28,11 @@ The audit found two concrete stability gaps:
    baseline.
 
 It also confirmed that the historical structured-trace proposal is not part of
-the shipped contract. `VersionedValidationError` remains as an unused exported
-placeholder, while one rendered reference sentence still describes contextual
-wrapping that the runtime does not perform. Adding a trace/result/error system
-would expand the product rather than prove the existing product stable.
+the shipped contract. `VersionedValidationError` was an unused exported
+placeholder, while one rendered reference sentence described contextual
+wrapping that the runtime does not perform. This track removes that placeholder
+and corrects the reference. Adding a trace/result/error system would expand the
+product rather than prove the existing product stable.
 
 ## Decision
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added an explicit stability and compatibility policy plus executable public
+  API and typing contract gates for the path to 1.0.0.
+
+### Changed
+- Corrected the API reference to document that user transition exceptions
+  propagate unchanged while invalid transition return values raise
+  `InvalidMigrationError`.
+
+### Removed
+- Removed the unused `VersionedValidationError` placeholder from the public
+  package surface before the 1.0.0 contract freeze.
+
 ## [0.3.0] - 2026-08-20
 
 ### Added

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -123,7 +123,7 @@ See
 [generated wire contracts](../guide/generated-wire-contracts.md) for the full
 supported preserve, omit, and reject boundary.
 
-### 0.2.0 behavior contract
+### Behavior contract
 
 The generated plan inventory and plans are the preferred compatibility artifacts:
 
@@ -135,9 +135,11 @@ The generated plan inventory and plans are the preferred compatibility artifacts
   conservative;
 - unsafe declarations fail at registration and keep payloads unchanged by never
   running custom transitions before full validation;
-- execution errors from transitions are represented as wrapped, contextual
-  operation errors and do not persist payload values in diagnostics or public
-  traces.
+- exceptions raised by user transition callables propagate with their original
+  type and traceback. A transition that violates the dictionary return contract
+  raises `InvalidMigrationError`; discovery, compilation, and rendering failures
+  use the documented `SchemaVersionError` subclasses. Exception messages are
+  diagnostic text rather than structured API.
 
 ### Reserved nested declarations
 
@@ -377,8 +379,7 @@ class VersionedValidation[T: BaseModel]:
   - `MissingSchemaVersionError`
   - `UnknownSchemaVersionError`
   - `DuplicateSchemaVersionError`
-  - `InvalidMigrationError`
-  - `VersionedValidationError`
+- `InvalidMigrationError`
 
 `UnsupportedWireModelError` reports that automatic projection cannot safely
 produce the required object-shaped Pydantic v2 wire contract. It is raised
@@ -386,3 +387,6 @@ during compilation and includes safe family, model, and unsupported-reason
 context, plus the version for projection-specific failures. Direct validation
 of a successfully generated wire model still raises Pydantic's native
 `ValidationError`.
+
+See the [stability and compatibility policy](stability-policy.md) for the exact
+public/private boundary and the Semantic Versioning rules applied to this API.

--- a/docs/reference/stability-policy.md
+++ b/docs/reference/stability-policy.md
@@ -1,0 +1,130 @@
+# Stability and Compatibility Policy
+
+`pydantic-versions` uses Semantic Versioning for the deliberate public
+contract described here. This policy becomes the compatibility promise at
+1.0.0. During the remaining 0.x releases, the project may still remove an
+accidental placeholder or correct a mismatched guarantee before freezing that
+surface; those changes are documented in the changelog.
+
+Stable does not mean feature-complete. It means that the behavior the package
+claims to support is deliberate, tested, and changed under explicit versioning
+rules.
+
+## Public Python surface
+
+The stable Python surface consists of:
+
+- names exported by `pydantic_versions.__all__` and imported from the package
+  root;
+- their documented call signatures and typing behavior;
+- fields of exported frozen records;
+- the inheritance relationships of exported exceptions;
+- documented `SchemaFamily` methods and read-only properties; and
+- the package's `py.typed` marker and supported static-typing examples.
+
+Modules whose names begin with an underscore are private. Other implementation
+modules are also not separate import contracts: import public names from
+`pydantic_versions`, not from the module that currently defines them.
+
+Exception classes and their inheritance are stable. Exact exception messages,
+tracebacks, and private chained-exception details are diagnostic text rather
+than machine-readable API.
+
+## Schema and wire behavior
+
+Application schema labels are immutable wire contracts. Reusing a published
+label for incompatible fields, aliases, constraints, defaults, metadata, or
+transition meaning is an application-level breaking change even if the Python
+package version is unchanged.
+
+For a supported declaration, compatible 1.x package releases preserve the
+documented behavior of:
+
+- version discovery and explicit `version=` selection;
+- generated input and output wire shapes;
+- historical defaults, removals, and renames;
+- upgrade and downgrade ordering;
+- nested-family conversion;
+- exact, lossy, and unavailable rendering semantics; and
+- validation into the authoritative current Pydantic model.
+
+Generated model object identity is stable within one compiled family. Private
+attributes and implementation class names are not a cross-release contract.
+The supported JSON Schema and serialized payload behavior is the contract.
+
+## Inventories and plans
+
+Exported inventory and plan records, their frozen fields, `to_dict()` keys and
+meanings, canonical ordering, path representation, semantics, and deterministic
+step IDs are stable for an equivalent supported declaration.
+
+A later release may add behavior for a newly supported declaration without
+changing the output for existing supported declarations. An unexplained change
+to a committed golden inventory or plan is treated as a compatibility failure,
+not accepted by regenerating the fixture silently.
+
+## Semantic Versioning rules
+
+Within 1.x, a major release is required to:
+
+- remove or rename a public export;
+- make a supported call signature incompatible;
+- remove or reinterpret an exported record field;
+- change documented exception inheritance;
+- invalidate persisted payloads that satisfy the stable contract;
+- change the meaning of an existing schema declaration; or
+- incompatibly change stable inventory or plan serialization for an equivalent
+  declaration.
+
+A minor release may add optional API, support a new declaration form, add a new
+runtime or dependency version, or deprecate API while keeping it operational.
+A patch release may correct behavior to match the existing contract, improve
+diagnostics or documentation, update compatible dependencies, and make
+internal performance or reliability changes.
+
+If a correctness or security fix necessarily changes observable behavior, the
+release notes identify the affected contract and migration path. Security and
+data integrity take priority over preserving a defect.
+
+## Deprecation
+
+During 1.x, a public API is not removed merely because a preferred alternative
+exists. Deprecation requires:
+
+1. a documented replacement or reason;
+2. a changelog entry;
+3. an appropriate runtime warning when the deprecated path is executed; and
+4. retention until the next major release unless an exceptional security or
+   data-integrity issue makes that unsafe.
+
+The decorator and model-first compatibility entry points are part of the
+deliberate contract unless they are explicitly deprecated under this policy.
+
+## Python and Pydantic support
+
+The current supported range is authoritative in package metadata and the
+[compatibility matrix](../guide/pydantic-compatibility-matrix.md). CI verifies
+the lowest supported Pydantic version, the locked environment, the latest
+allowed Pydantic version, and every supported Python minor.
+
+Adding support can occur in a minor or patch release. Dropping an end-of-life
+Python minor or raising the Pydantic lower bound is a maintenance compatibility
+change: it occurs in a minor release, is called out prominently in the
+changelog, and must be justified by upstream support, correctness, security, or
+standards alignment. The `<3.0` upper bound remains until Pydantic 3 support is
+deliberately designed and tested.
+
+Dependency updates that remain inside the declared support ranges are normal
+maintenance and do not by themselves require a feature release.
+
+## Evidence and maintenance
+
+The compatibility promise is enforced through public-surface, typing,
+cross-release golden, unit, integration, supported-version, documentation,
+security, and isolated-package tests. A green narrow test is not evidence for a
+broad compatibility claim; the complete relevant gate must pass.
+
+Once the package solves its defined problem, work is driven by concrete user
+feedback, bug and security reports, dependency/runtime updates, current
+ecosystem standards, and bounded polish. These are responses to real needs,
+not a commitment to a speculative long-range feature roadmap.

--- a/src/pydantic_versions/__init__.py
+++ b/src/pydantic_versions/__init__.py
@@ -34,7 +34,6 @@ from pydantic_versions.exceptions import (
     SchemaVersionError,
     UnknownSchemaVersionError,
     UnsupportedWireModelError,
-    VersionedValidationError,
 )
 from pydantic_versions.family import SchemaFamily
 from pydantic_versions.inspection import (
@@ -101,7 +100,6 @@ __all__ = [
     "VersionPath",
     "VersionTransition",
     "VersionedValidation",
-    "VersionedValidationError",
     "VersionDescription",
     "__version__",
     "dump_versioned",

--- a/src/pydantic_versions/exceptions.py
+++ b/src/pydantic_versions/exceptions.py
@@ -35,7 +35,3 @@ class DuplicateSchemaVersionError(SchemaVersionError):
 
 class InvalidMigrationError(SchemaVersionError):
     """Raised when a migration is invalid or returns an invalid value."""
-
-
-class VersionedValidationError(SchemaVersionError):
-    """Raised when versioned validation cannot be completed."""

--- a/tests/typing/schema_family_contract.py
+++ b/tests/typing/schema_family_contract.py
@@ -6,7 +6,16 @@ from pydantic import BaseModel
 
 from pydantic_versions import (
     ConversionPlan,
+    DuplicateSchemaVersionError,
+    FieldDefault,
+    FieldRemoved,
+    FieldRenamed,
+    InvalidMigrationError,
     IrreversibleTransitionError,
+    JsonValue,
+    MatchingLabels,
+    MissingSchemaVersionError,
+    NestedFamily,
     NestedFamilyDescription,
     PlanStep,
     ProjectionDescription,
@@ -15,16 +24,21 @@ from pydantic_versions import (
     SchemaFamilySelectionError,
     SchemaInventory,
     SchemaVersion,
+    SchemaVersionError,
     StepKind,
     StepSemantics,
     TransitionDescription,
     UnsupportedWireModelError,
     VersionDescription,
     VersionedValidation,
+    VersionMetadata,
     VersionPatch,
     VersionTransition,
     dump_versioned,
     field_default,
+    field_removed,
+    field_renamed,
+    matching_labels,
     model_for_version,
     validate_versioned,
 )
@@ -39,6 +53,11 @@ def upgrade_v1(data: dict[str, Any]) -> dict[str, Any]:
 
 
 patch: VersionPatch = field_default("timeout", 5.0)
+default_patch: FieldDefault = field_default("timeout", 5.0)
+removed_patch: FieldRemoved = field_removed("timeout")
+renamed_patch: FieldRenamed = field_renamed("timeout", "request_timeout")
+labels: MatchingLabels = matching_labels()
+metadata = VersionMetadata(path="schema_version", owner="family")
 family: SchemaFamily[AppConfig] = SchemaFamily(
     model=AppConfig,
     name="app_config",
@@ -52,6 +71,13 @@ family: SchemaFamily[AppConfig] = SchemaFamily(
         ),
     ),
 )
+nested: NestedFamily = NestedFamily(path="child", family=family, versions=labels)
+json_value: JsonValue = {"version": "1"}
+assert_type(default_patch, FieldDefault)
+assert_type(removed_patch, FieldRemoved)
+assert_type(renamed_patch, FieldRenamed)
+assert_type(nested, NestedFamily)
+assert_type(metadata, VersionMetadata)
 
 assert_type(family.compile(), SchemaFamily[AppConfig])
 assert_type(family.as_default(), SchemaFamily[AppConfig])
@@ -81,6 +107,10 @@ assert_type(family.dump(version="1"), dict[str, Any])
 assert_type(dump_versioned(family, version="1"), dict[str, Any])
 
 compilation_error: type[Exception] = SchemaCompilationError
+schema_error: type[Exception] = SchemaVersionError
 unsupported_wire_error: type[SchemaCompilationError] = UnsupportedWireModelError
 selection_error: type[Exception] = SchemaFamilySelectionError
 irreversible_error: type[Exception] = IrreversibleTransitionError
+missing_error: type[Exception] = MissingSchemaVersionError
+duplicate_error: type[Exception] = DuplicateSchemaVersionError
+invalid_migration_error: type[Exception] = InvalidMigrationError

--- a/tests/unit/test_public_api_contract.py
+++ b/tests/unit/test_public_api_contract.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import fields, is_dataclass
+from types import FunctionType
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+import pydantic_versions as public_api
+from pydantic_versions import (
+    DuplicateSchemaVersionError,
+    InvalidMigrationError,
+    IrreversibleTransitionError,
+    MissingSchemaVersionError,
+    SchemaCompilationError,
+    SchemaFamily,
+    SchemaFamilySelectionError,
+    SchemaVersion,
+    SchemaVersionError,
+    UnknownSchemaVersionError,
+    UnsupportedWireModelError,
+    VersionTransition,
+)
+
+EXPECTED_EXPORTS = (
+    "ConversionPlan",
+    "DuplicateSchemaVersionError",
+    "FieldDefault",
+    "FieldRemoved",
+    "FieldRenamed",
+    "InvalidMigrationError",
+    "IrreversibleTransitionError",
+    "JsonValue",
+    "MatchingLabels",
+    "MissingSchemaVersionError",
+    "NestedFamily",
+    "NestedFamilyDescription",
+    "PlanStep",
+    "ProjectionDescription",
+    "SchemaCompilationError",
+    "SchemaFamily",
+    "SchemaFamilySelectionError",
+    "SchemaInventory",
+    "SchemaVersion",
+    "SchemaVersionError",
+    "StepKind",
+    "StepSemantics",
+    "TransitionData",
+    "TransitionFunc",
+    "TransitionDescription",
+    "UnsupportedWireModelError",
+    "UnknownSchemaVersionError",
+    "VersionMetadata",
+    "VersionPatch",
+    "VersionPath",
+    "VersionTransition",
+    "VersionedValidation",
+    "VersionDescription",
+    "__version__",
+    "dump_versioned",
+    "field_default",
+    "field_removed",
+    "field_renamed",
+    "matching_labels",
+    "migration",
+    "model_for_version",
+    "schema_version",
+    "schema_versions",
+    "validate_versioned",
+    "versioned_schema",
+)
+
+EXPECTED_RECORD_FIELDS = {
+    "ConversionPlan": (
+        "family",
+        "source_version",
+        "target_version",
+        "operation",
+        "semantics",
+        "steps",
+    ),
+    "FieldDefault": ("name", "default", "default_factory", "has_default"),
+    "FieldRemoved": ("name",),
+    "FieldRenamed": ("current_name", "version_name"),
+    "MatchingLabels": (),
+    "NestedFamily": ("path", "family", "versions"),
+    "NestedFamilyDescription": ("schema_path", "family", "versions"),
+    "PlanStep": (
+        "id",
+        "family",
+        "source_version",
+        "target_version",
+        "operation",
+        "direction",
+        "kind",
+        "schema_path",
+        "semantics",
+        "conditional",
+    ),
+    "ProjectionDescription": ("kind", "current_field", "historical_field", "has_default"),
+    "SchemaInventory": (
+        "family",
+        "model",
+        "current_version",
+        "versions",
+        "transitions",
+        "nested",
+        "version_metadata",
+    ),
+    "SchemaVersion": ("label", "patches", "wire_model"),
+    "TransitionDescription": ("source", "target", "upgrade", "downgrade", "downgrade_semantics"),
+    "VersionDescription": ("label", "wire_model", "projections"),
+    "VersionMetadata": ("path", "owner"),
+    "VersionTransition": ("source", "target", "upgrade", "downgrade", "downgrade_semantics"),
+    "VersionedValidation": (
+        "source_version",
+        "current_version",
+        "source_model",
+        "current_model",
+        "migrations_applied",
+    ),
+}
+
+
+def _signature_shape(callable_: Any) -> tuple[tuple[str, str, bool], ...]:
+    return tuple(
+        (
+            name,
+            parameter.kind.name,
+            parameter.default is not inspect.Parameter.empty,
+        )
+        for name, parameter in inspect.signature(callable_).parameters.items()
+    )
+
+
+EXPECTED_FUNCTION_SIGNATURES = {
+    "dump_versioned": (
+        ("subject", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "KEYWORD_ONLY", False),
+        ("data", "KEYWORD_ONLY", True),
+        ("include_version", "KEYWORD_ONLY", True),
+        ("dump_kwargs", "VAR_KEYWORD", False),
+    ),
+    "field_default": (
+        ("name", "POSITIONAL_OR_KEYWORD", False),
+        ("default", "POSITIONAL_OR_KEYWORD", True),
+        ("default_factory", "KEYWORD_ONLY", True),
+    ),
+    "field_removed": (("name", "POSITIONAL_OR_KEYWORD", False),),
+    "field_renamed": (
+        ("current_name", "POSITIONAL_OR_KEYWORD", False),
+        ("version_name", "POSITIONAL_OR_KEYWORD", False),
+    ),
+    "matching_labels": (),
+    "migration": (
+        ("subject", "POSITIONAL_OR_KEYWORD", False),
+        ("from_version", "POSITIONAL_OR_KEYWORD", False),
+        ("to_version", "POSITIONAL_OR_KEYWORD", False),
+    ),
+    "model_for_version": (
+        ("subject", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "POSITIONAL_OR_KEYWORD", False),
+    ),
+    "schema_version": (
+        ("version", "POSITIONAL_OR_KEYWORD", False),
+        ("patches", "KEYWORD_ONLY", True),
+        ("wire_model", "KEYWORD_ONLY", True),
+    ),
+    "schema_versions": (
+        ("versions", "POSITIONAL_OR_KEYWORD", False),
+        ("patches", "KEYWORD_ONLY", True),
+        ("wire_model", "KEYWORD_ONLY", True),
+    ),
+    "validate_versioned": (
+        ("subject", "POSITIONAL_OR_KEYWORD", False),
+        ("data", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "KEYWORD_ONLY", True),
+    ),
+    "versioned_schema": (
+        ("name", "KEYWORD_ONLY", False),
+        ("versions", "KEYWORD_ONLY", False),
+        ("current", "KEYWORD_ONLY", False),
+        ("version_field", "KEYWORD_ONLY", True),
+        ("missing_version", "KEYWORD_ONLY", True),
+        ("metadata_owner", "KEYWORD_ONLY", True),
+        ("transitions", "KEYWORD_ONLY", True),
+        ("nested", "KEYWORD_ONLY", True),
+    ),
+}
+
+EXPECTED_FAMILY_SIGNATURES = {
+    "__init__": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("model", "KEYWORD_ONLY", False),
+        ("name", "KEYWORD_ONLY", False),
+        ("versions", "KEYWORD_ONLY", False),
+        ("transitions", "KEYWORD_ONLY", True),
+        ("nested", "KEYWORD_ONLY", True),
+        ("version_metadata", "KEYWORD_ONLY", True),
+        ("missing_version", "KEYWORD_ONLY", True),
+    ),
+    "compile": (("self", "POSITIONAL_OR_KEYWORD", False),),
+    "as_default": (("self", "POSITIONAL_OR_KEYWORD", False),),
+    "describe": (("self", "POSITIONAL_OR_KEYWORD", False),),
+    "plan_validation": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("source_version", "POSITIONAL_OR_KEYWORD", False),
+    ),
+    "plan_render": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("target_version", "POSITIONAL_OR_KEYWORD", False),
+    ),
+    "model_for": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "POSITIONAL_OR_KEYWORD", False),
+    ),
+    "validate": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("data", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "KEYWORD_ONLY", True),
+    ),
+    "defaults_for": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "KEYWORD_ONLY", False),
+        ("include_version", "KEYWORD_ONLY", True),
+        ("dump_kwargs", "VAR_KEYWORD", False),
+    ),
+    "dump": (
+        ("self", "POSITIONAL_OR_KEYWORD", False),
+        ("version", "KEYWORD_ONLY", False),
+        ("data", "KEYWORD_ONLY", True),
+        ("include_version", "KEYWORD_ONLY", True),
+        ("dump_kwargs", "VAR_KEYWORD", False),
+    ),
+}
+
+
+def test_package_root_exports_are_an_explicit_contract() -> None:
+    assert tuple(public_api.__all__) == EXPECTED_EXPORTS
+    assert all(hasattr(public_api, name) for name in EXPECTED_EXPORTS)
+
+
+def test_exported_record_fields_and_immutability_are_an_explicit_contract() -> None:
+    for name, expected_fields in EXPECTED_RECORD_FIELDS.items():
+        record = getattr(public_api, name)
+        assert is_dataclass(record), name
+        assert record.__dataclass_params__.frozen, name
+        assert tuple(field.name for field in fields(record)) == expected_fields
+
+
+def test_public_call_signatures_are_an_explicit_contract() -> None:
+    actual_functions = {
+        name: _signature_shape(getattr(public_api, name))
+        for name in EXPECTED_EXPORTS
+        if isinstance(getattr(public_api, name), FunctionType)
+    }
+    assert actual_functions == EXPECTED_FUNCTION_SIGNATURES
+    assert {
+        name: _signature_shape(getattr(SchemaFamily, name)) for name in EXPECTED_FAMILY_SIGNATURES
+    } == EXPECTED_FAMILY_SIGNATURES
+    assert {
+        name
+        for name, value in vars(SchemaFamily).items()
+        if isinstance(value, property) and not name.startswith("_")
+    } == {
+        "model",
+        "name",
+        "versions",
+        "transitions",
+        "nested",
+        "version_metadata",
+        "missing_version",
+        "current_version",
+    }
+
+
+def test_exception_hierarchy_is_an_explicit_contract() -> None:
+    assert SchemaVersionError.__bases__ == (Exception,)
+    assert SchemaCompilationError.__bases__ == (SchemaVersionError,)
+    assert UnsupportedWireModelError.__bases__ == (SchemaCompilationError,)
+    for exception in (
+        SchemaFamilySelectionError,
+        IrreversibleTransitionError,
+        MissingSchemaVersionError,
+        UnknownSchemaVersionError,
+        DuplicateSchemaVersionError,
+        InvalidMigrationError,
+    ):
+        assert exception.__bases__ == (SchemaVersionError,)
+
+
+def test_user_transition_exceptions_propagate_unchanged() -> None:
+    class CurrentConfig(BaseModel):
+        value: int
+
+    class ApplicationTransitionError(RuntimeError):
+        pass
+
+    error = ApplicationTransitionError("application-owned failure")
+
+    def fail(_data: dict[str, Any]) -> dict[str, Any]:
+        raise error
+
+    family = SchemaFamily(
+        model=CurrentConfig,
+        name="exception_contract",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(VersionTransition("1", "2", upgrade=fail),),
+    )
+
+    with pytest.raises(ApplicationTransitionError) as raised:
+        family.validate({"schema_version": "1", "value": 1})
+    assert raised.value is error

--- a/zensical.toml
+++ b/zensical.toml
@@ -29,6 +29,7 @@ nav = [
   ] },
   { "Reference" = [
     { "API" = "reference/api.md" },
+    { "Stability and Compatibility" = "reference/stability-policy.md" },
   ] },
   { "Development" = [
     { "Contributing" = "contributing.md" },


### PR DESCRIPTION
## Summary

- define the public/private and Semantic Versioning boundary intended for 1.0
- snapshot root exports, call signatures, frozen records, properties, exception inheritance, and typing behavior
- remove the unused VersionedValidationError placeholder and accurately document user transition failures

## Validation

- uv run make ci
- uv run make docs-build-strict

Closes #55