### PR TITLE
fix(nested): reject unsupported family boundaries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Replaced the redirecting Read the Docs badge source with a directly rendered
   Shields endpoint so the documentation status appears on PyPI.
+- Rejected nested-family mappings, heterogeneous branches, and child-model
+  mismatches during compilation while preserving supported homogeneous
+  collection and optional boundaries.
 
 ### Removed
 - Removed the unused `VersionedValidationError` placeholder from the public

--- a/docs/guide/complex-config-example.md
+++ b/docs/guide/complex-config-example.md
@@ -192,9 +192,10 @@ class RetryPolicy(BaseModel):
     backoff_seconds: float = 2.0
 ```
 
-Then any versioned model that references `RetryPolicy` can generate a matching
-historical nested schema for `list[WorkerConfig]`, `dict[str, RetryPolicy]`,
-tuples, sets, and optional nested model fields where applicable.
+Then a versioned model can explicitly connect that family through direct or
+optional fields and homogeneous lists, tuples, sets, or frozen sets. Mapping
+values and heterogeneous unions are rejected during family compilation because
+runtime conversion cannot dispatch them unambiguously.
 
 ## When Patches Are Not Enough
 

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -28,10 +28,17 @@ Pydantic's declarative handling of that shape:
 | Omitted | Server-internal fields marked with `Field(exclude=True)` or `Field(exclude_if=...)` | The field is absent from every generated wire projection; it remains available on the authoritative application model. |
 | Rejected | Callable discriminators and unknown behavior-changing model or field settings | The automatic compiler fails closed instead of silently changing the wire document. |
 | Rejected at registration | Pydantic v1 compatibility models | The family raises `SchemaVersionError` before automatic projection; wire models must inherit from Pydantic v2's `BaseModel`. |
+| Rejected | A `NestedFamily` path through a mapping, a heterogeneous union or collection, or a field owned by a different model than the declared child family | Runtime conversion cannot dispatch those shapes unambiguously, so compilation raises `UnsupportedWireModelError`. |
 
 Historical patches are applied to this preserved declaration state. A removed
 field is absent, a renamed field uses its historical Python name, and a default
 patch replaces the projected field's required/default/factory state.
+
+Explicit `NestedFamily` declarations support direct and optional child models,
+plus homogeneous `list`, `tuple`, `set`, and `frozenset` boundaries. The same
+boundaries can appear while traversing a multi-segment path. Mapping values and
+heterogeneous branches are intentionally rejected during compilation rather
+than accepted with payload-dependent behavior.
 
 An excluded field is also absent from the generated wire model. This is the
 supported way to keep server-internal state on the authoritative model while

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -4,7 +4,8 @@ import hashlib
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from types import UnionType
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -22,6 +23,7 @@ from pydantic_versions.exceptions import (
     SchemaCompilationError,
     SchemaVersionError,
     UnknownSchemaVersionError,
+    UnsupportedWireModelError,
 )
 from pydantic_versions.patches import FieldDefault, FieldRemoved, FieldRenamed, VersionPatch
 
@@ -190,15 +192,19 @@ def _validate_compilation_boundary(
     if not nested:
         return ()
 
-    compiled_nested: list[_CompiledNestedFamily] = []
-    used_paths: set[tuple[str, ...]] = set()
-    for declaration in nested:
-        path = (declaration.path,) if isinstance(declaration.path, str) else tuple(declaration.path)
-        if path in used_paths:
-            msg = f"Duplicate nested family declaration path {path!r} for {name!r}"
-            raise SchemaCompilationError(msg)
-        used_paths.add(path)
+    declared_paths = tuple(
+        (declaration.path,) if isinstance(declaration.path, str) else tuple(declaration.path)
+        for declaration in nested
+    )
+    duplicate_paths = tuple(
+        path for index, path in enumerate(declared_paths) if path in declared_paths[:index]
+    )
+    if duplicate_paths:
+        msg = f"Duplicate nested family declaration path {duplicate_paths[0]!r} for {name!r}"
+        raise SchemaCompilationError(msg)
 
+    compiled_nested: list[_CompiledNestedFamily] = []
+    for declaration, path in zip(nested, declared_paths, strict=True):
         declaration_family = declaration.family
         if isinstance(declaration_family, SchemaFamily):
             child_family = declaration_family
@@ -224,6 +230,21 @@ def _validate_compilation_boundary(
                 "the same owning model"
             )
             raise SchemaCompilationError(msg)
+
+        nested_model = _nested_path_model(
+            model=model,
+            family_name=name,
+            path=path,
+        )
+        if nested_model is not None and nested_model is not child_family.model:
+            expected = _model_display(nested_model)
+            declared = _model_display(child_family.model)
+            msg = (
+                f"Nested family declaration at path {path!r} for {name!r} targets model "
+                f"{expected!r}, but declared child family {child_family.name!r} owns "
+                f"model {declared!r}"
+            )
+            raise UnsupportedWireModelError(msg)
 
         parent_labels = labels
         child_labels = tuple(version.label for version in child_family.versions)
@@ -272,6 +293,112 @@ def _validate_compilation_boundary(
         )
 
     return tuple(compiled_nested)
+
+
+def _nested_path_model(
+    *,
+    model: type[BaseModel],
+    family_name: str,
+    path: tuple[str, ...],
+) -> type[BaseModel] | None:
+    annotation: Any = model
+    for index, field_name in enumerate(path):
+        annotation = _nested_container_element(
+            annotation,
+            family_name=family_name,
+            path=path,
+        )
+        if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+            return None
+        field_info = annotation.model_fields.get(field_name)
+        if field_info is None:
+            return None
+        annotation = field_info.annotation
+        if index < len(path) - 1:
+            annotation = _nested_container_element(
+                annotation,
+                family_name=family_name,
+                path=path,
+            )
+
+    annotation = _nested_container_element(
+        annotation,
+        family_name=family_name,
+        path=path,
+    )
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    msg = (
+        f"Nested family declaration at path {path!r} for {family_name!r} must resolve "
+        "to exactly one Pydantic model"
+    )
+    raise UnsupportedWireModelError(msg)
+
+
+def _nested_container_element(
+    annotation: Any,
+    *,
+    family_name: str,
+    path: tuple[str, ...],
+) -> Any:
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        arguments = get_args(annotation)
+        non_none = tuple(argument for argument in arguments if argument is not type(None))
+        if len(non_none) == 1 and len(non_none) != len(arguments):
+            return _nested_container_element(
+                non_none[0],
+                family_name=family_name,
+                path=path,
+            )
+        msg = (
+            f"Nested family declaration at path {path!r} for {family_name!r} uses a "
+            "heterogeneous union; only an optional single-model branch is supported"
+        )
+        raise UnsupportedWireModelError(msg)
+
+    if origin is not None and (
+        origin is dict or (isinstance(origin, type) and issubclass(origin, Mapping))
+    ):
+        msg = (
+            f"Nested family declaration at path {path!r} for {family_name!r} uses a "
+            "mapping container, which is not a supported nested-family boundary"
+        )
+        raise UnsupportedWireModelError(msg)
+
+    if origin not in (list, tuple, set, frozenset):
+        return annotation
+
+    arguments = tuple(argument for argument in get_args(annotation) if argument is not Ellipsis)
+    if not arguments:
+        msg = (
+            f"Nested family declaration at path {path!r} for {family_name!r} uses an "
+            "unparameterized collection"
+        )
+        raise UnsupportedWireModelError(msg)
+    elements = tuple(
+        _nested_container_element(
+            argument,
+            family_name=family_name,
+            path=path,
+        )
+        for argument in arguments
+    )
+    first = elements[0]
+    if any(element is not first for element in elements[1:]):
+        msg = (
+            f"Nested family declaration at path {path!r} for {family_name!r} uses a "
+            "heterogeneous collection; every element must use the same child model"
+        )
+        raise UnsupportedWireModelError(msg)
+    return first
+
+
+def _model_display(model: type[BaseModel]) -> str:
+    return f"{model.__module__}.{model.__qualname__}"
 
 
 def _validate_required_field_introductions(

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -1850,7 +1850,7 @@ def _rewrite_nested_default(
             f"field {field_name!r} uses an opaque factory for a projected nested model",
         )
     default = attributes.get("default", PydanticUndefined)
-    if default is PydanticUndefined:
+    if default is PydanticUndefined or default is None:
         return
     try:
         is_default_from_source = isinstance(default, original_annotation)

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -1168,6 +1168,122 @@ def test_unused_nested_declarations_are_rejected() -> None:
         family.model_for("1")
 
 
+def test_nested_family_mapping_boundary_is_rejected_during_compilation() -> None:
+    class ChildPayload(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=ChildPayload,
+        name="mapping_boundary_child",
+        versions=(SchemaVersion("1"),),
+    )
+
+    class ParentPayload(BaseModel):
+        children: dict[str, ChildPayload]
+
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="mapping_boundary_parent",
+        versions=(SchemaVersion("1"),),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="mapping container"):
+        family.compile()
+
+
+def test_nested_family_wrong_model_is_rejected_with_context() -> None:
+    class ExpectedChild(BaseModel):
+        value: int
+
+    class DeclaredChild(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=DeclaredChild,
+        name="wrong_model_child_family",
+        versions=(SchemaVersion("1"),),
+    )
+
+    class ParentPayload(BaseModel):
+        child: ExpectedChild
+
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="wrong_model_parent_family",
+        versions=(SchemaVersion("1"),),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError) as exc_info:
+        family.compile()
+
+    message = str(exc_info.value)
+    assert "wrong_model_parent_family" in message
+    assert "('child',)" in message
+    assert "ExpectedChild" in message
+    assert "wrong_model_child_family" in message
+    assert "DeclaredChild" in message
+
+
+def test_nested_family_heterogeneous_union_is_rejected_during_compilation() -> None:
+    class ChildPayload(BaseModel):
+        value: int
+
+    class OtherPayload(BaseModel):
+        other: str
+
+    child_family = SchemaFamily(
+        model=ChildPayload,
+        name="union_boundary_child",
+        versions=(SchemaVersion("1"),),
+    )
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload | OtherPayload
+
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="union_boundary_parent",
+        versions=(SchemaVersion("1"),),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="heterogeneous union"):
+        family.compile()
+
+
+def test_nested_family_supported_container_boundaries_compile() -> None:
+    class ChildPayload(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=ChildPayload,
+        name="supported_boundary_child",
+        versions=(SchemaVersion("1"),),
+    )
+
+    class ParentPayload(BaseModel):
+        direct: ChildPayload
+        optional: ChildPayload | None = None
+        listed: list[ChildPayload]
+        tupled: tuple[ChildPayload, ...]
+        setted: set[ChildPayload]
+        frozen: frozenset[ChildPayload]
+
+    paths = ("direct", "optional", "listed", "tupled", "setted", "frozen")
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="supported_nested_boundaries",
+        versions=(SchemaVersion("1"),),
+        nested=tuple(NestedFamily(path, child_family, matching_labels()) for path in paths),
+    )
+
+    wire = family.model_for("1")
+
+    assert set(wire.model_fields) == set(paths) | {"schema_version"}
+
+
 def test_nested_projection_rewrites_deeply_nested_models() -> None:
     class InnerPayload(BaseModel):
         label: int

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -125,11 +125,11 @@ def test_compiler_private_paths_raise_expected_errors() -> None:
 
 
 def test_compiler_validation_catches_nested_family_projection_errors() -> None:
-    class Parent(BaseModel):
-        value: int = 1
-
     class Child(BaseModel):
         value: int = 1
+
+    class Parent(BaseModel):
+        child: Child
 
     child = SchemaFamily(
         model=Child,
@@ -141,8 +141,8 @@ def test_compiler_validation_catches_nested_family_projection_errors() -> None:
         name="parent",
         versions=(SchemaVersion("v1"), SchemaVersion("v2")),
         nested=(
-            NestedFamily("value", child, matching_labels()),
-            NestedFamily("value", child, matching_labels()),
+            NestedFamily("child", child, matching_labels()),
+            NestedFamily("child", child, matching_labels()),
         ),
     )
 
@@ -159,14 +159,14 @@ def test_compiler_validation_catches_nested_family_projection_errors() -> None:
             name="parent",
             model=Parent,
             labels=("v1", "v2"),
-            nested=(NestedFamily("value", lambda: cast(Any, "not_family"), matching_labels()),),
+            nested=(NestedFamily("child", lambda: cast(Any, "not_family"), matching_labels()),),
         )
 
     compiled_boundary = _validate_compilation_boundary(
         name="parent",
         model=Parent,
         labels=("v1", "v2"),
-        nested=(NestedFamily("value", lambda: child, versions={"v1": "v1", "v2": "v2"}),),
+        nested=(NestedFamily("child", lambda: child, versions={"v1": "v1", "v2": "v2"}),),
     )
     assert len(compiled_boundary) == 1
 


### PR DESCRIPTION
## Summary

- validate every explicit `NestedFamily` path against its authoritative child model before wire generation
- reject mapping boundaries, heterogeneous unions/collections, and wrong child-family models during compilation
- retain direct, optional, list, tuple, set, and frozenset boundaries and preserve optional `None` defaults
- document the fail-closed boundary and record the pre-1.0 correction

## Validation

- `uv run make ci`
- `uv run python tests/compatibility/v0_3_0_contract.py --check`
- `uv run zensical build --strict`
- `uv run python scripts/check_conventional_commits.py --range origin/main..HEAD`

All passed locally on Python 3.12.12.

Closes #64