### PR TITLE
fix(runtime): validate current data before rendering

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Python-name acceptance policy at the raw input boundary.
 - Completed class- and function-preserving annotations for the public decorator
   factories and added downstream `ty` and mypy coverage against the built wheel.
+- Made mapping and unrelated-model rendering cross the authoritative
+  current-model validation boundary before downgrade execution while honoring
+  Pydantic's configured instance-revalidation policy for current-model
+  instances, excluding extras and subclass-only fields from the canonical
+  payload, detaching caller-owned containers, and enforcing metadata conflicts
+  at every accepted input name.
 
 ### Removed
 - Removed the unused `VersionedValidationError` placeholder from the public

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -38,7 +38,38 @@ dumped = dump_versioned(AppConfig, version="1", data=AppConfig(retries=5))
 assert dumped["attempts"] == 5
 ```
 
+Supplied `data` always describes the current schema. The `version` argument is
+the output version, not the input version. Mappings cross the authoritative
+current-model boundary with their original key shape, so Pydantic's current
+validators, alias priority, defaults, and constraints apply before any
+downgrade. An already-constructed instance of the authoritative model is
+handled according to that model's Pydantic `revalidate_instances` policy, so
+the default avoids duplicate validation while an opt-in revalidation policy is
+still enforced.
+
+Rendering extracts declared fields into a private JSON-shaped payload without
+flattening allowed extras, accepting subclass-only fields, or invoking model
+and field serializers. Mutations made by a downgrade therefore cannot reach
+caller-owned nested mappings or collections.
+
+An unrelated `BaseModel` is accepted only when its declared structure validates
+as current input. Otherwise Pydantic raises a validation error for the
+authoritative current model. Package-generated current wire instances also
+remain renderable, including hashable set projections that the original model
+annotation cannot construct directly.
+
+If that set bridge is required, an enclosing model with a custom `__init__`
+fails closed with `UnsupportedWireModelError`. Pydantic validators and
+`model_post_init` retain their exact model type and once-only lifecycle; a
+custom initializer cannot be replayed without re-entering field validation.
+
 Fields removed in the target version are dropped before historical validation.
+
+If current input includes version metadata, it must name the current version.
+Rendering rebases that metadata to the requested target. This makes a mapping
+such as `{"schema_version": "1", ...}` invalid current input when the current
+version is `"2"`, even if the requested output version is `"1"`. Omit the input
+metadata when the application model does not own it.
 
 ## Omit version metadata
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -343,8 +343,15 @@ forward upgrades, and validates the current model.
 `dump_versioned(subject, *, version, data=None, include_version=True, **dump_kwargs)`
 
 Renders defaults, model data, or mapping data using a requested version and
-returns a dictionary. Extra keyword arguments are passed to Pydantic
-`model_dump()`.
+returns a dictionary. Mapping and unrelated model data is validated as the
+authoritative current model before reverse transitions run; authoritative model
+instances follow their Pydantic `revalidate_instances` policy. Embedded version
+metadata at any accepted input name must match the current version. Rendering
+extracts authoritative declared fields into detached canonical data, excluding
+allowed extras, subclass-only fields, and serializers, so transition mutation
+cannot affect caller-owned containers. Invalid unrelated models raise the
+current model's `ValidationError`. Extra keyword arguments are passed to the
+final target model's Pydantic `model_dump()`.
 
 ## Result
 

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, get_origin
+from functools import partial
+from types import UnionType
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, cast, get_args, get_origin
 
-from pydantic import AliasChoices, AliasPath, BaseModel
-from pydantic_core import to_jsonable_python
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    BaseModel,
+    ConfigDict,
+    create_model,
+)
+from pydantic_core import SchemaValidator, core_schema, to_jsonable_python
 
 from pydantic_versions._compiler import (
     _CompiledFamily,
@@ -16,7 +24,9 @@ from pydantic_versions.exceptions import (
     InvalidMigrationError,
     MissingSchemaVersionError,
     SchemaCompilationError,
+    SchemaVersionError,
     UnknownSchemaVersionError,
+    UnsupportedWireModelError,
 )
 
 if TYPE_CHECKING:
@@ -30,24 +40,49 @@ def _runtime_label(value: object, *, family_name: str) -> str:
     return value
 
 
-def _extract_declared_fields(value: BaseModel) -> dict[str, Any]:
+def _extract_declared_fields(
+    value: BaseModel,
+    *,
+    declared_model: type[BaseModel] | None = None,
+) -> dict[str, Any]:
     """Build a private canonical payload from validated, declared fields only."""
-    fields = type(value).model_fields
+    selected_model = type(value) if declared_model is None else declared_model
+    fields = selected_model.model_fields
     return {
-        name: _extract_declared_value(value.__dict__[name], config=value.model_config)
-        for name in fields
-        if name in value.__dict__
+        name: _extract_declared_value(
+            value.__dict__[name],
+            config=selected_model.model_config,
+            annotation=field_info.annotation,
+        )
+        for name, field_info in fields.items()
+        if name in value.__dict__ and _field_crosses_wire_boundary(field_info)
     }
 
 
-def _extract_declared_value(value: Any, *, config: Mapping[str, Any]) -> Any:
+def _extract_declared_value(
+    value: Any,
+    *,
+    config: Mapping[str, Any],
+    annotation: Any = None,
+) -> Any:
+    declared_annotation = _matching_declared_annotation(annotation, value)
     if isinstance(value, BaseModel):
-        return _extract_declared_fields(value)
+        declared_model = (
+            declared_annotation
+            if isinstance(declared_annotation, type)
+            and issubclass(declared_annotation, BaseModel)
+            and isinstance(value, declared_annotation)
+            else None
+        )
+        return _extract_declared_fields(value, declared_model=declared_model)
     if isinstance(value, Mapping):
+        arguments = get_args(declared_annotation)
+        item_annotation = arguments[1] if len(arguments) == 2 else None
         return {
             _jsonable_declared_mapping_key(key, config=config): _extract_declared_value(
                 item,
                 config=config,
+                annotation=item_annotation,
             )
             for key, item in value.items()
         }
@@ -55,8 +90,75 @@ def _extract_declared_value(value: Any, *, config: Mapping[str, Any]) -> Any:
         # Pydantic's JSON-shaped transition payload has historically represented
         # every supported sequence and set container as a list.  Keep that shape
         # while reading nested model values without invoking serializers.
-        return [_extract_declared_value(item, config=config) for item in value]
+        arguments = get_args(declared_annotation)
+        if isinstance(value, tuple) and len(arguments) > 1 and arguments[-1] is not Ellipsis:
+            item_annotations = arguments
+        else:
+            item_annotation = arguments[0] if arguments else None
+            item_annotations = (item_annotation,) * len(value)
+        return [
+            _extract_declared_value(
+                item,
+                config=config,
+                annotation=item_annotation,
+            )
+            for item, item_annotation in zip(value, item_annotations, strict=True)
+        ]
     return _jsonable_declared_scalar(value, config=config)
+
+
+def _matching_declared_annotation(annotation: Any, value: Any) -> Any:
+    if annotation is None:
+        return None
+    normalized = _strip_annotated(annotation)
+    origin = get_origin(normalized)
+    if origin not in (Union, UnionType):
+        return normalized
+    candidates = tuple(_strip_annotated(candidate) for candidate in get_args(normalized))
+    for candidate in candidates:
+        if isinstance(candidate, type) and type(value) is candidate:
+            return candidate
+    class_matches = tuple(
+        candidate for candidate in candidates if _safe_annotation_instance(value, candidate)
+    )
+    if class_matches:
+        mro = type(value).mro()
+        return min(
+            class_matches,
+            key=lambda candidate: mro.index(candidate) if candidate in mro else len(mro),
+        )
+    for candidate in candidates:
+        if candidate is type(None):
+            if value is None:
+                return candidate
+            continue
+        candidate_origin = get_origin(candidate)
+        if candidate_origin is not None and isinstance(candidate_origin, type):
+            try:
+                if isinstance(value, candidate_origin):
+                    return candidate
+            except TypeError:
+                continue
+    return normalized
+
+
+def _safe_annotation_instance(value: Any, annotation: Any) -> bool:
+    if not isinstance(annotation, type):
+        return False
+    try:
+        return isinstance(value, annotation)
+    except TypeError:
+        return False
+
+
+def _field_crosses_wire_boundary(field_info: Any) -> bool:
+    for value in (field_info.exclude, field_info.exclude_if):
+        if value is None or value is False:
+            continue
+        if isinstance(value, Mapping | tuple | list | set | frozenset) and not value:
+            continue
+        return False
+    return True
 
 
 def _jsonable_declared_scalar(value: Any, *, config: Mapping[str, Any]) -> Any:
@@ -177,18 +279,12 @@ def _dump_family[T: BaseModel](
 
     if data is None:
         payload = {}
-    elif isinstance(data, BaseModel):
-        raw_payload = data.model_dump(by_alias=False, mode="json")
-        if requested == compiled.current_version:
-            payload = raw_payload
-        else:
-            payload = _to_current_names(
-                compiled,
-                compiled.version(compiled.current_version),
-                raw_payload,
-            )
     else:
-        payload = dict(data)
+        payload = _validated_current_render_payload(
+            family=family,
+            compiled=compiled,
+            data=data,
+        )
 
     if requested != compiled.current_version:
         for edge_index in range(current_index - 1, target_index - 1, -1):
@@ -210,13 +306,14 @@ def _dump_family[T: BaseModel](
                 raise InvalidMigrationError(msg)
             payload = migrated
 
-    if (
-        requested != compiled.current_version
-        and compiled.version_metadata is not None
-        and compiled.version_metadata.owner == "family"
+    if compiled.version_metadata is not None and (
+        requested != compiled.current_version or compiled.version_metadata.owner == "model"
     ):
         payload = dict(payload)
-        _set_version_field(payload, compiled.version_metadata.path, requested)
+        if compiled.version_metadata.owner == "family":
+            _set_version_field(payload, compiled.version_metadata.path, requested)
+        else:
+            payload[_model_metadata_field_name(compiled)] = requested
 
     target_model = target.model.model_validate(_to_version_names(target, payload), by_name=True)
     if "mode" in dump_kwargs:
@@ -237,11 +334,537 @@ def _dump_family[T: BaseModel](
                 family=nested.family,
             )
     if compiled.version_metadata is not None:
+        if compiled.version_metadata.owner == "model":
+            _remove_model_metadata_output_aliases(compiled, dumped)
         if include_version:
             _set_version_field(dumped, compiled.version_metadata.path, requested)
         else:
             _remove_version_field(dumped, compiled.version_metadata.path)
     return dumped
+
+
+def _validated_current_render_payload[T: BaseModel](
+    *,
+    family: SchemaFamily[T],
+    compiled: _CompiledFamily,
+    data: T | Mapping[str, Any],
+) -> dict[str, Any]:
+    current_version = compiled.version(compiled.current_version)
+    current_wire = current_version.model
+    if isinstance(data, family.model):
+        _validate_base_model_render_metadata(compiled, data)
+        current_model = family.model.model_validate(data)
+        raw_payload = _extract_declared_fields(
+            current_model,
+            declared_model=family.model,
+        )
+        _validate_current_render_metadata(compiled, raw_payload)
+    elif isinstance(data, BaseModel):
+        _validate_base_model_render_metadata(compiled, data)
+        raw_payload = _extract_declared_fields(data)
+        _validate_current_render_metadata(compiled, raw_payload)
+        validation_payload = (
+            _to_current_names(compiled, current_version, raw_payload)
+            if isinstance(data, current_wire)
+            else _without_family_render_metadata(compiled, raw_payload)
+        )
+        if isinstance(data, current_wire):
+            current_model = _current_wire_validation_adapter(
+                family.model,
+                family_name=compiled.name,
+            ).validate_python(
+                validation_payload,
+                by_name=True,
+            )
+        else:
+            current_model = family.model.model_validate(
+                validation_payload,
+                by_name=True,
+            )
+    elif isinstance(data, Mapping):
+        raw_payload = _copy_render_input(data)
+        _validate_current_render_metadata(compiled, raw_payload)
+        current_model = family.model.model_validate(
+            _without_family_render_metadata(compiled, raw_payload),
+        )
+    else:
+        msg = (
+            f"Render data for schema family {compiled.name!r} must be "
+            "a current model instance or mapping"
+        )
+        raise TypeError(msg)
+
+    _validate_base_model_render_metadata(compiled, current_model)
+    return _to_current_names(
+        compiled,
+        current_version,
+        _extract_declared_fields(
+            current_model,
+            declared_model=family.model,
+        ),
+    )
+
+
+def _validate_base_model_render_metadata(
+    compiled: _CompiledFamily,
+    data: BaseModel,
+) -> None:
+    _validate_current_render_metadata(compiled, data.__dict__)
+    extras = data.__pydantic_extra__
+    if isinstance(extras, Mapping):
+        _validate_current_render_metadata(compiled, extras)
+
+
+def _copy_render_input(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _copy_render_input(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_render_input(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_copy_render_input(item) for item in value)
+    if isinstance(value, set):
+        return {_copy_render_input(item) for item in value}
+    if isinstance(value, frozenset):
+        return frozenset(_copy_render_input(item) for item in value)
+    return value
+
+
+def _without_family_render_metadata(
+    compiled: _CompiledFamily,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    validation_payload = dict(payload)
+    metadata = compiled.version_metadata
+    if metadata is not None and metadata.owner == "family":
+        _remove_version_field(validation_payload, metadata.path)
+    return validation_payload
+
+
+def _current_wire_validation_adapter(
+    model: type[BaseModel],
+    *,
+    family_name: str,
+) -> SchemaValidator:
+    source_schema = model.__pydantic_core_schema__
+    model_references = _render_validation_model_references(source_schema)
+    changed_references: set[str] = set()
+    carrier_cache: dict[type[BaseModel], type[BaseModel]] = {}
+    while True:
+        discovered_references: set[str] = set()
+        schema, _changed = _clone_render_validation_schema(
+            source_schema,
+            family_name=family_name,
+            model_references=model_references,
+            changed_references=changed_references,
+            discovered_references=discovered_references,
+            carrier_cache=carrier_cache,
+            hash_required=False,
+        )
+        if discovered_references <= changed_references:
+            return SchemaValidator(cast(core_schema.CoreSchema, schema))
+        changed_references.update(discovered_references)
+
+
+class _RenderValidationShell:
+    """Private allocation target for carrier-aware model-field validation."""
+
+
+def _build_hashable_render_carrier(
+    *,
+    model: type[BaseModel],
+    cache: dict[type[BaseModel], type[BaseModel]],
+) -> type[BaseModel]:
+    cached = cache.get(model)
+    if cached is not None:
+        return cached
+    carrier = create_model(
+        f"{model.__name__}__HashableSetElement",
+        __base__=model,
+        __module__=model.__module__,
+        __config__=ConfigDict(
+            frozen=True,
+            revalidate_instances="never",
+            title=model.model_config.get("title") or model.__name__,
+        ),
+    )
+    cache[model] = carrier
+    return carrier
+
+
+def _construct_hashable_render_carrier(
+    carrier: type[BaseModel],
+    value: BaseModel,
+) -> BaseModel:
+    instance = object.__new__(carrier)
+    _copy_validated_model_state(instance, value, model=carrier)
+    return instance
+
+
+def _render_validation_model_references(value: Any) -> dict[str, type[BaseModel]]:
+    references: dict[str, type[BaseModel]] = {}
+    while True:
+        previous = dict(references)
+        _collect_render_validation_model_references(value, references)
+        if references == previous:
+            return references
+
+
+def _collect_render_validation_model_references(
+    value: Any,
+    references: dict[str, type[BaseModel]],
+) -> None:
+    if isinstance(value, dict):
+        schema_ref = value.get("ref")
+        if isinstance(schema_ref, str):
+            model = _render_validation_schema_model(value, model_references=references)
+            if model is not None:
+                references[schema_ref] = model
+        for item in value.values():
+            _collect_render_validation_model_references(item, references)
+        return
+    if isinstance(value, list | tuple):
+        for item in value:
+            _collect_render_validation_model_references(item, references)
+
+
+def _render_validation_schema_model(
+    schema: Any,
+    *,
+    model_references: Mapping[str, type[BaseModel]],
+) -> type[BaseModel] | None:
+    if not isinstance(schema, dict):
+        return None
+    schema_type = schema.get("type")
+    if schema_type == "model":
+        model = schema.get("cls")
+        if isinstance(model, type) and issubclass(model, BaseModel):
+            return model
+        return None
+    if schema_type == "definition-ref":
+        schema_ref = schema.get("schema_ref")
+        return model_references.get(schema_ref) if isinstance(schema_ref, str) else None
+    if schema_type in {
+        "custom-error",
+        "default",
+        "definitions",
+        "function-after",
+        "function-before",
+        "function-wrap",
+    }:
+        return _render_validation_schema_model(
+            schema.get("schema"),
+            model_references=model_references,
+        )
+    if schema_type == "chain":
+        steps = schema.get("steps")
+        if isinstance(steps, list) and steps:
+            return _render_validation_schema_model(
+                steps[-1],
+                model_references=model_references,
+            )
+        return None
+    if schema_type in {"json-or-python", "lax-or-strict"}:
+        candidates = tuple(
+            _render_validation_schema_model(
+                schema.get(key),
+                model_references=model_references,
+            )
+            for key in (
+                ("json_schema", "python_schema")
+                if schema_type == "json-or-python"
+                else ("lax_schema", "strict_schema")
+            )
+        )
+        if candidates[0] is not None and candidates[0] is candidates[1]:
+            return candidates[0]
+    return None
+
+
+def _clone_render_validation_schema(
+    value: Any,
+    *,
+    family_name: str,
+    model_references: Mapping[str, type[BaseModel]],
+    changed_references: set[str],
+    discovered_references: set[str],
+    carrier_cache: dict[type[BaseModel], type[BaseModel]],
+    hash_required: bool,
+) -> tuple[Any, bool]:
+    """Clone an authoritative schema and bridge only hash-required model outputs."""
+    if isinstance(value, list):
+        cloned_items = [
+            _clone_render_validation_schema(
+                item,
+                family_name=family_name,
+                model_references=model_references,
+                changed_references=changed_references,
+                discovered_references=discovered_references,
+                carrier_cache=carrier_cache,
+                hash_required=hash_required,
+            )
+            for item in value
+        ]
+        return [item for item, _changed in cloned_items], any(
+            changed for _item, changed in cloned_items
+        )
+    if isinstance(value, tuple):
+        cloned_items = tuple(
+            _clone_render_validation_schema(
+                item,
+                family_name=family_name,
+                model_references=model_references,
+                changed_references=changed_references,
+                discovered_references=discovered_references,
+                carrier_cache=carrier_cache,
+                hash_required=hash_required,
+            )
+            for item in value
+        )
+        return tuple(item for item, _changed in cloned_items), any(
+            changed for _item, changed in cloned_items
+        )
+    if isinstance(value, dict):
+        schema_type = value.get("type")
+        if hash_required:
+            output_model = _render_validation_schema_model(
+                value,
+                model_references=model_references,
+            )
+            if output_model is not None:
+                cloned, changed = _clone_render_validation_schema(
+                    value,
+                    family_name=family_name,
+                    model_references=model_references,
+                    changed_references=changed_references,
+                    discovered_references=discovered_references,
+                    carrier_cache=carrier_cache,
+                    hash_required=False,
+                )
+                if output_model.__hash__ is not None:
+                    return cloned, changed
+                carrier = _build_hashable_render_carrier(
+                    model=output_model,
+                    cache=carrier_cache,
+                )
+                return (
+                    core_schema.no_info_after_validator_function(
+                        partial(_construct_hashable_render_carrier, carrier),
+                        cast(core_schema.CoreSchema, cloned),
+                    ),
+                    True,
+                )
+        if schema_type == "definitions":
+            definitions, _definitions_changed = _clone_render_validation_schema(
+                value.get("definitions", []),
+                family_name=family_name,
+                model_references=model_references,
+                changed_references=changed_references,
+                discovered_references=discovered_references,
+                carrier_cache=carrier_cache,
+                hash_required=False,
+            )
+            schema, schema_changed = _clone_render_validation_schema(
+                value.get("schema"),
+                family_name=family_name,
+                model_references=model_references,
+                changed_references=changed_references,
+                discovered_references=discovered_references,
+                carrier_cache=carrier_cache,
+                hash_required=hash_required,
+            )
+            cloned = dict(value)
+            cloned["definitions"] = definitions
+            cloned["schema"] = schema
+            return cloned, schema_changed
+        if schema_type == "definition-ref":
+            schema_ref = value.get("schema_ref")
+            return dict(value), isinstance(schema_ref, str) and schema_ref in changed_references
+
+        propagate_hash_keys: set[str] = set()
+        if schema_type is None and hash_required:
+            propagate_hash_keys.update(value)
+        elif schema_type in {"set", "frozenset"}:
+            propagate_hash_keys.add("items_schema")
+        elif hash_required and schema_type == "tuple":
+            propagate_hash_keys.add("items_schema")
+        elif hash_required and schema_type in {"union", "tagged-union"}:
+            propagate_hash_keys.add("choices")
+        elif hash_required and schema_type == "chain":
+            propagate_hash_keys.add("steps")
+        elif hash_required and schema_type == "json-or-python":
+            propagate_hash_keys.update(("json_schema", "python_schema"))
+        elif hash_required and schema_type == "lax-or-strict":
+            propagate_hash_keys.update(("lax_schema", "strict_schema"))
+        elif hash_required and schema_type in {
+            "custom-error",
+            "default",
+            "function-after",
+            "function-before",
+            "function-wrap",
+            "nullable",
+        }:
+            propagate_hash_keys.add("schema")
+
+        cloned_items = {
+            key: _clone_render_validation_schema(
+                item,
+                family_name=family_name,
+                model_references=model_references,
+                changed_references=changed_references,
+                discovered_references=discovered_references,
+                carrier_cache=carrier_cache,
+                hash_required=key in propagate_hash_keys,
+            )
+            for key, item in value.items()
+        }
+        cloned = {key: item for key, (item, _changed) in cloned_items.items()}
+        changed = any(changed for _item, changed in cloned_items.values())
+        if schema_type == "model" and changed:
+            model = value.get("cls")
+            if not isinstance(model, type) or not issubclass(model, BaseModel):
+                return cloned, changed
+            if value.get("custom_init"):
+                msg = (
+                    f"Automatic current-wire render validation for family {family_name!r} "
+                    f"cannot safely execute custom __init__ on model {model.__qualname__!r}"
+                )
+                raise UnsupportedWireModelError(msg)
+            cloned["cls"] = _RenderValidationShell
+            cloned["custom_init"] = False
+            cloned.pop("post_init", None)
+            schema_ref = cloned.pop("ref", None)
+            cloned = core_schema.no_info_after_validator_function(
+                partial(_construct_authoritative_render_model, model),
+                cast(core_schema.CoreSchema, cloned),
+                ref=schema_ref,
+            )
+        schema_ref = value.get("ref")
+        if changed and isinstance(schema_ref, str):
+            discovered_references.add(schema_ref)
+        return cloned, changed
+    return value, False
+
+
+def _construct_authoritative_render_model(
+    model: type[BaseModel],
+    value: Any,
+) -> BaseModel:
+    instance = object.__new__(model)
+    _copy_validated_model_state(instance, value, model=model)
+    if model.__pydantic_post_init__:
+        instance.model_post_init(None)
+    return instance
+
+
+def _copy_validated_model_state(
+    target: BaseModel,
+    source: Any,
+    *,
+    model: type[BaseModel],
+) -> None:
+    source_values = source.__dict__
+    values = {name: source_values[name] for name in model.model_fields if name in source_values}
+    object.__setattr__(target, "__dict__", values)
+    object.__setattr__(
+        target,
+        "__pydantic_fields_set__",
+        set(source.__pydantic_fields_set__),
+    )
+    if not model.__pydantic_root_model__:
+        extras = source.__pydantic_extra__
+        object.__setattr__(
+            target,
+            "__pydantic_extra__",
+            None if extras is None else dict(extras),
+        )
+        private = source.__pydantic_private__
+        object.__setattr__(
+            target,
+            "__pydantic_private__",
+            None if private is None else dict(private),
+        )
+
+
+def _validate_current_render_metadata(
+    compiled: _CompiledFamily,
+    payload: Mapping[str, Any],
+) -> None:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        return
+
+    locations: list[tuple[Any, ...]] = [
+        (metadata.path,) if isinstance(metadata.path, str) else metadata.path,
+    ]
+    if metadata.owner == "model":
+        field_name = _model_metadata_field_name(compiled)
+        field_info = compiled.model.model_fields[field_name]
+        locations.append((field_name,))
+        if compiled.model.model_config.get("validate_by_alias", True) is not False:
+            locations.extend(_field_alias_paths(field_info))
+
+    checked_locations: list[tuple[Any, ...]] = []
+    for location in locations:
+        if location in checked_locations:
+            continue
+        checked_locations.append(location)
+        found, raw_value = _read_render_metadata_path(payload, location)
+        if not found:
+            continue
+        declared = _runtime_label(
+            raw_value,
+            family_name=compiled.name,
+        )
+        if declared == compiled.current_version:
+            continue
+        msg = (
+            f"Render data for schema family {compiled.name!r} declares version "
+            f"{declared!r}; current-model input must declare "
+            f"{compiled.current_version!r}"
+        )
+        raise SchemaVersionError(msg)
+
+
+def _read_render_metadata_path(
+    payload: Mapping[Any, Any],
+    path: tuple[Any, ...],
+) -> tuple[bool, Any]:
+    current: Any = payload
+    for part in path:
+        if isinstance(current, Mapping):
+            if part not in current:
+                return False, None
+            current = current[part]
+            continue
+        if isinstance(current, list | tuple) and isinstance(part, int):
+            try:
+                current = current[part]
+            except IndexError:
+                return False, None
+            continue
+        return False, None
+    return True, current
+
+
+def _remove_model_metadata_output_aliases(
+    compiled: _CompiledFamily,
+    payload: dict[str, Any],
+) -> None:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        msg = f"Compiled family {compiled.name!r} lost its version metadata"
+        raise SchemaCompilationError(msg)
+    field_name = _model_metadata_field_name(compiled)
+    field_info = compiled.model.model_fields[field_name]
+    candidates = (
+        field_name,
+        field_info.alias,
+        field_info.validation_alias,
+        field_info.serialization_alias,
+    )
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate != metadata.path:
+            payload.pop(candidate, None)
 
 
 def _apply_nested_family_migrations(

--- a/tests/unit/test_render_current_validation.py
+++ b/tests/unit/test_render_current_validation.py
@@ -1,0 +1,1204 @@
+from __future__ import annotations
+
+from typing import Any, Self, cast
+
+import pytest
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    BaseModel,
+    ConfigDict,
+    Field,
+    ModelWrapValidatorHandler,
+    PrivateAttr,
+    ValidationError,
+    create_model,
+    field_validator,
+    model_validator,
+)
+from pydantic_core import PydanticCustomError
+
+from pydantic_versions import (
+    SchemaFamily,
+    SchemaVersion,
+    SchemaVersionError,
+    UnsupportedWireModelError,
+    VersionMetadata,
+    VersionTransition,
+    dump_versioned,
+    model_for_version,
+    versioned_schema,
+)
+
+
+def test_mapping_render_validates_and_detaches_before_downgrade() -> None:
+    seen_values: list[int] = []
+
+    class NestedPayload(BaseModel):
+        values: list[int]
+
+    class CurrentPayload(BaseModel):
+        value: int
+        nested: NestedPayload
+
+        @field_validator("value", mode="before")
+        @classmethod
+        def normalize_value(cls, value: Any) -> Any:
+            return int(value) + 1
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_values.append(data["value"])
+        data["nested"]["values"].append(9)
+        return data
+
+    family = SchemaFamily(
+        model=CurrentPayload,
+        name="validated_render_input",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    mapping_input = {"value": 1, "nested": {"values": [1]}}
+    model_input = CurrentPayload.model_validate(mapping_input)
+
+    from_mapping = family.dump(
+        version="1",
+        data=mapping_input,
+        include_version=False,
+    )
+    from_model = family.dump(
+        version="1",
+        data=model_input,
+        include_version=False,
+    )
+
+    expected = {"value": 2, "nested": {"values": [1, 9]}}
+    assert from_mapping == expected
+    assert from_model == expected
+    assert seen_values == [2, 2]
+    assert mapping_input == {"value": 1, "nested": {"values": [1]}}
+    assert model_input.nested.values == [1]
+
+
+def test_mapping_render_preserves_authoritative_alias_input() -> None:
+    seen_inputs: list[Any] = []
+
+    class AliasPayload(BaseModel):
+        value: int = Field(
+            validation_alias=AliasChoices(
+                "legacy_value",
+                AliasPath("payload", "value"),
+            ),
+        )
+
+        @model_validator(mode="before")
+        @classmethod
+        def capture_input(cls, data: Any) -> Any:
+            seen_inputs.append(data)
+            return data
+
+    family = SchemaFamily(
+        model=AliasPayload,
+        name="current_alias_render",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    assert family.dump(
+        version="1",
+        data={
+            "value": "3",
+            "legacy_value": "1",
+            "payload": {"value": "2"},
+        },
+    ) == {"value": 1}
+    assert family.dump(
+        version="1",
+        data={"payload": {"value": "4"}},
+    ) == {"value": 4}
+    assert seen_inputs == [
+        {
+            "value": "3",
+            "legacy_value": "1",
+            "payload": {"value": "2"},
+        },
+        {"payload": {"value": "4"}},
+    ]
+
+
+def test_render_canonical_payload_excludes_allowed_current_extras() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class ExtensiblePayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(data))
+        return data
+
+    family = SchemaFamily(
+        model=ExtensiblePayload,
+        name="render_extra_boundary",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+    mapping_input = {"value": 1, "extension": "source-only"}
+    model_input = ExtensiblePayload.model_validate(mapping_input)
+
+    assert family.dump(version="1", data=mapping_input) == {"value": 1}
+    assert family.dump(version="1", data=model_input) == {"value": 1}
+    assert seen_payloads == [{"value": 1}, {"value": 1}]
+    assert model_input.__pydantic_extra__ == {"extension": "source-only"}
+
+
+def test_family_owned_render_metadata_must_describe_current_input() -> None:
+    class MetadataPayload(BaseModel):
+        value: int
+
+    family = SchemaFamily(
+        model=MetadataPayload,
+        name="family_metadata_render",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata(("meta", "version"), owner="family"),
+    )
+    current_input = {"meta": {"version": "2"}, "value": "5"}
+
+    assert family.dump(version="1", data=current_input) == {
+        "value": 5,
+        "meta": {"version": "1"},
+    }
+    assert current_input == {"meta": {"version": "2"}, "value": "5"}
+
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(
+            version="1",
+            data={"meta": {"version": "1"}, "value": 5},
+        )
+
+
+def test_model_owned_render_metadata_is_rebased_without_alias_leaks() -> None:
+    class ModelMetadataPayload(BaseModel):
+        schema_version: str = Field(default="2", validation_alias="wire_version")
+        value: int
+
+    family = SchemaFamily(
+        model=ModelMetadataPayload,
+        name="model_metadata_render",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("wire_version", owner="model"),
+    )
+
+    assert family.dump(
+        version="1",
+        data={"wire_version": "2", "value": "7"},
+    ) == {"wire_version": "1", "value": 7}
+    assert family.dump(
+        version="1",
+        data={"schema_version": "2", "value": 7},
+        include_version=False,
+    ) == {"value": 7}
+
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(
+            version="1",
+            data={"wire_version": "1", "value": 7},
+        )
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(
+            version="1",
+            data={"schema_version": "1", "value": 7},
+        )
+
+
+def test_model_owned_metadata_rejects_conflicts_at_any_accepted_name() -> None:
+    class CanonicalMetadataPayload(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=True)
+
+        schema_version: str = Field(default="2", validation_alias="wire_version")
+        value: int
+
+    family = SchemaFamily(
+        model=CanonicalMetadataPayload,
+        name="canonical_model_metadata_render",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    assert family.dump(
+        version="1",
+        data={"wire_version": "2", "value": 7},
+    ) == {"schema_version": "1", "value": 7}
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(
+            version="1",
+            data={"wire_version": "1", "value": 7},
+        )
+
+
+def test_unrelated_models_are_structurally_validated_as_current_input() -> None:
+    class CurrentPayload(BaseModel):
+        value: int
+
+    class CompatiblePayload(BaseModel):
+        value: str
+
+    class IncompatiblePayload(BaseModel):
+        other: str
+
+    family = SchemaFamily(
+        model=CurrentPayload,
+        name="unrelated_model_render",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    assert family.dump(version="1", data=cast(Any, CompatiblePayload(value="8"))) == {
+        "value": 8,
+    }
+    with pytest.raises(ValidationError, match="CurrentPayload"):
+        family.dump(
+            version="1",
+            data=cast(Any, IncompatiblePayload(other="missing")),
+        )
+    with pytest.raises(TypeError, match="current model instance or mapping"):
+        family.dump(version="1", data=cast(Any, ["not", "render", "data"]))
+
+
+def test_generated_current_wire_does_not_bypass_unrelated_current_errors() -> None:
+    @versioned_schema(
+        name="rejecting_set_child",
+        versions=("1",),
+        current="1",
+    )
+    class RejectingChild(BaseModel):
+        value: int
+
+        @model_validator(mode="after")
+        def reject_model(self) -> Self:
+            raise PydanticCustomError(
+                "set_item_not_hashable",
+                "Set items should be hashable",
+            )
+
+    @versioned_schema(
+        name="rejecting_set_parent",
+        versions=("1",),
+        current="1",
+    )
+    class RejectingParent(BaseModel):
+        children: set[RejectingChild]
+
+    generated_current = model_for_version(RejectingParent, "1").model_validate(
+        {"children": [{"value": 1}]},
+    )
+
+    with pytest.raises(ValidationError, match="Set items should be hashable"):
+        dump_versioned(
+            RejectingParent,
+            version="1",
+            data=cast(Any, generated_current),
+        )
+
+
+def test_generated_set_projection_runs_mutating_after_validators_once() -> None:
+    events: list[str] = []
+
+    @versioned_schema(
+        name="mutating_after_set_child",
+        versions=("1",),
+        current="1",
+    )
+    class MutatingChild(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int
+
+        @model_validator(mode="after")
+        def normalize_value(self) -> Self:
+            events.append("child after")
+            self.value += 1
+            return self
+
+    @versioned_schema(
+        name="mutating_after_set_parent",
+        versions=("1",),
+        current="1",
+    )
+    class MutatingParent(BaseModel):
+        children: set[MutatingChild]
+        parent_runs: int = 0
+
+        @model_validator(mode="after")
+        def record_parent_validation(self) -> Self:
+            events.append("parent after")
+            self.parent_runs += 1
+            return self
+
+    generated_current = model_for_version(MutatingParent, "1").model_validate(
+        {"children": [{"value": 1}]},
+    )
+
+    rendered = dump_versioned(
+        MutatingParent,
+        version="1",
+        data=cast(Any, generated_current),
+    )
+
+    assert rendered == {
+        "children": [{"value": 2, "schema_version": "1"}],
+        "parent_runs": 1,
+        "schema_version": "1",
+    }
+    assert events == ["child after", "parent after"]
+
+
+def test_nested_frozenset_projection_runs_model_post_init_once() -> None:
+    events: list[str] = []
+
+    @versioned_schema(
+        name="post_init_frozenset_child",
+        versions=("1",),
+        current="1",
+    )
+    class PostInitChild(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int
+
+        def model_post_init(self, _context: Any) -> None:
+            events.append("child post init")
+            self.value += 10
+
+    @versioned_schema(
+        name="post_init_frozenset_parent",
+        versions=("1",),
+        current="1",
+    )
+    class PostInitParent(BaseModel):
+        groups: dict[str, list[frozenset[PostInitChild]]]
+        parent_runs: int = 0
+
+        @model_validator(mode="after")
+        def record_parent_validation(self) -> Self:
+            events.append("parent after")
+            self.parent_runs += 1
+            return self
+
+    generated_current = model_for_version(PostInitParent, "1").model_validate(
+        {
+            "groups": {
+                "primary": [
+                    [{"value": 1}],
+                ],
+            },
+        },
+    )
+
+    rendered = dump_versioned(
+        PostInitParent,
+        version="1",
+        data=cast(Any, generated_current),
+    )
+
+    assert rendered == {
+        "groups": {
+            "primary": [
+                [{"value": 11, "schema_version": "1"}],
+            ],
+        },
+        "parent_runs": 1,
+        "schema_version": "1",
+    }
+    assert events == ["child post init", "parent after"]
+
+
+def test_generated_set_projection_runs_parent_hooks_on_authoritative_type_once() -> None:
+    events: list[str] = []
+
+    @versioned_schema(
+        name="authoritative_type_set_child",
+        versions=("1",),
+        current="1",
+    )
+    class HashableChild(BaseModel):
+        value: int
+
+        def __hash__(self) -> int:
+            return hash(self.value)
+
+    @versioned_schema(
+        name="authoritative_type_set_parent",
+        versions=("1",),
+        current="1",
+    )
+    class ExactParent(BaseModel):
+        children: set[HashableChild]
+
+        @model_validator(mode="before")
+        @classmethod
+        def record_before(cls, value: Any) -> Any:
+            assert cls is ExactParent
+            events.append("parent before")
+            return value
+
+        @model_validator(mode="wrap")
+        @classmethod
+        def record_wrap(
+            cls,
+            value: Any,
+            handler: ModelWrapValidatorHandler[Self],
+        ) -> Self:
+            assert cls is ExactParent
+            events.append("parent wrap before")
+            result = handler(value)
+            assert type(result) is ExactParent
+            events.append("parent wrap after")
+            return result
+
+        @field_validator("children", mode="after")
+        @classmethod
+        def record_field(cls, value: set[HashableChild]) -> set[HashableChild]:
+            assert cls is ExactParent
+            events.append("parent field")
+            return value
+
+        def model_post_init(self, _context: Any) -> None:
+            assert type(self) is ExactParent
+            events.append("parent post init")
+
+        @model_validator(mode="after")
+        def record_after(self) -> Self:
+            assert type(self) is ExactParent
+            events.append("parent after")
+            return self
+
+    expected = {
+        "children": [{"value": 1, "schema_version": "1"}],
+        "schema_version": "1",
+    }
+    assert (
+        dump_versioned(
+            ExactParent,
+            version="1",
+            data={"children": [{"value": 1}]},
+        )
+        == expected
+    )
+    assert events == [
+        "parent wrap before",
+        "parent before",
+        "parent field",
+        "parent post init",
+        "parent wrap after",
+        "parent after",
+    ]
+
+    events.clear()
+    generated_current = model_for_version(ExactParent, "1").model_validate(
+        {"children": [{"value": 1}]},
+    )
+    assert (
+        dump_versioned(
+            ExactParent,
+            version="1",
+            data=cast(Any, generated_current),
+        )
+        == expected
+    )
+    assert events == [
+        "parent wrap before",
+        "parent before",
+        "parent field",
+        "parent post init",
+        "parent wrap after",
+        "parent after",
+    ]
+
+
+def test_generated_set_carrier_preserves_exact_init_and_private_lifecycle() -> None:
+    events: list[Any] = []
+
+    def private_state() -> list[str]:
+        events.append("parent private")
+        return ["ready"]
+
+    @versioned_schema(
+        name="carrier_lifecycle_set_child",
+        versions=("1",),
+        current="1",
+    )
+    class CarrierChild(BaseModel):
+        value: int
+
+        def __init__(self, **data: Any) -> None:
+            events.append(("child init", type(self)))
+            super().__init__(**data)
+
+    @versioned_schema(
+        name="carrier_lifecycle_set_parent",
+        versions=("1",),
+        current="1",
+    )
+    class CarrierParent(BaseModel):
+        children: set[CarrierChild]
+        _state: list[str] = PrivateAttr(default_factory=private_state)
+
+        def model_post_init(self, _context: Any) -> None:
+            assert type(self) is CarrierParent
+            assert self._state == ["ready"]
+            events.append(("parent post init", type(self)))
+
+    assert CarrierChild.__hash__ is None
+    generated_current = model_for_version(CarrierParent, "1").model_validate(
+        {"children": [{"value": 1}]},
+    )
+    assert events == []
+
+    assert dump_versioned(
+        CarrierParent,
+        version="1",
+        data=cast(Any, generated_current),
+    ) == {
+        "children": [{"value": 1, "schema_version": "1"}],
+        "schema_version": "1",
+    }
+    assert events == [
+        ("child init", CarrierChild),
+        "parent private",
+        ("parent post init", CarrierParent),
+    ]
+
+
+def test_nested_carrier_hooks_use_authoritative_wrapper_types_once() -> None:
+    events: list[str] = []
+
+    @versioned_schema(
+        name="authoritative_type_nested_leaf",
+        versions=("1",),
+        current="1",
+    )
+    class NestedLeaf(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int
+
+        def model_post_init(self, _context: Any) -> None:
+            assert type(self) is NestedLeaf
+            events.append("leaf post init")
+
+        @model_validator(mode="after")
+        def normalize_value(self) -> Self:
+            assert type(self) is NestedLeaf
+            events.append("leaf after")
+            self.value += 1
+            return self
+
+    @versioned_schema(
+        name="authoritative_type_nested_wrapper",
+        versions=("1",),
+        current="1",
+    )
+    class NestedWrapper(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        leaves: frozenset[NestedLeaf]
+        wrapper_runs: int = 0
+
+        def model_post_init(self, _context: Any) -> None:
+            assert type(self) is NestedWrapper
+            events.append("wrapper post init")
+
+        @model_validator(mode="after")
+        def record_validation(self) -> Self:
+            assert type(self) is NestedWrapper
+            events.append("wrapper after")
+            self.wrapper_runs += 1
+            return self
+
+    @versioned_schema(
+        name="authoritative_type_nested_parent",
+        versions=("1",),
+        current="1",
+    )
+    class NestedParent(BaseModel):
+        wrapper: NestedWrapper
+        parent_runs: int = 0
+
+        def model_post_init(self, _context: Any) -> None:
+            assert type(self) is NestedParent
+            events.append("parent post init")
+
+        @model_validator(mode="after")
+        def record_validation(self) -> Self:
+            assert type(self) is NestedParent
+            events.append("parent after")
+            self.parent_runs += 1
+            return self
+
+    generated_current = model_for_version(NestedParent, "1").model_validate(
+        {"wrapper": {"leaves": [{"value": 1}]}},
+    )
+
+    assert dump_versioned(
+        NestedParent,
+        version="1",
+        data=cast(Any, generated_current),
+    ) == {
+        "wrapper": {
+            "leaves": [{"value": 2, "schema_version": "1"}],
+            "wrapper_runs": 1,
+            "schema_version": "1",
+        },
+        "parent_runs": 1,
+        "schema_version": "1",
+    }
+    assert events == [
+        "leaf post init",
+        "leaf after",
+        "wrapper post init",
+        "wrapper after",
+        "parent post init",
+        "parent after",
+    ]
+
+
+def test_generated_set_projection_rejects_parent_custom_init_before_execution() -> None:
+    init_types: list[type[BaseModel]] = []
+
+    @versioned_schema(
+        name="custom_init_set_child",
+        versions=("1",),
+        current="1",
+    )
+    class CustomInitChild(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="custom_init_set_parent",
+        versions=("1",),
+        current="1",
+    )
+    class CustomInitParent(BaseModel):
+        children: set[CustomInitChild]
+
+        def __init__(self, **data: Any) -> None:
+            init_types.append(type(self))
+            super().__init__(**data)
+
+    generated_current = model_for_version(CustomInitParent, "1").model_validate(
+        {"children": [{"value": 1}]},
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="custom __init__.*CustomInitParent",
+    ):
+        dump_versioned(
+            CustomInitParent,
+            version="1",
+            data=cast(Any, generated_current),
+        )
+    assert init_types == []
+
+
+def test_current_model_instances_follow_configured_revalidation_policy() -> None:
+    class RevalidatedPayload(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int = Field(gt=0)
+
+    family = SchemaFamily(
+        model=RevalidatedPayload,
+        name="revalidated_current_instance",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    current = RevalidatedPayload(value=1)
+    current.value = -1
+
+    with pytest.raises(ValidationError, match="greater than 0"):
+        family.dump(version="1", data=current)
+
+
+def test_current_model_subclass_fields_stay_outside_canonical_payload() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class CurrentPayload(BaseModel):
+        value: int
+
+    class ExtendedPayload(CurrentPayload):
+        extension: str
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(data))
+        return data
+
+    family = SchemaFamily(
+        model=CurrentPayload,
+        name="current_subclass_boundary",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.dump(
+        version="1",
+        data=ExtendedPayload(value=1, extension="source-only"),
+    ) == {"value": 1}
+    assert seen_payloads == [{"value": 1}]
+
+
+def test_declared_model_config_controls_top_level_canonical_scalars() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(ser_json_bytes="utf8")
+
+        value: bytes
+
+    class ExtendedPayload(CurrentPayload):
+        model_config = ConfigDict(ser_json_bytes="base64")
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(data))
+        return data
+
+    family = SchemaFamily(
+        model=CurrentPayload,
+        name="declared_config_top_level",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.dump(version="1", data={"value": b"abc"}) == {"value": "abc"}
+    assert family.dump(version="1", data=ExtendedPayload(value=b"abc")) == {
+        "value": "abc",
+    }
+    assert seen_payloads == [{"value": "abc"}, {"value": "abc"}]
+
+
+def test_nested_subclass_fields_stay_outside_canonical_payload() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class ChildPayload(BaseModel):
+        value: int
+
+    class ExtendedChild(ChildPayload):
+        secret: str
+
+    class ParentPayload(BaseModel):
+        direct: ChildPayload
+        items: list[ChildPayload]
+        grouped: dict[str, ChildPayload]
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(data)
+        return data
+
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="nested_subclass_boundary",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+    child = ExtendedChild(value=1, secret="never-cross-the-boundary")
+
+    rendered = family.dump(
+        version="1",
+        data=ParentPayload(direct=child, items=[child], grouped={"key": child}),
+    )
+
+    assert rendered == {
+        "direct": {"value": 1},
+        "items": [{"value": 1}],
+        "grouped": {"key": {"value": 1}},
+    }
+    assert seen_payloads == [rendered]
+
+
+def test_declared_model_config_controls_nested_canonical_scalars() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(ser_json_bytes="utf8")
+
+        value: bytes
+
+    class ExtendedChild(ChildPayload):
+        model_config = ConfigDict(ser_json_bytes="base64")
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload
+        items: list[ChildPayload]
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(data)
+        return data
+
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="declared_config_nested",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+    child = ExtendedChild(value=b"abc")
+
+    expected = {
+        "child": {"value": "abc"},
+        "items": [{"value": "abc"}],
+    }
+    assert (
+        family.dump(
+            version="1",
+            data={
+                "child": {"value": b"abc"},
+                "items": [{"value": b"abc"}],
+            },
+        )
+        == expected
+    )
+    assert (
+        family.dump(
+            version="1",
+            data=ParentPayload(child=child, items=[child]),
+        )
+        == expected
+    )
+    assert seen_payloads == [expected, expected]
+
+
+@pytest.mark.parametrize("subclass_first", [False, True])
+def test_declared_union_keeps_fields_from_the_selected_subclass(
+    subclass_first: bool,
+) -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class BaseChild(BaseModel):
+        value: int
+
+    class DeclaredChild(BaseChild):
+        declared_detail: str
+
+    union = DeclaredChild | BaseChild if subclass_first else BaseChild | DeclaredChild
+
+    parent_model = create_model(
+        f"DeclaredUnionParent_{subclass_first}",
+        child=(union, ...),
+    )
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(data)
+        return data
+
+    family = SchemaFamily(
+        model=parent_model,
+        name=f"declared_union_boundary_{subclass_first}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    family.dump(
+        version="1",
+        data=parent_model.model_validate(
+            {"child": DeclaredChild(value=1, declared_detail="kept")},
+        ),
+    )
+
+    assert seen_payloads == [
+        {"child": {"value": 1, "declared_detail": "kept"}},
+    ]
+
+
+def test_any_union_member_does_not_hide_the_declared_model_boundary() -> None:
+    seen_payloads: list[dict[str, Any]] = []
+
+    class BaseChild(BaseModel):
+        value: int
+
+    class ExtendedChild(BaseChild):
+        secret: str
+
+    class ParentPayload(BaseModel):
+        child: Any | BaseChild
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(data)
+        return data
+
+    family = SchemaFamily(
+        model=ParentPayload,
+        name="any_union_declared_boundary",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    rendered = family.dump(
+        version="1",
+        data=ParentPayload(child=ExtendedChild(value=1, secret="excluded")),
+    )
+
+    assert rendered == {"child": {"value": 1}}
+    assert seen_payloads == [rendered]
+
+
+@pytest.mark.parametrize("field_kind", ["exclude", "exclude_if"])
+def test_excluded_current_fields_do_not_cross_the_transition_boundary(
+    field_kind: str,
+) -> None:
+    seen_payloads: list[dict[str, Any]] = []
+    excluded = (
+        Field(default="private", exclude=True)
+        if field_kind == "exclude"
+        else Field(default="private", exclude_if=lambda value: value == "private")
+    )
+
+    class CurrentPayload(BaseModel):
+        public: str
+        internal: str = excluded
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(data)
+        return data
+
+    family = SchemaFamily(
+        model=CurrentPayload,
+        name=f"excluded_render_boundary_{field_kind}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.dump(
+        version="1",
+        data=CurrentPayload(public="visible", internal="private"),
+    ) == {"public": "visible"}
+    assert seen_payloads == [{"public": "visible"}]
+
+
+def test_mapping_render_honors_disabled_name_validation() -> None:
+    class AliasOnlyPayload(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=False)
+
+        value: int = Field(alias="wire")
+
+    family = SchemaFamily(
+        model=AliasOnlyPayload,
+        name="mapping_alias_policy",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValidationError, match="wire"):
+        family.dump(version="1", data={"value": 1})
+    assert family.dump(version="1", data={"wire": 1}) == {"value": 1}
+
+
+def test_render_metadata_checks_list_alias_paths() -> None:
+    class MetadataPayload(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=True)
+
+        schema_version: str = Field(
+            default="2",
+            validation_alias=AliasPath("meta", 0, "version"),
+        )
+        value: int
+
+    family = SchemaFamily(
+        model=MetadataPayload,
+        name="list_alias_metadata_render",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(
+            version="1",
+            data={"meta": [{"version": "1"}], "value": 7},
+        )
+    assert family.dump(
+        version="1",
+        data={"meta": [{"version": "2"}], "value": 7},
+    ) == {"schema_version": "1", "value": 7}
+
+
+def test_model_instance_family_metadata_extras_cannot_bypass_conflict_check() -> None:
+    class ExtensiblePayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    family = SchemaFamily(
+        model=ExtensiblePayload,
+        name="model_extra_metadata_render",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    stale = ExtensiblePayload.model_validate({"schema_version": "1", "value": 7})
+
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(version="1", data=stale)
+
+
+def test_validated_model_metadata_must_still_name_the_current_version() -> None:
+    class DefaultedMetadataPayload(BaseModel):
+        schema_version: str = "1"
+        value: int
+
+    family = SchemaFamily(
+        model=DefaultedMetadataPayload,
+        name="validated_metadata_render",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    with pytest.raises(SchemaVersionError, match="current-model input"):
+        family.dump(version="1", data={"value": 7})
+
+
+def test_decorator_discovered_current_wire_set_projection_is_renderable() -> None:
+    @versioned_schema(
+        name="decorator_set_child",
+        versions=("1", "2"),
+        current="2",
+    )
+    class DecoratorChild(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="decorator_set_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class DecoratorParent(BaseModel):
+        children: set[DecoratorChild]
+
+    current_wire = model_for_version(DecoratorParent, "2").model_validate(
+        {"children": [{"value": 1}]},
+    )
+
+    rendered = dump_versioned(
+        DecoratorParent,
+        version="1",
+        data=cast(Any, current_wire),
+    )
+
+    assert rendered["schema_version"] == "1"
+    assert len(rendered["children"]) == 1
+    assert {item["value"] for item in rendered["children"]} == {1}
+    assert {item["schema_version"] for item in rendered["children"]} == {"1"}
+
+
+def test_decorator_set_projection_beneath_mapping_is_renderable() -> None:
+    @versioned_schema(
+        name="mapped_set_leaf",
+        versions=("1", "2"),
+        current="2",
+    )
+    class MappedLeaf(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="mapped_set_container",
+        versions=("1", "2"),
+        current="2",
+    )
+    class MappedContainer(BaseModel):
+        leaves: set[MappedLeaf]
+
+    @versioned_schema(
+        name="mapped_set_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class MappedParent(BaseModel):
+        groups: dict[str, MappedContainer]
+
+    current_wire = model_for_version(MappedParent, "2").model_validate(
+        {
+            "groups": {
+                "primary": {
+                    "leaves": [{"value": 1}],
+                },
+            },
+        },
+    )
+
+    rendered = dump_versioned(
+        MappedParent,
+        version="1",
+        data=cast(Any, current_wire),
+    )
+
+    assert rendered["schema_version"] == "1"
+    primary = rendered["groups"]["primary"]
+    assert primary["schema_version"] == "1"
+    assert primary["leaves"] == [{"value": 1, "schema_version": "1"}]

--- a/tests/unit/test_versioned_schema.py
+++ b/tests/unit/test_versioned_schema.py
@@ -360,7 +360,7 @@ def test_dump_versioned_accepts_mapping_data_for_historical_schema() -> None:
     assert dumped == {"value": 6}
 
 
-def test_dump_versioned_normalizes_alias_paths_and_choices_in_input() -> None:
+def test_dump_versioned_uses_current_model_alias_priority_in_input() -> None:
     @versioned_schema(
         name="aliased_dump_input",
         versions=["1", "2"],
@@ -377,7 +377,7 @@ def test_dump_versioned_normalizes_alias_paths_and_choices_in_input() -> None:
         include_version=False,
     )
 
-    assert dumped == {"value": 3}
+    assert dumped == {"value": 1}
 
 
 def test_dump_versioned_rejects_non_mapping_data() -> None:


### PR DESCRIPTION
## Summary

- validate mapping and model render input through the authoritative current contract
- detach a canonical payload containing only declared wire-visible fields
- preserve alias, metadata, exclusion, subclass, and serialization-config boundaries
- bridge generated set/frozenset projections through authoritative core schemas
- keep validators, private factories, custom child initialization, and post-init behavior exact and once-only
- fail closed before unsafe enclosing custom initializers execute

Decorator-discovered nested conversion remains separately tracked by #77.

## Validation

- `uv run make ci` — 313 passed, 93.77% coverage; Ruff, ty, and strict mypy passed
- `uv run make docs-build-strict` — passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check` — passed
- conventional commit range check — passed
- `git diff --check HEAD^ HEAD` — clean

Closes #65