### PR TITLE
fix(docs): restore the PyPI documentation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bring version control and history to your Pydantic schemas.
   <a href="https://github.com/dariuszpanas/pydantic-versions/actions/workflows/ci.yml"><img src="https://github.com/dariuszpanas/pydantic-versions/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
   <a href="https://pypi.org/project/pydantic-versions/"><img src="https://img.shields.io/pypi/v/pydantic-versions.svg" alt="PyPI version"></a>
   <a href="https://pypi.org/project/pydantic-versions/"><img src="https://img.shields.io/pypi/pyversions/pydantic-versions.svg" alt="Supported Python versions"></a>
-  <a href="https://pydantic-versions.readthedocs.io/en/latest/"><img src="https://readthedocs.org/projects/pydantic-versions/badge/?version=latest" alt="Documentation status"></a>
+  <a href="https://pydantic-versions.readthedocs.io/en/latest/"><img src="https://img.shields.io/readthedocs/pydantic-versions/latest.svg" alt="Documentation status"></a>
   <a href="https://github.com/dariuszpanas/pydantic-versions/blob/main/LICENSE"><img src="https://img.shields.io/github/license/dariuszpanas/pydantic-versions" alt="License"></a>
 </p>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   propagate unchanged while invalid transition return values raise
   `InvalidMigrationError`.
 
+### Fixed
+- Replaced the redirecting Read the Docs badge source with a directly rendered
+  Shields endpoint so the documentation status appears on PyPI.
+
 ### Removed
 - Removed the unused `VersionedValidationError` placeholder from the public
   package surface before the 1.0.0 contract freeze.

--- a/tests/unit/test_package_metadata.py
+++ b/tests/unit/test_package_metadata.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+README = ROOT / "README.md"
+DOCS_URL = "https://pydantic-versions.readthedocs.io/en/latest/"
+DOCS_BADGE_URL = "https://img.shields.io/readthedocs/pydantic-versions/latest.svg"
+REDIRECTING_BADGE_URL = "https://readthedocs.org/projects/pydantic-versions/badge/?version=latest"
+
+
+def test_readme_uses_a_non_redirecting_documentation_badge_for_pypi() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert f'<a href="{DOCS_URL}"><img src="{DOCS_BADGE_URL}"' in readme
+    assert REDIRECTING_BADGE_URL not in readme


### PR DESCRIPTION
## Summary

- replace the Read the Docs badge URL that redirects and fails through PyPI's image proxy
- use the direct Shields Read the Docs status SVG while retaining the documentation link and alt text
- add package README regression coverage and an Unreleased changelog entry

## Root cause

The old image URL now returns HTTP 307 to app.readthedocs.org. PyPI's image proxy returns HTTP 404 for that proxied badge instead of following the redirect. The replacement returns HTTP 200 with image/svg+xml directly.

## Validation

- uv run make ci
- uv run make docs-build-strict
- uv build
- replacement badge endpoint: HTTP 200 image/svg+xml
- built wheel metadata contains the replacement and excludes the redirecting source

Closes #61