### PR TITLE
fix(runtime): honor source wire alias policy

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rejected nested-family mappings, heterogeneous branches, and child-model
   mismatches during compilation while preserving supported homogeneous
   collection and optional boundaries.
+- Made family validation honor each source wire model's configured alias and
+  Python-name acceptance policy at the raw input boundary.
 
 ### Removed
 - Removed the unused `VersionedValidationError` placeholder from the public

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -37,7 +37,7 @@ def _validate_family[T: BaseModel](
     compiled = family._compiled_family()
     source_version = _detect_version(compiled, data, explicit_version=version)
     source = compiled.version(source_version)
-    source_model = source.model.model_validate(data, by_name=True)
+    source_model = source.model.model_validate(data)
     payload = _to_current_names(
         compiled,
         source,

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -744,6 +744,107 @@ def test_alias_handoff_uses_canonical_names_without_creating_forbidden_extras() 
     assert complex_result.current_model.path == 4
 
 
+@pytest.mark.parametrize("explicit_wire", [False, True])
+@pytest.mark.parametrize(
+    ("validate_by_alias", "validate_by_name", "accepted_key", "rejected_key"),
+    [
+        (True, False, "admin", "is_admin"),
+        (False, True, "is_admin", "admin"),
+    ],
+)
+def test_family_validation_honors_source_wire_alias_policy(
+    *,
+    explicit_wire: bool,
+    validate_by_alias: bool,
+    validate_by_name: bool,
+    accepted_key: str,
+    rejected_key: str,
+) -> None:
+    alias_policy_config = ConfigDict(
+        extra="forbid",
+        validate_by_alias=validate_by_alias,
+        validate_by_name=validate_by_name,
+    )
+
+    class AliasPolicyPayload(BaseModel):
+        model_config = alias_policy_config
+
+        is_admin: bool = Field(False, alias="admin")
+
+    class ExplicitAliasPolicyWire(BaseModel):
+        model_config = alias_policy_config
+
+        is_admin: bool = Field(False, alias="admin")
+
+    source = SchemaVersion(
+        "1",
+        wire_model=ExplicitAliasPolicyWire if explicit_wire else None,
+    )
+    family = SchemaFamily(
+        model=AliasPolicyPayload,
+        name=f"source_alias_policy_{explicit_wire}_{validate_by_alias}",
+        versions=(source, SchemaVersion("2")),
+        version_metadata=None,
+    )
+    source_model = family.model_for("1")
+
+    accepted = {accepted_key: True}
+    assert source_model.model_validate(accepted).model_dump()["is_admin"] is True
+    assert family.validate(accepted, version="1").current_model.is_admin is True
+
+    rejected = {rejected_key: True}
+    with pytest.raises(ValidationError):
+        source_model.model_validate(rejected)
+    with pytest.raises(ValidationError):
+        family.validate(rejected, version="1")
+
+    if validate_by_alias:
+        assert source_model.model_json_schema(mode="validation")["properties"].keys() == {"admin"}
+
+
+def test_family_validation_honors_nested_alias_choices_and_paths() -> None:
+    class NestedAliasPayload(BaseModel):
+        model_config = ConfigDict(
+            extra="forbid",
+            validate_by_alias=True,
+            validate_by_name=False,
+        )
+
+        choice: int = Field(validation_alias=AliasChoices("choiceIn", "legacyChoice"))
+        path: int = Field(validation_alias=AliasPath("envelope", "path"))
+
+    child_family = SchemaFamily(
+        model=NestedAliasPayload,
+        name="nested_source_alias_policy_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    class ParentAliasPayload(BaseModel):
+        child: NestedAliasPayload
+
+    parent_family = SchemaFamily(
+        model=ParentAliasPayload,
+        name="nested_source_alias_policy_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+        version_metadata=None,
+    )
+    source_model = parent_family.model_for("1")
+
+    accepted = {"child": {"legacyChoice": 3, "envelope": {"path": 4}}}
+    assert source_model.model_validate(accepted).model_dump() == {"child": {"choice": 3, "path": 4}}
+    current = parent_family.validate(accepted, version="1").current_model
+    assert current.child.choice == 3
+    assert current.child.path == 4
+
+    rejected = {"child": {"choice": 3, "path": 4}}
+    with pytest.raises(ValidationError):
+        source_model.model_validate(rejected)
+    with pytest.raises(ValidationError):
+        parent_family.validate(rejected, version="1")
+
+
 def test_generated_config_preserves_wire_settings_but_omits_lifecycle_settings() -> None:
     class Mode(StrEnum):
         FAST = "fast"

--- a/tests/unit/test_versioned_schema.py
+++ b/tests/unit/test_versioned_schema.py
@@ -178,7 +178,7 @@ def test_validate_versioned_normalizes_alias_paths_in_upgrade_output() -> None:
 
     result = validate_versioned(
         AliasPathMigrationTarget,
-        {"schema_version": "1", "value": 4},
+        {"schema_version": "1", "payload": {"value": 4}},
     )
 
     assert result.current_model == AliasPathMigrationTarget.model_validate(


### PR DESCRIPTION
## Summary

- honor the selected generated or explicit source wire model's alias/name validation policy at the raw input boundary
- keep Python-name normalization limited to the private canonical migration handoff
- cover alias-only and name-only modes, explicit wire models, nested fields, `AliasChoices`, and `AliasPath`
- correct the legacy test input that depended on forced Python-name acceptance

## Security evidence

This directly regresses finding `8ec15d112d68819180519e1ccab4f9f2`: Python-name input is rejected when `validate_by_name=False`, while enabled aliases still validate exactly as the selected source model does.

## Validation

- `uv run make ci`
- `uv run python tests/compatibility/v0_3_0_contract.py --check`
- `uv run zensical build --strict`
- `uv run python scripts/check_conventional_commits.py --range origin/main..HEAD`

All passed locally on Python 3.12.12. The original security finding must still be re-verified before merge.

Closes #71