### PR TITLE
fix(runtime): isolate canonical payloads from extras

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the unused `VersionedValidationError` placeholder from the public
   package surface before the 1.0.0 contract freeze.
 
+### Security
+- Prevented allowed Pydantic extras from reintroducing excluded or historically
+  removed fields into migrations and authoritative current models by extracting
+  private canonical payloads recursively from declared source fields only.
+
 ## [0.3.0] - 2026-08-20
 
 ### Added

--- a/docs/guide/application-exchange.md
+++ b/docs/guide/application-exchange.md
@@ -241,6 +241,13 @@ Choose an explicit ownership model:
 Do not claim transparent relay behavior without a round-trip test for the exact
 models and Pydantic configuration in use.
 
+`extra="allow"` on a wire model retains unknown values on the returned
+`source_model` for inspection, but those extras are not migration input and are
+not promoted into the authoritative current model. Family conversion extracts
+declared fields recursively so omitted application state cannot be restored by
+an alias-shaped extra. Use a declared namespaced extension mapping or a separate
+envelope when opaque values must cross that boundary.
+
 ## Useful operating modes
 
 The same primitives support several deployments:

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -48,6 +48,16 @@ field present during wire validation. Conditional exclusions are treated the
 same way: the field is omitted unconditionally from generated projections.
 The configured model-owned version field may not be excluded.
 
+`extra="allow"` remains a source wire-validation policy. The returned
+`source_model` retains untyped extras in `__pydantic_extra__`, but family
+conversion does not flatten those values into migration input. The private
+canonical mapping is built recursively from declared, validated Python fields
+without invoking source serializers. Consequently, an excluded or historically
+removed field cannot re-enter through its Python name, an alias, `AliasChoices`,
+an `AliasPath`, or an automatically projected nested model. A user upgrade may
+still introduce that canonical field deliberately. Model opaque extensions as a
+declared mapping or envelope when they must cross the conversion boundary.
+
 Zero-argument factories remain safe when the field annotation is unchanged. A
 decorator-owned child annotation can replace the child class itself as a
 factory, and a direct child instance is projected without running its

--- a/docs/guide/pydantic-compatibility-matrix.md
+++ b/docs/guide/pydantic-compatibility-matrix.md
@@ -35,6 +35,14 @@ copy of the application model. Omitted lifecycle settings therefore do not
 mean that the setting is unsupported on the authoritative model; they mean it
 does not belong in the generated wire contract.
 
+Preserved `extra="allow"` applies to source wire validation and inspection.
+Untyped extras remain on the returned source model, but the private transition
+mapping recursively contains declared fields only. Extras therefore do not
+populate excluded or historically removed application fields through Python
+names or validation aliases, and unrelated extras are not an implicit opaque
+relay across family conversion. Declare an extension field or envelope when
+that data must participate in migrations or current-model validation.
+
 ## Cross-cutting boundaries
 
 - Unresolved generic bases, behavioral dataclasses, typed extras, and custom

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, get_origin
 
 from pydantic import AliasChoices, AliasPath, BaseModel
+from pydantic_core import to_jsonable_python
 
 from pydantic_versions._compiler import (
     _CompiledFamily,
@@ -28,6 +30,62 @@ def _runtime_label(value: object, *, family_name: str) -> str:
     return value
 
 
+def _extract_declared_fields(value: BaseModel) -> dict[str, Any]:
+    """Build a private canonical payload from validated, declared fields only."""
+    fields = type(value).model_fields
+    return {
+        name: _extract_declared_value(value.__dict__[name], config=value.model_config)
+        for name in fields
+        if name in value.__dict__
+    }
+
+
+def _extract_declared_value(value: Any, *, config: Mapping[str, Any]) -> Any:
+    if isinstance(value, BaseModel):
+        return _extract_declared_fields(value)
+    if isinstance(value, Mapping):
+        return {key: _extract_declared_value(item, config=config) for key, item in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        # Pydantic's JSON-shaped transition payload has historically represented
+        # every supported sequence and set container as a list.  Keep that shape
+        # while reading nested model values without invoking serializers.
+        return [_extract_declared_value(item, config=config) for item in value]
+    return _jsonable_declared_scalar(value, config=config)
+
+
+def _jsonable_declared_scalar(value: Any, *, config: Mapping[str, Any]) -> Any:
+    if isinstance(value, bytes):
+        return to_jsonable_python(
+            value,
+            bytes_mode=config.get("ser_json_bytes", "utf8"),
+            fallback=_preserve_unknown_scalar,
+        )
+    if isinstance(value, dt.timedelta):
+        temporal_mode = config.get("ser_json_temporal")
+        if temporal_mode is not None:
+            return to_jsonable_python(
+                value,
+                temporal_mode=temporal_mode,
+                fallback=_preserve_unknown_scalar,
+            )
+        return to_jsonable_python(
+            value,
+            timedelta_mode=config.get("ser_json_timedelta", "iso8601"),
+            fallback=_preserve_unknown_scalar,
+        )
+    if isinstance(value, dt.datetime | dt.date | dt.time):
+        return to_jsonable_python(
+            value,
+            temporal_mode=config.get("ser_json_temporal", "iso8601"),
+            fallback=_preserve_unknown_scalar,
+        )
+    return to_jsonable_python(value, fallback=_preserve_unknown_scalar)
+
+
+def _preserve_unknown_scalar(value: Any) -> Any:
+    return value
+
+
 def _validate_family[T: BaseModel](
     family: SchemaFamily[T],
     data: Any,
@@ -41,7 +99,7 @@ def _validate_family[T: BaseModel](
     payload = _to_current_names(
         compiled,
         source,
-        source_model.model_dump(by_alias=False, mode="json"),
+        _extract_declared_fields(source_model),
     )
 
     migrations_applied: list[tuple[str, str]] = []
@@ -583,7 +641,7 @@ def _convert_nested_family_payload(
         _to_current_names(
             compiled,
             source_version,
-            source_data.model_dump(by_alias=False, mode="json"),
+            _extract_declared_fields(source_data),
         )
     )
     if source_index < target_index:

--- a/tests/unit/test_canonical_payload_security.py
+++ b/tests/unit/test_canonical_payload_security.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Literal, cast
+
+import pytest
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+    field_serializer,
+    model_serializer,
+)
+
+from pydantic_versions import (
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    VersionTransition,
+    field_removed,
+    matching_labels,
+)
+
+
+class ExcludedPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    public: str
+    internal: bool = Field(False, exclude=True)
+
+
+class ConditionallyExcludedPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    public: str
+    internal: bool = Field(False, exclude_if=lambda value: value is False)
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [ExcludedPayload, ConditionallyExcludedPayload],
+    ids=["exclude", "exclude_if"],
+)
+def test_allowed_extras_cannot_populate_excluded_current_fields(
+    model_cls: type[BaseModel],
+) -> None:
+    family = SchemaFamily(
+        model=model_cls,
+        name=f"excluded_extra_{model_cls.__name__}",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    result = family.validate(
+        {
+            "public": "visible",
+            "internal": True,
+            "extension": {"owner": "source"},
+        },
+        version="1",
+    )
+
+    assert result.source_model.__pydantic_extra__ == {
+        "internal": True,
+        "extension": {"owner": "source"},
+    }
+    assert cast(Any, result.current_model).internal is False
+    assert result.current_model.__pydantic_extra__ == {}
+
+
+def test_removed_fields_cannot_reenter_through_names_or_validation_aliases() -> None:
+    class RemovedAliasPayload(BaseModel):
+        model_config = ConfigDict(
+            extra="allow",
+            validate_by_alias=True,
+            validate_by_name=True,
+        )
+
+        direct: int = 0
+        plain: int = Field(0, alias="plainAlias")
+        choice: int = Field(
+            0,
+            validation_alias=AliasChoices("choiceFirst", "choiceSecond"),
+        )
+        path: int = Field(0, validation_alias=AliasPath("envelope", "path"))
+
+    family = SchemaFamily(
+        model=RemovedAliasPayload,
+        name="removed_alias_extras",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=tuple(field_removed(name) for name in RemovedAliasPayload.model_fields),
+            ),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+    attack = {
+        "direct": 1,
+        "plain": 2,
+        "plainAlias": 3,
+        "choice": 4,
+        "choiceSecond": 5,
+        "path": 6,
+        "envelope": {"path": 7},
+        "extension": "source-only",
+    }
+
+    result = family.validate(attack, version="1")
+
+    assert result.source_model.__pydantic_extra__ == attack
+    assert result.current_model.direct == 0
+    assert result.current_model.plain == 0
+    assert result.current_model.choice == 0
+    assert result.current_model.path == 0
+    assert result.current_model.__pydantic_extra__ == {}
+
+
+def test_upgrade_can_deliberately_introduce_a_removed_field() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class UpgradePayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        public: str
+        internal: bool = False
+
+    def add_internal(payload: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(payload))
+        return {**payload, "internal": True}
+
+    family = SchemaFamily(
+        model=UpgradePayload,
+        name="trusted_removed_field_upgrade",
+        versions=(
+            SchemaVersion("1", patches=(field_removed("internal"),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=add_internal),),
+        version_metadata=None,
+    )
+    result = family.validate(
+        {"public": "visible", "internal": False, "extension": "source-only"},
+        version="1",
+    )
+
+    assert result.source_model.__pydantic_extra__ == {
+        "internal": False,
+        "extension": "source-only",
+    }
+    assert seen_payloads == [{"public": "visible"}]
+    assert result.current_model.internal is True
+
+
+def test_nested_automatic_projections_drop_excluded_and_removed_extras() -> None:
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+        removed: bool = False
+
+    child_family = SchemaFamily(
+        model=ChildPayload,
+        name="nested_extra_child",
+        versions=(
+            SchemaVersion("1", patches=(field_removed("removed"),)),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    class InnerPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        public: str
+        internal: bool = Field(False, exclude=True)
+        child: ChildPayload
+
+    class RootPayload(BaseModel):
+        inner: InnerPayload
+
+    family = SchemaFamily(
+        model=RootPayload,
+        name="nested_omitted_extras",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily(("inner", "child"), child_family, matching_labels()),),
+        version_metadata=None,
+    )
+    result = family.validate(
+        {
+            "inner": {
+                "public": "visible",
+                "internal": True,
+                "extension": "inner-source-only",
+                "child": {
+                    "value": 1,
+                    "removed": True,
+                    "extension": "child-source-only",
+                },
+            },
+        },
+        version="1",
+    )
+
+    source_inner = cast(Any, result.source_model).inner
+    assert source_inner.__pydantic_extra__ == {
+        "internal": True,
+        "extension": "inner-source-only",
+    }
+    assert source_inner.child.__pydantic_extra__ == {
+        "removed": True,
+        "extension": "child-source-only",
+    }
+    assert result.current_model.inner.internal is False
+    assert result.current_model.inner.child.removed is False
+    assert result.current_model.inner.__pydantic_extra__ == {}
+    assert result.current_model.inner.child.__pydantic_extra__ == {}
+
+
+@pytest.mark.parametrize("extra_mode", [None, "ignore"], ids=["default", "ignore"])
+def test_ignored_excluded_input_keeps_the_current_default(
+    extra_mode: Literal["ignore"] | None,
+) -> None:
+    config = ConfigDict() if extra_mode is None else ConfigDict(extra=extra_mode)
+
+    class IgnoredPayload(BaseModel):
+        model_config = config
+
+        public: str
+        internal: bool = Field(False, exclude=True)
+
+    family = SchemaFamily(
+        model=IgnoredPayload,
+        name=f"ignored_excluded_{extra_mode}",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    result = family.validate(
+        {"public": "visible", "internal": True},
+        version="1",
+    )
+
+    assert result.current_model.internal is False
+
+
+def test_forbidden_excluded_input_remains_rejected() -> None:
+    class ForbiddenPayload(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        public: str
+        internal: bool = Field(False, exclude=True)
+
+    family = SchemaFamily(
+        model=ForbiddenPayload,
+        name="forbidden_excluded",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        family.validate(
+            {"public": "visible", "internal": True},
+            version="1",
+        )
+
+
+def test_extra_allow_without_omitted_fields_remains_a_source_wire_policy() -> None:
+    class ExtensiblePayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    family = SchemaFamily(
+        model=ExtensiblePayload,
+        name="source_wire_extensions",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    result = family.validate(
+        {"value": 1, "extension": {"owner": "source"}},
+        version="1",
+    )
+
+    assert result.source_model.__pydantic_extra__ == {
+        "extension": {"owner": "source"},
+    }
+    assert result.current_model.value == 1
+    assert result.current_model.__pydantic_extra__ == {}
+
+
+def test_source_serializers_do_not_define_the_canonical_transition_payload() -> None:
+    field_serializer_calls = 0
+    model_serializer_calls = 0
+    seen_payloads: list[dict[str, Any]] = []
+
+    class HistoricalWire(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+        @field_serializer("value")
+        def serialize_value(self, value: int) -> str:
+            nonlocal field_serializer_calls
+            field_serializer_calls += 1
+            return f"serialized:{value}"
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, str]:
+            nonlocal model_serializer_calls
+            model_serializer_calls += 1
+            return {"value": f"model-serialized:{self.value}"}
+
+    class CurrentPayload(BaseModel):
+        value: int
+
+    def inspect_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(payload))
+        return payload
+
+    family = SchemaFamily(
+        model=CurrentPayload,
+        name="serializer_free_source_extraction",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalWire),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=inspect_payload),),
+        version_metadata=None,
+    )
+    result = family.validate(
+        {"value": 1, "extension": "source-only"},
+        version="1",
+    )
+
+    assert field_serializer_calls == 0
+    assert model_serializer_calls == 0
+    assert seen_payloads == [{"value": 1}]
+    assert result.current_model.value == 1
+    assert result.source_model.__pydantic_extra__ == {"extension": "source-only"}
+
+
+def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    seen_payloads: list[dict[str, Any]] = []
+
+    class HistoricalScalarWire(BaseModel):
+        model_config = ConfigDict(
+            ser_json_bytes="base64",
+            ser_json_temporal="milliseconds",
+            val_json_bytes="base64",
+            val_temporal_unit="milliseconds",
+        )
+
+        occurred_at: datetime
+        endpoint: AnyUrl
+        mode: Mode
+        raw: bytes
+        amount: Decimal
+        secret: SecretStr
+        labels: tuple[Mode, ...]
+        indexes: set[int]
+
+    class CurrentScalarPayload(BaseModel):
+        occurred_at: Any
+        endpoint: Any
+        mode: Any
+        raw: Any
+        amount: Any
+        secret: Any
+        labels: Any
+        indexes: Any
+
+    def inspect_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(payload))
+        return payload
+
+    family = SchemaFamily(
+        model=CurrentScalarPayload,
+        name="json_scalar_compatibility",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalScalarWire),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=inspect_payload),),
+        version_metadata=None,
+    )
+    source_data = {
+        "occurred_at": "2020-01-02T03:04:05Z",
+        "endpoint": "https://example.com/config",
+        "mode": "active",
+        "raw": "_wA=",
+        "amount": "1.20",
+        "secret": "private",
+        "labels": ["active"],
+        "indexes": [2, 1],
+    }
+    expected = (
+        family.model_for("1")
+        .model_validate(source_data)
+        .model_dump(
+            by_alias=False,
+            mode="json",
+        )
+    )
+
+    family.validate(source_data, version="1")
+
+    assert seen_payloads == [expected]
+    assert seen_payloads == [
+        {
+            "occurred_at": 1_577_934_245_000.0,
+            "endpoint": "https://example.com/config",
+            "mode": "active",
+            "raw": "_wA=",
+            "amount": "1.20",
+            "secret": "**********",
+            "labels": ["active"],
+            "indexes": [1, 2],
+        },
+    ]
+
+
+def test_legacy_timedelta_mode_does_not_change_other_temporal_scalars() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class HistoricalDurationWire(BaseModel):
+        model_config = ConfigDict(ser_json_timedelta="float")
+
+        occurred_at: datetime
+        duration: timedelta
+
+    class CurrentDurationPayload(BaseModel):
+        occurred_at: Any
+        duration: Any
+
+    def inspect_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(payload))
+        return payload
+
+    family = SchemaFamily(
+        model=CurrentDurationPayload,
+        name="legacy_timedelta_compatibility",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalDurationWire),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=inspect_payload),),
+        version_metadata=None,
+    )
+    source_data = {
+        "occurred_at": datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC),
+        "duration": timedelta(seconds=1.5),
+    }
+    expected = (
+        family.model_for("1")
+        .model_validate(source_data)
+        .model_dump(
+            by_alias=False,
+            mode="json",
+        )
+    )
+
+    family.validate(source_data, version="1")
+
+    assert seen_payloads == [expected]
+    assert seen_payloads == [
+        {
+            "occurred_at": "2020-01-02T03:04:05Z",
+            "duration": 1.5,
+        },
+    ]


### PR DESCRIPTION
## Summary

- build canonical migration payloads recursively from declared, validated source fields only
- retain source extras for inspection without allowing them to restore excluded or historically removed state
- preserve the former JSON scalar/container contract with Pydantic Core without invoking source field or model serializers
- document the explicit extension-envelope boundary for application exchange

## Security disposition

This closes the code paths reported by Codex Security findings:

- `3543f85a0cd88191a3e306369ad56b35`
- `d491ed163a5081918ef19279fd72ffc0`
- `9baa8f9bf32c8191af53fa1ab699d63b`

The regression suite executes root, nested, alias, `AliasChoices`, and `AliasPath` variants, plus deliberate trusted upgrade output. A fresh Codex Security review is currently unavailable because the account scan quota is exhausted; the external findings remain pending refresh, tracked by #69 and #57.

## Validation

- `uv run make ci` — passed (282 tests; 94.98% coverage)
- focused security and wire-contract tests — passed (81 tests)
- `uv run make docs-build-strict` — passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check` — passed
- Conventional Commit validation — passed

Closes #70