### PR TITLE
fix(runtime): preserve canonical mapping key shape

### DIFF
--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -44,7 +44,13 @@ def _extract_declared_value(value: Any, *, config: Mapping[str, Any]) -> Any:
     if isinstance(value, BaseModel):
         return _extract_declared_fields(value)
     if isinstance(value, Mapping):
-        return {key: _extract_declared_value(item, config=config) for key, item in value.items()}
+        return {
+            _jsonable_declared_mapping_key(key, config=config): _extract_declared_value(
+                item,
+                config=config,
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, list | tuple | set | frozenset):
         # Pydantic's JSON-shaped transition payload has historically represented
         # every supported sequence and set container as a list.  Keep that shape
@@ -80,6 +86,25 @@ def _jsonable_declared_scalar(value: Any, *, config: Mapping[str, Any]) -> Any:
             fallback=_preserve_unknown_scalar,
         )
     return to_jsonable_python(value, fallback=_preserve_unknown_scalar)
+
+
+def _jsonable_declared_mapping_key(value: Any, *, config: Mapping[str, Any]) -> Any:
+    temporal_mode = config.get("ser_json_temporal")
+    if temporal_mode is not None:
+        dumped = to_jsonable_python(
+            {value: None},
+            bytes_mode=config.get("ser_json_bytes", "utf8"),
+            temporal_mode=temporal_mode,
+            fallback=_preserve_unknown_scalar,
+        )
+    else:
+        dumped = to_jsonable_python(
+            {value: None},
+            bytes_mode=config.get("ser_json_bytes", "utf8"),
+            timedelta_mode=config.get("ser_json_timedelta", "iso8601"),
+            fallback=_preserve_unknown_scalar,
+        )
+    return next(iter(dumped))
 
 
 def _preserve_unknown_scalar(value: Any) -> Any:

--- a/tests/unit/test_canonical_payload_security.py
+++ b/tests/unit/test_canonical_payload_security.py
@@ -369,6 +369,7 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
         secret: SecretStr
         labels: tuple[Mode, ...]
         indexes: set[int]
+        schedule: dict[datetime, Mode]
 
     class CurrentScalarPayload(BaseModel):
         occurred_at: Any
@@ -379,6 +380,7 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
         secret: Any
         labels: Any
         indexes: Any
+        schedule: Any
 
     def inspect_payload(payload: dict[str, Any]) -> dict[str, Any]:
         seen_payloads.append(dict(payload))
@@ -403,6 +405,7 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
         "secret": "private",
         "labels": ["active"],
         "indexes": [2, 1],
+        "schedule": {"2020-01-02T03:04:05Z": "active"},
     }
     expected = (
         family.model_for("1")
@@ -426,6 +429,7 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
             "secret": "**********",
             "labels": ["active"],
             "indexes": [1, 2],
+            "schedule": {"1577934245000": "active"},
         },
     ]
 


### PR DESCRIPTION
## Summary

- preserve the previous JSON-mode representation of non-string mapping keys in canonical migration payloads
- apply source temporal and byte serialization modes through Pydantic Core without invoking field or model serializers
- add datetime-key parity coverage to the security regression matrix

## Why this follow-up exists

The focused post-merge compatibility audit for #74 found that declared mapping values were parity-tested but non-string mapping keys were not. Without this correction, datetime keys retained Python objects instead of the strings produced by the former `model_dump(mode="json")` path. This PR closes that compatibility edge without changing the declared-field-only security boundary.

## Validation

- `uv run make ci` — passed (282 tests; 94.99% coverage)
- focused security and wire-contract tests — passed (81 tests)
- `uv run make docs-build-strict` — passed
- Conventional Commit validation — passed

Closes #70