### PR TITLE
fix(planning): propagate nested route semantics

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instances, excluding extras and subclass-only fields from the canonical
   payload, detaching caller-owned containers, and enforcing metadata conflicts
   at every accepted input name.
+- Made validation and render plans include deterministic nested-family steps,
+  propagate child loss or unavailability to the parent route, and reject a
+  missing child downgrade before any user transition runs. Nested execution is
+  recursive, historical mappings may change child direction independently, and
+  each current parent label must map to its child's current label.
+- Kept explicit nested-family payloads in canonical current names through parent
+  transitions, then projected the complete subtree at the final wire boundary.
+  Child metadata is rebased to its mapped label, conflicting raw labels fail
+  preflight, and set cardinality is checked again after target wire coercion.
 
 ### Removed
 - Removed the unused `VersionedValidationError` placeholder from the public

--- a/docs/guide/application-exchange.md
+++ b/docs/guide/application-exchange.md
@@ -158,6 +158,13 @@ For the example above, version `2` is the newest exact common version. Version
 `1` is lossy because it omits `telemetry`. A deployment may permit that loss,
 but it must opt in rather than discovering it after data has been discarded.
 
+The same decision includes declared nested families. If a child schema loses a
+field on the selected route, the parent plan is lossy and the selector above
+requires `allow_lossy=True`. If a child route has no required downgrade,
+`plan_render()` rejects the parent route and the selector continues searching.
+This preflight is payload-independent, so an optional child or an empty child
+collection cannot make an otherwise unavailable contract safe.
+
 Version labels are opaque strings. “Newest” here means the producer's declared
 order, not lexical or numeric sorting.
 

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -144,6 +144,32 @@ version-specific projections, every adjacent upgrade or identity edge, and the
 final current-model validation boundary. Their overall semantics are
 `not_applicable`; individual identity steps are marked `exact`.
 
+When a parent edge changes the version selected for a declared nested family,
+the plan places a `nested` step immediately before that parent edge. Its schema
+path and child source/target labels describe the complete child conversion
+without inspecting a payload. The step is conditional because an optional or
+collection-valued path may have no value to convert for one document.
+Its direction follows the child labels rather than the owning parent edge, so an
+explicit historical mapping may require a child downgrade during parent
+validation or a child upgrade during rendering. Validation preflights the whole
+route and rejects an unavailable child downgrade before source validation or any
+parent or child transition callable runs.
+
+Runtime execution keeps nested transition dictionaries in canonical current
+field names. Each child value migration runs before its owning parent
+transition, so the parent callable can read and update current child keys even
+when that edge selects a historical child label. Target child field names are
+applied recursively only after the parent route completes, immediately before
+the final wire-validation boundary. Model-owned child metadata is rebased to
+the mapped child label at each edge. If raw nested metadata declares a different
+label than the parent mapping, validation and rendering reject the complete
+document before source/current validation or any transition callable runs.
+
+For nested `set` and `frozenset` fields, cardinality is checked both after value
+migrations and after target wire coercion. Distinct current values therefore
+cannot silently collapse because an explicit historical wire model normalizes
+them to the same set element.
+
 Each step has a deterministic `pv1-` ID followed by the full 64-character
 SHA-256 digest of safe schema identity. IDs never depend on Python's
 process-randomized hash, callable `repr()`, object identity, or payload values.
@@ -168,6 +194,12 @@ The method takes no payload and raises before any user transition can run.
 Structural rename and default projections are exact. A target projection that
 removes a current field is available but marks its step and the complete render
 plan as `lossy`.
+
+Nested render semantics roll up into the parent plan. A lossy child route makes
+the parent route lossy. An unavailable child route rejects the complete parent
+plan before any parent or child downgrade callable runs, even if the particular
+payload would omit that optional path or use an empty collection. `conditional`
+describes execution, not a way to weaken compatibility preflight.
 
 Custom downgrade declarations are fully supported. When an explicit downgrade is
 declared on a `VersionTransition`, rendering a historical schema will execute the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -141,11 +141,15 @@ The generated plan inventory and plans are the preferred compatibility artifacts
   use the documented `SchemaVersionError` subclasses. Exception messages are
   diagnostic text rather than structured API.
 
-### Reserved nested declarations
+### Nested declarations
 
 `NestedFamily`, `MatchingLabels`, and `matching_labels()` are exported as frozen
 declaration types so the final constructor remains stable. These allow complex
 nested schema execution and graph compilation to handle tree-structured data safely.
+An explicit mapping may select child labels independently for historical parent
+versions, but the current parent label must map to the child's current label.
+Compilation rejects a different current mapping because application models hold
+authoritative current child data.
 
 ## Compiled inventory and plans
 
@@ -256,7 +260,8 @@ class ConversionPlan:
 ```
 
 `plan_validation(source_version)` exposes source metadata and wire validation,
-field projections, each adjacent upgrade or identity edge, and current-model
+field projections, each adjacent upgrade or identity edge, nested-family
+conversions immediately before their owning parent edges, and current-model
 validation. Its overall semantics are `not_applicable`.
 
 `plan_render(target_version)` exposes current validation, reverse edges, target
@@ -265,6 +270,15 @@ structural changes produce an `exact` plan; removing a current field produces a
 `lossy` plan. A custom upgrade without a declared downgrade makes the route
 unavailable, so the method raises `IrreversibleTransitionError` instead of
 returning that candidate.
+
+Every parent edge whose child-version mapping changes has one `nested` step per
+declared path, in declaration order and immediately before the owning parent
+step. The child labels appear as that step's source and target versions, while
+the parent family continues to own the step and its schema path. Nested steps
+are conditional because a payload may omit an optional branch or contain an
+empty collection, but planning is deliberately conservative: child loss makes
+the parent render plan lossy, and an unavailable child route makes the complete
+parent route unavailable before any user downgrade callable runs.
 
 Plan construction is data-independent and does not execute transition
 callables or default factories. Step IDs use `pv1-` plus a full 64-character

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -288,6 +288,17 @@ def _validate_compilation_boundary(
                 raise SchemaCompilationError(msg)
             nested_versions = tuple((parent, parent_map[parent]) for parent in parent_labels)
 
+        current_parent = parent_labels[-1]
+        current_child = child_labels[-1]
+        mapped_current = nested_versions[-1][1]
+        if mapped_current != current_child:
+            msg = (
+                f"Nested family declaration at path {path!r} for {name!r} must map "
+                f"current parent label {current_parent!r} to current child label "
+                f"{current_child!r}, not {mapped_current!r}"
+            )
+            raise SchemaCompilationError(msg)
+
         compiled_nested.append(
             _CompiledNestedFamily(path=path, family=child_family, versions=nested_versions),
         )

--- a/src/pydantic_versions/_planning.py
+++ b/src/pydantic_versions/_planning.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_versions._compiler import (
+    _CompiledFamily,
     _CompiledField,
     _CompiledNestedFamily,
     _CompiledTransition,
@@ -62,6 +63,7 @@ def _build_planning_catalog(
             family,
             versions,
             transitions,
+            nested,
             source_index=source_index,
         )
         for source_index in range(len(versions))
@@ -71,6 +73,7 @@ def _build_planning_catalog(
             family,
             versions,
             transitions,
+            nested,
             target_index=target_index,
         )
         for target_index in range(len(versions))
@@ -159,6 +162,7 @@ def _build_validation_plan(
     family: SchemaFamily[Any],
     versions: tuple[_CompiledVersion, ...],
     transitions: tuple[_CompiledTransition, ...],
+    nested: tuple[_CompiledNestedFamily, ...],
     *,
     source_index: int,
 ) -> ConversionPlan:
@@ -209,6 +213,16 @@ def _build_validation_plan(
         )
     )
     for edge_index, transition in enumerate(transitions[source_index:], start=source_index):
+        steps.extend(
+            _nested_steps(
+                family,
+                nested,
+                operation="validate",
+                parent_source_version=transition.source,
+                parent_target_version=transition.target,
+                edge_ordinal=edge_index,
+            )
+        )
         kind: StepKind = transition.upgrade_kind
         semantics: StepSemantics = "exact" if kind == "implicit_identity" else "not_applicable"
         steps.append(
@@ -252,6 +266,7 @@ def _build_render_plan(
     family: SchemaFamily[Any],
     versions: tuple[_CompiledVersion, ...],
     transitions: tuple[_CompiledTransition, ...],
+    nested: tuple[_CompiledNestedFamily, ...],
     *,
     target_index: int,
 ) -> ConversionPlan:
@@ -274,6 +289,16 @@ def _build_render_plan(
 
     route = tuple(enumerate(transitions[target_index:], start=target_index))
     for edge_index, transition in reversed(route):
+        steps.extend(
+            _nested_steps(
+                family,
+                nested,
+                operation="render",
+                parent_source_version=transition.target,
+                parent_target_version=transition.source,
+                edge_ordinal=edge_index,
+            )
+        )
         kind: StepKind = (
             "custom_transition"
             if transition.downgrade_kind == "unavailable"
@@ -365,6 +390,131 @@ def _build_render_plan(
     )
 
 
+def _nested_steps(
+    family: SchemaFamily[Any],
+    nested: tuple[_CompiledNestedFamily, ...],
+    *,
+    operation: Literal["validate", "render"],
+    parent_source_version: str,
+    parent_target_version: str,
+    edge_ordinal: int,
+) -> tuple[PlanStep, ...]:
+    steps: list[PlanStep] = []
+    for nested_ordinal, declaration in enumerate(nested):
+        source_version = declaration.child_label(parent_source_version)
+        target_version = declaration.child_label(parent_target_version)
+        if source_version == target_version:
+            continue
+        child = declaration.family
+        child_compiled = child._compiled_family()
+        direction: Literal["upgrade", "downgrade"] = (
+            "upgrade"
+            if child_compiled.index(source_version) < child_compiled.index(target_version)
+            else "downgrade"
+        )
+        steps.append(
+            _step(
+                family,
+                operation=operation,
+                direction=direction,
+                kind="nested",
+                source_version=source_version,
+                target_version=target_version,
+                schema_path=_schema_path(declaration.path),
+                semantics=_nested_route_semantics(
+                    child_compiled,
+                    source_version=source_version,
+                    target_version=target_version,
+                ),
+                ordinal=edge_ordinal,
+                identity_details=(
+                    child.model.__module__,
+                    child.model.__qualname__,
+                    child.name,
+                    parent_source_version,
+                    parent_target_version,
+                    str(nested_ordinal),
+                    "conditional",
+                ),
+                conditional=True,
+            )
+        )
+    return tuple(steps)
+
+
+def _nested_route_semantics(
+    compiled: _CompiledFamily,
+    *,
+    source_version: str,
+    target_version: str,
+) -> StepSemantics:
+    source_index = compiled.index(source_version)
+    target_index = compiled.index(target_version)
+    if source_index == target_index:
+        return "exact"
+
+    risks: list[StepSemantics] = []
+    if source_index < target_index:
+        route = compiled.transitions[source_index:target_index]
+        for transition in route:
+            risks.extend(
+                _nested_route_risks(
+                    compiled.nested,
+                    parent_source_version=transition.source,
+                    parent_target_version=transition.target,
+                )
+            )
+        default: StepSemantics = "not_applicable"
+    else:
+        route = tuple(
+            compiled.transitions[edge_index]
+            for edge_index in range(source_index - 1, target_index - 1, -1)
+        )
+        for transition in route:
+            risks.extend(
+                _nested_route_risks(
+                    compiled.nested,
+                    parent_source_version=transition.target,
+                    parent_target_version=transition.source,
+                )
+            )
+            risks.append(transition.downgrade_semantics)
+        if any(
+            description.kind == "removed"
+            for description in _describe_version(compiled.versions[target_index]).projections
+        ):
+            risks.append("lossy")
+        default = "exact"
+
+    if "unavailable" in risks:
+        return "unavailable"
+    if "lossy" in risks:
+        return "lossy"
+    return default
+
+
+def _nested_route_risks(
+    nested: tuple[_CompiledNestedFamily, ...],
+    *,
+    parent_source_version: str,
+    parent_target_version: str,
+) -> tuple[StepSemantics, ...]:
+    risks: list[StepSemantics] = []
+    for declaration in nested:
+        source_version = declaration.child_label(parent_source_version)
+        target_version = declaration.child_label(parent_target_version)
+        if source_version == target_version:
+            continue
+        semantics = _nested_route_semantics(
+            declaration.family._compiled_family(),
+            source_version=source_version,
+            target_version=target_version,
+        )
+        if semantics in ("lossy", "unavailable"):
+            risks.append(semantics)
+    return tuple(risks)
+
+
 def _projection_steps(
     family: SchemaFamily[Any],
     *,
@@ -413,6 +563,7 @@ def _step(
     semantics: StepSemantics,
     ordinal: int,
     identity_details: tuple[str, ...] = (),
+    conditional: bool = False,
 ) -> PlanStep:
     components = (
         family.model.__module__,
@@ -438,7 +589,7 @@ def _step(
         kind=kind,
         schema_path=schema_path,
         semantics=semantics,
-        conditional=False,
+        conditional=conditional,
     )
 
 

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import datetime as dt
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from functools import partial
-from types import UnionType
+from types import NoneType, UnionType
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, cast, get_args, get_origin
 
 from pydantic import (
@@ -19,9 +19,11 @@ from pydantic_versions._compiler import (
     _CompiledFamily,
     _CompiledVersion,
 )
+from pydantic_versions._planning import _nested_route_semantics
 from pydantic_versions.declarations import VersionedValidation, VersionPath
 from pydantic_versions.exceptions import (
     InvalidMigrationError,
+    IrreversibleTransitionError,
     MissingSchemaVersionError,
     SchemaCompilationError,
     SchemaVersionError,
@@ -221,6 +223,12 @@ def _validate_family[T: BaseModel](
 ) -> VersionedValidation[T]:
     compiled = family._compiled_family()
     source_version = _detect_version(compiled, data, explicit_version=version)
+    _preflight_validation_route(family, compiled, source_version=source_version)
+    _preflight_nested_version_metadata(
+        payload=data,
+        compiled=compiled,
+        parent_label=source_version,
+    )
     source = compiled.version(source_version)
     source_model = source.model.model_validate(data)
     payload = _to_current_names(
@@ -231,14 +239,16 @@ def _validate_family[T: BaseModel](
 
     migrations_applied: list[tuple[str, str]] = []
     source_index = compiled.index(source_version)
+    nested_payload_is_canonical = False
     for transition in compiled.transitions[source_index:]:
-        if source_version != compiled.current_version:
-            payload = _apply_nested_family_migrations(
-                payload=payload,
-                compiled=compiled,
-                source_label=transition.source,
-                target_label=transition.target,
-            )
+        payload = _apply_nested_family_migrations(
+            payload=payload,
+            compiled=compiled,
+            source_label=transition.source,
+            target_label=transition.target,
+            source_payload_is_canonical=nested_payload_is_canonical,
+        )
+        nested_payload_is_canonical = True
         if transition.upgrade is None:
             continue
         migrated = transition.upgrade(dict(payload))
@@ -248,6 +258,12 @@ def _validate_family[T: BaseModel](
         payload = migrated
         migrations_applied.append((transition.source, transition.target))
 
+    payload = _project_nested_family_payloads(
+        payload=payload,
+        compiled=compiled,
+        parent_label=compiled.current_version,
+        wire_boundary=False,
+    )
     current_model = family.model.model_validate(
         _current_validation_input(family.model, payload),
         by_name=True,
@@ -277,6 +293,12 @@ def _dump_family[T: BaseModel](
     if requested != compiled.current_version:
         family.plan_render(requested)
 
+    _preflight_nested_version_metadata(
+        payload=data,
+        compiled=compiled,
+        parent_label=compiled.current_version,
+    )
+
     if data is None:
         payload = {}
     else:
@@ -286,6 +308,10 @@ def _dump_family[T: BaseModel](
             data=data,
         )
 
+    # Authoritative current-model validation already returns canonical field
+    # names for the complete declared subtree. Nested conversion must not
+    # validate those child values a second time merely to normalize them.
+    nested_payload_is_canonical = True
     if requested != compiled.current_version:
         for edge_index in range(current_index - 1, target_index - 1, -1):
             transition = compiled.transitions[edge_index]
@@ -294,7 +320,9 @@ def _dump_family[T: BaseModel](
                 compiled=compiled,
                 source_label=transition.target,
                 target_label=transition.source,
+                source_payload_is_canonical=nested_payload_is_canonical,
             )
+            nested_payload_is_canonical = True
             if transition.downgrade is None:
                 continue
             migrated = transition.downgrade(dict(payload))
@@ -306,6 +334,12 @@ def _dump_family[T: BaseModel](
                 raise InvalidMigrationError(msg)
             payload = migrated
 
+    payload = _project_nested_family_payloads(
+        payload=payload,
+        compiled=compiled,
+        parent_label=requested,
+        wire_boundary=True,
+    )
     if compiled.version_metadata is not None and (
         requested != compiled.current_version or compiled.version_metadata.owner == "model"
     ):
@@ -315,7 +349,14 @@ def _dump_family[T: BaseModel](
         else:
             payload[_model_metadata_field_name(compiled)] = requested
 
-    target_model = target.model.model_validate(_to_version_names(target, payload), by_name=True)
+    target_payload = _to_version_names(target, payload)
+    target_model = target.model.model_validate(target_payload, by_name=True)
+    _validate_nested_collection_cardinality(
+        input_payload=target_payload,
+        validated_model=target_model,
+        compiled=compiled,
+        parent_label=requested,
+    )
     if "mode" in dump_kwargs:
         dumped = target_model.model_dump(**dump_kwargs)
     else:
@@ -330,8 +371,10 @@ def _dump_family[T: BaseModel](
                 continue
             _prune_nested_family_metadata_at_path(
                 payload=dumped,
-                path=nested.path,
-                family=nested.family,
+                model=target.model,
+                path=_target_nested_path(target, nested.path),
+                family=nested.family._compiled_family(),
+                target_label=nested.child_label(requested),
             )
     if compiled.version_metadata is not None:
         if compiled.version_metadata.owner == "model":
@@ -873,29 +916,202 @@ def _apply_nested_family_migrations(
     compiled: _CompiledFamily,
     source_label: str,
     target_label: str,
+    source_payload_is_canonical: bool = False,
 ) -> dict[str, Any]:
     if not compiled.nested:
         return payload
     current_payload: dict[str, Any] = payload
-    if source_label == target_label:
+    if source_label == target_label and source_payload_is_canonical:
         return current_payload
     for nested in compiled.nested:
         nested_source = nested.child_label(source_label)
         nested_target = nested.child_label(target_label)
-        if nested_source == nested_target:
+        if nested_source == nested_target and source_payload_is_canonical:
             continue
         current_payload = _convert_nested_child_family(
             payload=current_payload,
+            model=compiled.model,
             path=nested.path,
             family=nested.family,
             source_label=nested_source,
             target_label=nested_target,
+            source_payload_is_canonical=source_payload_is_canonical,
+            normalize_unchanged=True,
             collection_kind=_nested_family_collection_kind(
                 model=compiled.model,
                 path=nested.path,
             ),
         )
     return current_payload
+
+
+def _preflight_validation_route(
+    family: SchemaFamily[Any],
+    compiled: _CompiledFamily,
+    *,
+    source_version: str,
+) -> None:
+    candidate = compiled.catalog.validation_plans[compiled.index(source_version)]
+    blocked = next(
+        (step for step in candidate.steps if step.semantics == "unavailable"),
+        None,
+    )
+    if blocked is None:
+        return
+    msg = (
+        f"Schema family {family.name!r} cannot validate "
+        f"{candidate.source_version!r} -> {candidate.target_version!r}: nested route "
+        f"at path {blocked.schema_path!r} has no complete route "
+        f"{blocked.source_version!r} -> {blocked.target_version!r}"
+    )
+    raise IrreversibleTransitionError(msg)
+
+
+def _preflight_nested_version_metadata(
+    *,
+    payload: Any,
+    compiled: _CompiledFamily,
+    parent_label: str,
+) -> None:
+    if not compiled.nested:
+        return
+    parent_version = compiled.version(parent_label)
+    payload_is_canonical = False
+    if isinstance(payload, BaseModel):
+        payload_is_canonical = isinstance(payload, parent_version.model) or (
+            parent_label == compiled.current_version and isinstance(payload, compiled.model)
+        )
+        payload = _extract_preflight_fields(
+            payload,
+            preserve_nested_models=True,
+        )
+    if not isinstance(payload, Mapping):
+        return
+
+    for nested in compiled.nested:
+        source_path = _target_nested_path(parent_version, nested.path)
+        if source_path is None:
+            continue
+        expected = nested.child_label(parent_label)
+        child_compiled = nested.family._compiled_family()
+        for nested_payload in _declared_payload_values_at_path(
+            payload,
+            model=parent_version.model,
+            path=source_path,
+            prefer_aliases=not payload_is_canonical,
+        ):
+            for item in _nested_payload_items(nested_payload):
+                metadata_payload = (
+                    _extract_preflight_fields(item) if isinstance(item, BaseModel) else item
+                )
+                if not isinstance(metadata_payload, Mapping):
+                    continue
+                found, declared = _declared_nested_version_metadata(
+                    payload=metadata_payload,
+                    compiled=child_compiled,
+                    source_label=expected,
+                )
+                if found and declared != expected:
+                    msg = (
+                        f"Nested family {nested.family.name!r} at path {nested.path!r} "
+                        f"expects version {expected!r} for parent label {parent_label!r}, "
+                        f"but the payload declares {declared!r}"
+                    )
+                    raise SchemaVersionError(msg)
+                _preflight_nested_version_metadata(
+                    payload=item,
+                    compiled=child_compiled,
+                    parent_label=expected,
+                )
+
+
+def _extract_preflight_fields(
+    value: BaseModel,
+    *,
+    preserve_nested_models: bool = False,
+) -> dict[str, Any]:
+    fields = type(value).model_fields
+    extracted = {
+        name: _extract_preflight_value(
+            value.__dict__[name],
+            preserve_nested_models=preserve_nested_models,
+        )
+        for name in fields
+        if name in value.__dict__
+    }
+    extras = value.__pydantic_extra__
+    if extras is not None:
+        extracted.update(
+            (
+                name,
+                _extract_preflight_value(
+                    item,
+                    preserve_nested_models=preserve_nested_models,
+                ),
+            )
+            for name, item in extras.items()
+        )
+    return extracted
+
+
+def _extract_preflight_value(
+    value: Any,
+    *,
+    preserve_nested_models: bool,
+) -> Any:
+    if isinstance(value, BaseModel):
+        if preserve_nested_models:
+            return value
+        return _extract_preflight_fields(value)
+    if isinstance(value, Mapping):
+        return {
+            key: _extract_preflight_value(
+                item,
+                preserve_nested_models=preserve_nested_models,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple | set | frozenset):
+        return tuple(
+            _extract_preflight_value(
+                item,
+                preserve_nested_models=preserve_nested_models,
+            )
+            for item in value
+        )
+    return value
+
+
+def _nested_payload_items(payload: Any) -> tuple[Any, ...]:
+    if isinstance(payload, list | tuple | set | frozenset):
+        return tuple(payload)
+    if payload is None:
+        return ()
+    return (payload,)
+
+
+def _declared_nested_version_metadata(
+    *,
+    payload: Mapping[str, Any],
+    compiled: _CompiledFamily,
+    source_label: str,
+) -> tuple[bool, Any]:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        return False, None
+    if metadata.owner == "family":
+        metadata_path = (metadata.path,) if isinstance(metadata.path, str) else metadata.path
+        if not _path_has_payload(payload, metadata_path):
+            return False, None
+        declared = _get_version_field(payload, metadata.path)
+        return True, declared
+
+    source_model = compiled.version(source_label).model
+    normalized = _normalize_payload_field_aliases(source_model, payload)
+    metadata_field = _model_metadata_field_name(compiled)
+    if metadata_field not in normalized:
+        return False, None
+    return True, normalized[metadata_field]
 
 
 def _nested_family_collection_kind(
@@ -910,7 +1126,7 @@ def _nested_family_collection_kind(
         field_info = annotation.model_fields.get(key)
         if field_info is None:
             return None
-        annotation = _strip_annotated(field_info.annotation)
+        annotation = _unwrap_optional_annotated(field_info.annotation)
         kind = _collection_kind(annotation)
         if index == len(path) - 1:
             return kind
@@ -919,7 +1135,7 @@ def _nested_family_collection_kind(
         args = get_args(annotation)
         if not args:
             return None
-        annotation = args[0]
+        annotation = _unwrap_optional_annotated(args[0])
     return None
 
 
@@ -948,6 +1164,22 @@ def _strip_annotated(annotation: Any) -> Any:
     return annotation
 
 
+def _unwrap_optional_annotated(annotation: Any) -> Any:
+    current = annotation
+    while True:
+        stripped = _strip_annotated(current)
+        if stripped is not current:
+            current = stripped
+            continue
+        origin = get_origin(current)
+        if origin not in (Union, UnionType):
+            return current
+        concrete = tuple(argument for argument in get_args(current) if argument is not NoneType)
+        if len(concrete) != 1:
+            return current
+        current = concrete[0]
+
+
 def _has_duplicate_payload(payload: list[Any]) -> bool:
     for index, item in enumerate(payload):
         if item in payload[:index]:
@@ -959,19 +1191,29 @@ def _prune_nested_family_metadata(
     *,
     payload: dict[str, Any],
     compiled: _CompiledFamily,
+    parent_label: str | None = None,
 ) -> None:
+    target_label = compiled.current_version if parent_label is None else parent_label
+    target = compiled.version(target_label)
     for nested in compiled.nested:
+        target_path = _target_nested_path(target, nested.path)
+        if target_path is None:
+            continue
         _prune_nested_family_metadata_at_path(
             payload=payload,
-            path=nested.path,
-            family=nested.family,
+            model=target.model,
+            path=target_path,
+            family=nested.family._compiled_family(),
+            target_label=nested.child_label(target_label),
         )
 
 
 def _prune_nested_family_metadata_payload(
     payload: Any,
     family: _CompiledFamily,
+    target_label: str | None = None,
 ) -> None:
+    resolved_target = family.current_version if target_label is None else target_label
     metadata = family.version_metadata
     if metadata is not None and metadata.owner == "family" and isinstance(payload, Mapping):
         _remove_version_field(payload, metadata.path)
@@ -979,215 +1221,84 @@ def _prune_nested_family_metadata_payload(
     if not family.nested:
         return
 
+    target = family.version(resolved_target)
     for child in family.nested:
+        target_path = _target_nested_path(target, child.path)
+        if target_path is None:
+            continue
         _prune_nested_family_metadata_at_path(
             payload=payload,
-            path=child.path,
-            family=child.family,
+            model=target.model,
+            path=target_path,
+            family=child.family._compiled_family(),
+            target_label=child.child_label(resolved_target),
         )
 
 
 def _prune_nested_family_metadata_at_path(
     *,
     payload: Any,
-    path: tuple[str, ...],
-    family: SchemaFamily[Any],
+    path: tuple[str, ...] | None,
+    family: SchemaFamily[Any] | _CompiledFamily,
+    model: type[BaseModel] | None = None,
+    target_label: str | None = None,
 ) -> None:
+    if path is None:
+        return
+    compiled_family = family if isinstance(family, _CompiledFamily) else family._compiled_family()
+    resolved_target = compiled_family.current_version if target_label is None else target_label
     if not path:
-        compiled_family = family._compiled_family()
-        if isinstance(payload, Mapping | list | tuple | set | frozenset):
-            if isinstance(payload, list):
-                for item in payload:
-                    _prune_nested_family_metadata_payload(item, compiled_family)
-                return
-            if isinstance(payload, tuple):
-                for item in payload:
-                    _prune_nested_family_metadata_payload(item, compiled_family)
-                return
-            if isinstance(payload, set):
-                for item in payload:
-                    _prune_nested_family_metadata_payload(item, compiled_family)
-                return
-            if isinstance(payload, frozenset):
-                for item in payload:
-                    _prune_nested_family_metadata_payload(item, compiled_family)
-                return
-            _prune_nested_family_metadata_payload(payload, compiled_family)
+        nested_payloads = (payload,)
+    elif model is None:
+        # A path without its declaring model cannot be traversed safely: searching
+        # arbitrary mapping values would let unrelated payload data impersonate a
+        # declared nested field.
         return
-
-    key, *remaining = path
-    if isinstance(payload, Mapping):
-        if key in payload:
-            _prune_nested_family_metadata_at_path(
-                payload=payload[key],
-                path=tuple(remaining),
-                family=family,
-            )
-            return
-        for field_value in payload.values():
-            _prune_nested_family_metadata_at_path(
-                payload=field_value,
-                path=path,
-                family=family,
-            )
-        return
-
-    if isinstance(payload, list):
-        for field_value in payload:
-            _prune_nested_family_metadata_at_path(
-                payload=field_value,
-                path=path,
-                family=family,
-            )
-        return
-
-    if isinstance(payload, tuple):
-        for field_value in payload:
-            _prune_nested_family_metadata_at_path(
-                payload=field_value,
-                path=path,
-                family=family,
-            )
-        return
-
-    if isinstance(payload, set):
-        for field_value in payload:
-            _prune_nested_family_metadata_at_path(
-                payload=field_value,
-                path=path,
-                family=family,
-            )
-        return
-
-    if isinstance(payload, frozenset):
-        for field_value in payload:
-            _prune_nested_family_metadata_at_path(
-                payload=field_value,
-                path=path,
-                family=family,
+    else:
+        nested_payloads = _declared_payload_values_at_path(
+            payload,
+            model=model,
+            path=path,
+            include_serialization_aliases=True,
+        )
+    for nested_payload in nested_payloads:
+        for item in _nested_payload_items(nested_payload):
+            _prune_nested_family_metadata_payload(
+                item,
+                compiled_family,
+                resolved_target,
             )
 
 
 def _convert_nested_child_family(
     *,
     payload: Any,
+    model: type[BaseModel],
     path: tuple[str, ...],
     family: SchemaFamily[Any],
     source_label: str,
     target_label: str,
+    source_payload_is_canonical: bool = False,
+    normalize_unchanged: bool = False,
     collection_kind: Literal["list", "tuple", "set", "frozenset"] | None = None,
 ) -> Any:
-    if not path:
+    def convert(nested_payload: Any) -> Any:
         return _convert_nested_family_payload(
             family=family,
-            payload=payload,
+            payload=nested_payload,
             source_label=source_label,
             target_label=target_label,
+            source_payload_is_canonical=source_payload_is_canonical,
+            normalize_unchanged=normalize_unchanged,
             collection_kind=collection_kind,
         )
-    key, *remaining = path
-    if isinstance(payload, Mapping):
-        if key in payload:
-            nested_payload = payload[key]
-            converted = _convert_nested_child_family(
-                payload=nested_payload,
-                path=tuple(remaining),
-                family=family,
-                source_label=source_label,
-                target_label=target_label,
-                collection_kind=collection_kind,
-            )
-            if converted is nested_payload:
-                return payload
-            updated = dict(payload)
-            updated[key] = converted
-            return updated
-        converted_children = {
-            field_name: _convert_nested_child_family(
-                payload=field_value,
-                path=path,
-                family=family,
-                source_label=source_label,
-                target_label=target_label,
-                collection_kind=collection_kind,
-            )
-            for field_name, field_value in payload.items()
-        }
-        if any(
-            converted_children[field_name] is not field_value
-            for field_name, field_value in payload.items()
-        ):
-            return converted_children
-        return payload
-    if isinstance(payload, list):
-        converted_items = [
-            _convert_nested_child_family(
-                payload=item,
-                path=path,
-                family=family,
-                source_label=source_label,
-                target_label=target_label,
-                collection_kind=collection_kind,
-            )
-            for item in payload
-        ]
-        if all(converted is item for converted, item in zip(converted_items, payload, strict=True)):
-            return payload
-        return converted_items
-    if isinstance(payload, tuple):
-        converted_items = tuple(
-            _convert_nested_child_family(
-                payload=item,
-                path=path,
-                family=family,
-                source_label=source_label,
-                target_label=target_label,
-                collection_kind=collection_kind,
-            )
-            for item in payload
-        )
-        if all(converted is item for converted, item in zip(converted_items, payload, strict=True)):
-            return payload
-        return converted_items
-    if isinstance(payload, set):
-        converted_items = {
-            _convert_nested_child_family(
-                payload=item,
-                path=path,
-                family=family,
-                source_label=source_label,
-                target_label=target_label,
-                collection_kind=collection_kind,
-            )
-            for item in payload
-        }
-        if len(converted_items) != len(payload):
-            msg = (
-                f"Nested migration for family {family.name!r} "
-                "cannot preserve set cardinality while converting mixed payload values"
-            )
-            raise InvalidMigrationError(msg)
-        return converted_items
-    if isinstance(payload, frozenset):
-        converted_items = frozenset(
-            _convert_nested_child_family(
-                payload=item,
-                path=path,
-                family=family,
-                source_label=source_label,
-                target_label=target_label,
-                collection_kind=collection_kind,
-            )
-            for item in payload
-        )
-        if len(converted_items) != len(payload):
-            msg = (
-                f"Nested migration for family {family.name!r} "
-                "cannot preserve set cardinality while converting mixed payload values"
-            )
-            raise InvalidMigrationError(msg)
-        return converted_items
-    return payload
+
+    return _transform_declared_payload_at_path(
+        payload,
+        model=model,
+        path=path,
+        transform=convert,
+    )
 
 
 def _convert_nested_family_payload(
@@ -1195,10 +1306,63 @@ def _convert_nested_family_payload(
     payload: Any,
     source_label: str,
     target_label: str,
+    source_payload_is_canonical: bool = False,
+    normalize_unchanged: bool = False,
     collection_kind: Literal["list", "tuple", "set", "frozenset"] | None = None,
 ) -> Any:
+    compiled = family._compiled_family()
+    source_index = compiled.index(source_label)
+    target_index = compiled.index(target_label)
+    if (
+        _nested_route_semantics(
+            compiled,
+            source_version=source_label,
+            target_version=target_label,
+        )
+        == "unavailable"
+    ):
+        blocked = (
+            next(
+                (
+                    compiled.transitions[edge_index]
+                    for edge_index in range(source_index - 1, target_index - 1, -1)
+                    if compiled.transitions[edge_index].downgrade_kind == "unavailable"
+                ),
+                None,
+            )
+            if source_index > target_index
+            else None
+        )
+        if blocked is None:
+            detail = "the route has no complete nested downgrade"
+        else:
+            detail = (
+                f"transition {blocked.source!r} -> {blocked.target!r} has no declared downgrade"
+            )
+        msg = (
+            f"Nested family {family.name!r} cannot convert "
+            f"{source_label!r} -> {target_label!r}: {detail}"
+        )
+        raise IrreversibleTransitionError(msg)
     if payload is None:
         return payload
+    if isinstance(payload, BaseModel):
+        # Parent migrations operate on canonical payloads and may replace a
+        # nested value with the current child model between route edges. Keep
+        # walking the child route from its declared fields without invoking
+        # model or field serializers (or validating the instance again).
+        if not isinstance(payload, family.model):
+            msg = (
+                f"Nested migration for family {family.name!r} received BaseModel "
+                f"{type(payload).__name__!r}; expected current model "
+                f"{family.model.__name__!r}"
+            )
+            raise InvalidMigrationError(msg)
+        payload = _extract_declared_fields(
+            payload,
+            declared_model=family.model,
+        )
+        source_payload_is_canonical = True
     if isinstance(payload, list):
         converted = [
             _convert_nested_family_payload(
@@ -1206,6 +1370,8 @@ def _convert_nested_family_payload(
                 payload=item,
                 source_label=source_label,
                 target_label=target_label,
+                source_payload_is_canonical=source_payload_is_canonical,
+                normalize_unchanged=normalize_unchanged,
                 collection_kind=collection_kind,
             )
             for item in payload
@@ -1229,6 +1395,8 @@ def _convert_nested_family_payload(
                 payload=item,
                 source_label=source_label,
                 target_label=target_label,
+                source_payload_is_canonical=source_payload_is_canonical,
+                normalize_unchanged=normalize_unchanged,
                 collection_kind=collection_kind,
             )
             for item in payload
@@ -1246,6 +1414,8 @@ def _convert_nested_family_payload(
                 payload=item,
                 source_label=source_label,
                 target_label=target_label,
+                source_payload_is_canonical=source_payload_is_canonical,
+                normalize_unchanged=normalize_unchanged,
                 collection_kind=collection_kind,
             )
             for item in payload
@@ -1264,6 +1434,8 @@ def _convert_nested_family_payload(
                 payload=item,
                 source_label=source_label,
                 target_label=target_label,
+                source_payload_is_canonical=source_payload_is_canonical,
+                normalize_unchanged=normalize_unchanged,
                 collection_kind=collection_kind,
             )
             for item in payload
@@ -1277,24 +1449,46 @@ def _convert_nested_family_payload(
         return converted
     if not isinstance(payload, Mapping):
         return payload
-    compiled = family._compiled_family()
-    source_index = compiled.index(source_label)
-    target_index = compiled.index(target_label)
-    if source_index == target_index:
+    if source_index == target_index and not source_payload_is_canonical and not normalize_unchanged:
         return dict(payload)
-    source_version = compiled.version(source_label)
-    source_model = source_version.model
-    source_data = source_model.model_validate(payload, by_name=True)
-    current_payload = dict(
-        _to_current_names(
-            compiled,
-            source_version,
-            _extract_declared_fields(source_data),
+    if source_payload_is_canonical:
+        current_payload = dict(payload)
+    else:
+        source_version = compiled.version(source_label)
+        source_data = source_version.model.model_validate(payload, by_name=True)
+        current_payload = dict(
+            _to_current_names(
+                compiled,
+                source_version,
+                _extract_declared_fields(source_data),
+            )
         )
-    )
+    nested_payload_is_canonical = source_payload_is_canonical
+    if source_index == target_index:
+        current_payload = _apply_nested_family_migrations(
+            payload=current_payload,
+            compiled=compiled,
+            source_label=source_label,
+            target_label=target_label,
+            source_payload_is_canonical=nested_payload_is_canonical,
+        )
+        _rebase_canonical_version_metadata(
+            payload=current_payload,
+            compiled=compiled,
+            target_label=target_label,
+        )
+        return current_payload
     if source_index < target_index:
         for edge_index in range(source_index, target_index):
             transition = compiled.transitions[edge_index]
+            current_payload = _apply_nested_family_migrations(
+                payload=current_payload,
+                compiled=compiled,
+                source_label=transition.source,
+                target_label=transition.target,
+                source_payload_is_canonical=nested_payload_is_canonical,
+            )
+            nested_payload_is_canonical = True
             if transition.upgrade is None:
                 continue
             migrated = transition.upgrade(dict(current_payload))
@@ -1308,6 +1502,14 @@ def _convert_nested_family_payload(
     else:
         for edge_index in range(source_index - 1, target_index - 1, -1):
             transition = compiled.transitions[edge_index]
+            current_payload = _apply_nested_family_migrations(
+                payload=current_payload,
+                compiled=compiled,
+                source_label=transition.target,
+                target_label=transition.source,
+                source_payload_is_canonical=nested_payload_is_canonical,
+            )
+            nested_payload_is_canonical = True
             if transition.downgrade is None:
                 continue
             migrated = transition.downgrade(dict(current_payload))
@@ -1318,12 +1520,563 @@ def _convert_nested_family_payload(
                 )
                 raise InvalidMigrationError(msg)
             current_payload = migrated
-    if compiled.version_metadata is not None and compiled.version_metadata.owner == "family":
-        if collection_kind in ("set", "tuple", "frozenset"):
-            _set_version_field(current_payload, compiled.version_metadata.path, target_label)
-        else:
-            _remove_version_field(current_payload, compiled.version_metadata.path)
+    _rebase_canonical_version_metadata(
+        payload=current_payload,
+        compiled=compiled,
+        target_label=target_label,
+    )
     return current_payload
+
+
+def _rebase_canonical_version_metadata(
+    *,
+    payload: dict[str, Any],
+    compiled: _CompiledFamily,
+    target_label: str,
+) -> None:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        return
+    if metadata.owner == "family":
+        _remove_version_field(payload, metadata.path)
+        return
+    payload[_model_metadata_field_name(compiled)] = target_label
+
+
+def _project_nested_family_payloads(
+    *,
+    payload: dict[str, Any],
+    compiled: _CompiledFamily,
+    parent_label: str,
+    wire_boundary: bool,
+) -> dict[str, Any]:
+    if not compiled.nested:
+        return payload
+    projected: dict[str, Any] = payload
+    for nested in compiled.nested:
+        projected = _project_nested_child_family(
+            payload=projected,
+            model=compiled.model,
+            path=nested.path,
+            family=nested.family,
+            target_label=nested.child_label(parent_label),
+            wire_boundary=wire_boundary,
+            collection_kind=_nested_family_collection_kind(
+                model=compiled.model,
+                path=nested.path,
+            ),
+        )
+    return projected
+
+
+def _project_nested_child_family(
+    *,
+    payload: Any,
+    model: type[BaseModel],
+    path: tuple[str, ...],
+    family: SchemaFamily[Any],
+    target_label: str,
+    wire_boundary: bool,
+    collection_kind: Literal["list", "tuple", "set", "frozenset"] | None,
+) -> Any:
+    def project(nested_payload: Any) -> Any:
+        return _project_nested_family_payload(
+            family=family,
+            payload=nested_payload,
+            target_label=target_label,
+            wire_boundary=wire_boundary,
+            collection_kind=collection_kind,
+        )
+
+    return _transform_declared_payload_at_path(
+        payload,
+        model=model,
+        path=path,
+        transform=project,
+    )
+
+
+def _project_nested_family_payload(
+    *,
+    family: SchemaFamily[Any],
+    payload: Any,
+    target_label: str,
+    wire_boundary: bool,
+    collection_kind: Literal["list", "tuple", "set", "frozenset"] | None,
+) -> Any:
+    if payload is None:
+        return payload
+    if isinstance(payload, list):
+        return [
+            _project_nested_family_payload(
+                family=family,
+                payload=item,
+                target_label=target_label,
+                wire_boundary=wire_boundary,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        ]
+    if isinstance(payload, tuple):
+        return tuple(
+            _project_nested_family_payload(
+                family=family,
+                payload=item,
+                target_label=target_label,
+                wire_boundary=wire_boundary,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        )
+    if isinstance(payload, set | frozenset):
+        return [
+            _project_nested_family_payload(
+                family=family,
+                payload=item,
+                target_label=target_label,
+                wire_boundary=wire_boundary,
+                collection_kind=collection_kind,
+            )
+            for item in payload
+        ]
+    if isinstance(payload, BaseModel):
+        payload = _extract_declared_fields(payload)
+    if not isinstance(payload, Mapping):
+        return payload
+
+    compiled = family._compiled_family()
+    projected = _project_nested_family_payloads(
+        payload=dict(payload),
+        compiled=compiled,
+        parent_label=target_label,
+        wire_boundary=wire_boundary,
+    )
+    _rebase_canonical_version_metadata(
+        payload=projected,
+        compiled=compiled,
+        target_label=target_label,
+    )
+    if not wire_boundary:
+        return projected
+
+    target_payload = _to_version_names(compiled.version(target_label), projected)
+    metadata = compiled.version_metadata
+    if metadata is not None and metadata.owner == "family":
+        if collection_kind in ("set", "tuple", "frozenset"):
+            _set_version_field(target_payload, metadata.path, target_label)
+        else:
+            _remove_version_field(target_payload, metadata.path)
+    return target_payload
+
+
+def _validate_nested_collection_cardinality(
+    *,
+    input_payload: dict[str, Any],
+    validated_model: BaseModel,
+    compiled: _CompiledFamily,
+    parent_label: str,
+) -> None:
+    if not compiled.nested:
+        return
+    validated_payload = _extract_declared_fields(validated_model)
+    _validate_nested_collection_cardinality_payloads(
+        input_payloads=(input_payload,),
+        validated_payloads=(validated_payload,),
+        compiled=compiled,
+        parent_label=parent_label,
+    )
+
+
+def _validate_nested_collection_cardinality_payloads(
+    *,
+    input_payloads: tuple[Any, ...],
+    validated_payloads: tuple[Any, ...],
+    compiled: _CompiledFamily,
+    parent_label: str,
+) -> None:
+    target = compiled.version(parent_label)
+    for nested in compiled.nested:
+        target_path = _target_nested_path(target, nested.path)
+        if target_path is None:
+            continue
+        input_values = tuple(
+            item
+            for payload in input_payloads
+            for item in _declared_payload_values_at_path(
+                payload,
+                model=target.model,
+                path=target_path,
+            )
+        )
+        validated_values = tuple(
+            item
+            for payload in validated_payloads
+            for item in _declared_payload_values_at_path(
+                payload,
+                model=target.model,
+                path=target_path,
+            )
+        )
+        collection_kind = _nested_family_collection_kind(
+            model=compiled.model,
+            path=nested.path,
+        )
+        if collection_kind in ("set", "frozenset"):
+            before = sorted(
+                len(value)
+                for value in input_values
+                if isinstance(value, list | tuple | set | frozenset)
+            )
+            after = sorted(
+                len(value)
+                for value in validated_values
+                if isinstance(value, list | tuple | set | frozenset)
+            )
+            collapsed = len(after) < len(before) or any(
+                actual < expected for expected, actual in zip(before, after, strict=False)
+            )
+            if collapsed:
+                msg = (
+                    f"Nested migration for family {nested.family.name!r} cannot "
+                    "preserve set cardinality after target wire validation at path "
+                    f"{nested.path!r}"
+                )
+                raise InvalidMigrationError(msg)
+
+        child_input = tuple(item for value in input_values for item in _nested_payload_items(value))
+        child_validated = tuple(
+            item for value in validated_values for item in _nested_payload_items(value)
+        )
+        child_compiled = nested.family._compiled_family()
+        if child_compiled.nested:
+            _validate_nested_collection_cardinality_payloads(
+                input_payloads=child_input,
+                validated_payloads=child_validated,
+                compiled=child_compiled,
+                parent_label=nested.child_label(parent_label),
+            )
+
+
+def _target_nested_path(
+    target: _CompiledVersion,
+    path: tuple[str, ...],
+) -> tuple[str, ...] | None:
+    if not path:
+        return path
+    first = target.projection.field(path[0]).version_name
+    if first is None:
+        return None
+    return (first, *path[1:])
+
+
+def _declared_payload_values_at_path(
+    payload: Any,
+    *,
+    model: type[BaseModel],
+    path: tuple[str, ...],
+    prefer_aliases: bool = False,
+    include_serialization_aliases: bool = False,
+) -> tuple[Any, ...]:
+    if not path:
+        return (payload,)
+    if isinstance(payload, BaseModel):
+        payload_is_canonical = isinstance(payload, model)
+        payload = _extract_preflight_fields(
+            payload,
+            preserve_nested_models=True,
+        )
+        # Only an instance of the model declaring this path has canonical
+        # storage. Unrelated models are structural input and must follow the
+        # declaring model's enabled validation locations.
+        if payload_is_canonical:
+            prefer_aliases = False
+    if not isinstance(payload, Mapping):
+        return ()
+
+    field_name, *remaining = path
+    field_info = model.model_fields.get(field_name)
+    if field_info is None:
+        return ()
+    found, field_value = _declared_field_payload_value(
+        payload,
+        field_name=field_name,
+        field_info=field_info,
+        model_config=model.model_config,
+        prefer_aliases=prefer_aliases,
+        include_serialization_aliases=include_serialization_aliases,
+    )
+    if not found:
+        return ()
+    if not remaining:
+        return (field_value,)
+    return _declared_payload_values_through_annotation(
+        field_value,
+        annotation=field_info.annotation,
+        path=tuple(remaining),
+        prefer_aliases=prefer_aliases,
+        include_serialization_aliases=include_serialization_aliases,
+    )
+
+
+def _declared_payload_values_through_annotation(
+    payload: Any,
+    *,
+    annotation: Any,
+    path: tuple[str, ...],
+    prefer_aliases: bool,
+    include_serialization_aliases: bool,
+) -> tuple[Any, ...]:
+    annotation = _unwrap_optional_annotated(annotation)
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return _declared_payload_values_at_path(
+            payload,
+            model=annotation,
+            path=path,
+            prefer_aliases=prefer_aliases,
+            include_serialization_aliases=include_serialization_aliases,
+        )
+
+    element_annotation = _declared_collection_element(annotation)
+    if element_annotation is None or not isinstance(payload, list | tuple | set | frozenset):
+        return ()
+    values: list[Any] = []
+    for item in payload:
+        values.extend(
+            _declared_payload_values_through_annotation(
+                item,
+                annotation=element_annotation,
+                path=path,
+                prefer_aliases=prefer_aliases,
+                include_serialization_aliases=include_serialization_aliases,
+            ),
+        )
+    return tuple(values)
+
+
+def _transform_declared_payload_at_path(
+    payload: Any,
+    *,
+    model: type[BaseModel],
+    path: tuple[str, ...],
+    transform: Callable[[Any], Any],
+    prefer_aliases: bool = False,
+) -> Any:
+    if not path:
+        return transform(payload)
+    if isinstance(payload, BaseModel):
+        payload = _extract_declared_fields(payload)
+    if not isinstance(payload, Mapping):
+        return payload
+
+    field_name, *remaining = path
+    field_info = model.model_fields.get(field_name)
+    if field_info is None:
+        return payload
+    access_path = _declared_field_payload_path(
+        payload,
+        field_name=field_name,
+        field_info=field_info,
+        model_config=model.model_config,
+        prefer_aliases=prefer_aliases,
+    )
+    if access_path is None:
+        return payload
+    field_value = _payload_value_at_access_path(payload, access_path)
+    if not remaining:
+        transformed = transform(field_value)
+    else:
+        transformed = _transform_declared_payload_through_annotation(
+            field_value,
+            annotation=field_info.annotation,
+            path=tuple(remaining),
+            transform=transform,
+            prefer_aliases=prefer_aliases,
+        )
+    if transformed is field_value:
+        return payload
+    return _replace_payload_value_at_access_path(payload, access_path, transformed)
+
+
+def _transform_declared_payload_through_annotation(
+    payload: Any,
+    *,
+    annotation: Any,
+    path: tuple[str, ...],
+    transform: Callable[[Any], Any],
+    prefer_aliases: bool,
+) -> Any:
+    annotation = _unwrap_optional_annotated(annotation)
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return _transform_declared_payload_at_path(
+            payload,
+            model=annotation,
+            path=path,
+            transform=transform,
+            prefer_aliases=prefer_aliases,
+        )
+
+    element_annotation = _declared_collection_element(annotation)
+    if element_annotation is None or not isinstance(payload, list | tuple | set | frozenset):
+        return payload
+    transformed_items = [
+        _transform_declared_payload_through_annotation(
+            item,
+            annotation=element_annotation,
+            path=path,
+            transform=transform,
+            prefer_aliases=prefer_aliases,
+        )
+        for item in payload
+    ]
+    if all(
+        transformed is original
+        for transformed, original in zip(transformed_items, payload, strict=True)
+    ):
+        return payload
+    if isinstance(payload, list):
+        return transformed_items
+    if isinstance(payload, tuple):
+        return tuple(transformed_items)
+    try:
+        transformed_set = type(payload)(transformed_items)
+    except TypeError:
+        # Canonical transition payloads use JSON-shaped lists for set-like
+        # fields, so an intermediate model-to-mapping conversion may cease to
+        # be hashable without losing any declared member.
+        return transformed_items
+    if len(transformed_set) != len(payload):
+        msg = "Nested migration cannot preserve set cardinality along its declared path"
+        raise InvalidMigrationError(msg)
+    return transformed_set
+
+
+def _declared_collection_element(annotation: Any) -> Any | None:
+    annotation = _unwrap_optional_annotated(annotation)
+    if _collection_kind(annotation) is None:
+        return None
+    arguments = tuple(argument for argument in get_args(annotation) if argument is not Ellipsis)
+    if not arguments:
+        return None
+    return _unwrap_optional_annotated(arguments[0])
+
+
+def _declared_field_payload_value(
+    payload: Mapping[Any, Any],
+    *,
+    field_name: str,
+    field_info: Any,
+    model_config: Mapping[str, Any],
+    prefer_aliases: bool,
+    include_serialization_aliases: bool,
+) -> tuple[bool, Any]:
+    access_path = _declared_field_payload_path(
+        payload,
+        field_name=field_name,
+        field_info=field_info,
+        model_config=model_config,
+        prefer_aliases=prefer_aliases,
+        include_serialization_aliases=include_serialization_aliases,
+    )
+    if access_path is None:
+        return False, None
+    return True, _payload_value_at_access_path(payload, access_path)
+
+
+def _declared_field_payload_path(
+    payload: Mapping[Any, Any],
+    *,
+    field_name: str,
+    field_info: Any,
+    model_config: Mapping[str, Any],
+    prefer_aliases: bool,
+    include_serialization_aliases: bool = False,
+) -> tuple[Any, ...] | None:
+    if include_serialization_aliases:
+        output_alias = field_info.serialization_alias
+        if output_alias is None:
+            output_alias = field_info.alias
+        candidates = ((field_name,), *_alias_path(output_alias))
+    elif prefer_aliases:
+        validation_aliases = _field_alias_paths(field_info)
+        if not validation_aliases:
+            # An unaliased field is always accepted by its field name, even
+            # when validate_by_name is otherwise disabled for aliased fields.
+            candidates = ((field_name,),)
+        else:
+            aliases_enabled = model_config.get("validate_by_alias", True) is not False
+            names_enabled = model_config.get("validate_by_name", False) is True
+            name_candidates = ((field_name,),) if names_enabled else ()
+            candidates = (
+                *(validation_aliases if aliases_enabled else ()),
+                *name_candidates,
+            )
+    else:
+        candidates = ((field_name,),)
+    visited: list[tuple[Any, ...]] = []
+    for candidate in candidates:
+        if not candidate or candidate in visited:
+            continue
+        visited.append(candidate)
+        if _payload_access_path_exists(payload, candidate):
+            return candidate
+    return None
+
+
+def _payload_access_path_exists(payload: Any, path: tuple[Any, ...]) -> bool:
+    current = payload
+    for part in path:
+        if isinstance(current, Mapping):
+            if part not in current:
+                return False
+            current = current[part]
+            continue
+        if isinstance(current, list | tuple) and isinstance(part, int):
+            try:
+                current = current[part]
+            except IndexError:
+                return False
+            continue
+        return False
+    return True
+
+
+def _payload_value_at_access_path(payload: Any, path: tuple[Any, ...]) -> Any:
+    current = payload
+    for part in path:
+        current = current[part]
+    return current
+
+
+def _replace_payload_value_at_access_path(
+    payload: Any,
+    path: tuple[Any, ...],
+    value: Any,
+) -> Any:
+    if not path:
+        return value
+    part, *remaining = path
+    if isinstance(payload, Mapping):
+        if part not in payload:
+            return payload
+        child = payload[part]
+        replaced = _replace_payload_value_at_access_path(child, tuple(remaining), value)
+        if replaced is child:
+            return payload
+        updated = dict(payload)
+        updated[part] = replaced
+        return updated
+    if isinstance(payload, list | tuple) and isinstance(part, int):
+        try:
+            child = payload[part]
+        except IndexError:
+            return payload
+        replaced = _replace_payload_value_at_access_path(child, tuple(remaining), value)
+        if replaced is child:
+            return payload
+        updated_items = list(payload)
+        updated_items[part] = replaced
+        return updated_items if isinstance(payload, list) else tuple(updated_items)
+    return payload
 
 
 def _infer_metadata_owner(
@@ -1470,7 +2223,7 @@ def _normalize_payload_field_aliases(
     *,
     prefer_aliases: bool = False,
 ) -> dict[str, Any]:
-    normalized = dict(payload)
+    normalized = {key: _copy_alias_payload_value(value) for key, value in payload.items()}
     for name, field_info in model_cls.model_fields.items():
         alias_paths = _field_alias_paths(field_info)
         if name in normalized:
@@ -1498,6 +2251,16 @@ def _normalize_payload_field_aliases(
             _remove_payload_path(normalized, source_path)
             normalized[name] = value
     return normalized
+
+
+def _copy_alias_payload_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _copy_alias_payload_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_alias_payload_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_copy_alias_payload_value(item) for item in value)
+    return value
 
 
 def _field_alias_paths(field_info: Any) -> tuple[tuple[Any, ...], ...]:

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -235,6 +235,20 @@ class SchemaFamily[T: BaseModel]:
         candidate = compiled.catalog.render_plans[compiled.index(requested)]
         if candidate.semantics == "unavailable":
             blocked = next(step for step in candidate.steps if step.semantics == "unavailable")
+            if blocked.kind == "nested":
+                nested = next(
+                    description
+                    for description in compiled.catalog.inventory.nested
+                    if description.schema_path == blocked.schema_path
+                )
+                msg = (
+                    f"Schema family {self.name!r} cannot render "
+                    f"{candidate.source_version!r} -> {candidate.target_version!r}: "
+                    f"nested family {nested.family!r} at path {blocked.schema_path!r} "
+                    f"has no complete route {blocked.source_version!r} -> "
+                    f"{blocked.target_version!r}"
+                )
+                raise IrreversibleTransitionError(msg)
             msg = (
                 f"Schema family {self.name!r} cannot render "
                 f"{candidate.source_version!r} -> {candidate.target_version!r}: "

--- a/tests/compatibility/README.md
+++ b/tests/compatibility/README.md
@@ -16,6 +16,13 @@ Check the committed artifact with the current checkout:
 uv run python tests/compatibility/v0_3_0_contract.py --check
 ```
 
+Current code intentionally adds two steps to the frozen artifact: a conditional
+`$.credentials` nested step in `validate_v1` and another in `render_v1_lossy`.
+The checker applies that reviewed additive overlay without modifying the 0.3.0
+fixture, then compares the exact rendered artifact, including dictionary key
+order and step positions. It returns success only for those two additions; any
+other output remains an unexplained compatibility delta.
+
 The write command refuses a different package version. Review the resulting
 human-readable diff before committing it. Never regenerate solely to make a
 compatibility failure disappear: either preserve the stable contract or

--- a/tests/compatibility/v0_3_0_contract.py
+++ b/tests/compatibility/v0_3_0_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,41 @@ BASELINE_TAG = "v0.3.0"
 BASELINE_COMMIT = "a03e67e5adc83e0087773383c3d55ed9e8da9bde"
 SCHEMA_NAME = "com.example.golden-service-config"
 FIXTURE_PATH = Path(__file__).parents[1] / "fixtures" / "compatibility" / "v0.3.0.json"
+
+_REVIEWED_NESTED_PLAN_OVERLAY: tuple[tuple[str, str, dict[str, Any]], ...] = (
+    (
+        "validate_v1",
+        "pv1-4e531e5e4ad4f54c2971167c7da787f2d33e96f8713ee5fb9d9f3af51514b32c",
+        {
+            "id": "pv1-0f03ddf9ebd7693766aa6232192adaeb02b20634cb1f5bf871ad92d9d93e833d",
+            "family": SCHEMA_NAME,
+            "source_version": "1",
+            "target_version": "2",
+            "operation": "validate",
+            "direction": "upgrade",
+            "kind": "nested",
+            "schema_path": "$.credentials",
+            "semantics": "not_applicable",
+            "conditional": True,
+        },
+    ),
+    (
+        "render_v1_lossy",
+        "pv1-e4054d80fff357a46244b427c480e943b37a1481c17c471d50296f94ae7f5374",
+        {
+            "id": "pv1-dd8410f673330912f3b42b32b6722102dea8ba7e9d3b04d8b121d93f44aa214a",
+            "family": SCHEMA_NAME,
+            "source_version": "2",
+            "target_version": "1",
+            "operation": "render",
+            "direction": "downgrade",
+            "kind": "nested",
+            "schema_path": "$.credentials",
+            "semantics": "exact",
+            "conditional": True,
+        },
+    ),
+)
 
 
 def _upgrade_endpoint(data: dict[str, Any]) -> dict[str, Any]:
@@ -241,32 +277,53 @@ def render_artifact() -> str:
     return f"{json.dumps(build_artifact(), indent=2)}\n"
 
 
+def _expected_current_artifact(baseline: dict[str, Any]) -> dict[str, Any]:
+    expected = deepcopy(baseline)
+    inspection = expected["inspection"]
+    for plan_name, owning_step_id, nested_step in _REVIEWED_NESTED_PLAN_OVERLAY:
+        steps = inspection[plan_name]["steps"]
+        owning_indexes = [index for index, step in enumerate(steps) if step["id"] == owning_step_id]
+        if len(owning_indexes) != 1:
+            msg = (
+                f"Frozen v0.3.0 plan {plan_name!r} must contain exactly one owning "
+                f"step {owning_step_id!r}"
+            )
+            raise RuntimeError(msg)
+        steps.insert(owning_indexes[0], deepcopy(nested_step))
+    return expected
+
+
+def _render_expected_current_artifact(baseline: str) -> str:
+    expected = _expected_current_artifact(json.loads(baseline))
+    return f"{json.dumps(expected, indent=2)}\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     action = parser.add_mutually_exclusive_group(required=True)
     action.add_argument("--check", action="store_true")
     action.add_argument("--write", action="store_true")
     args = parser.parse_args()
-    rendered = render_artifact()
-
     if args.write:
         if __version__ != BASELINE_VERSION:
             parser.error(
                 f"--write requires pydantic-versions=={BASELINE_VERSION}; found {__version__}"
             )
         FIXTURE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        FIXTURE_PATH.write_text(rendered, encoding="utf-8")
+        FIXTURE_PATH.write_text(render_artifact(), encoding="utf-8")
         return 0
 
     committed = FIXTURE_PATH.read_text(encoding="utf-8")
-    if committed == rendered:
+    expected_rendered = _render_expected_current_artifact(committed)
+    current_rendered = render_artifact()
+    if current_rendered == expected_rendered:
         return 0
     print(
         "".join(
             difflib.unified_diff(
-                committed.splitlines(keepends=True),
-                rendered.splitlines(keepends=True),
-                fromfile=str(FIXTURE_PATH),
+                expected_rendered.splitlines(keepends=True),
+                current_rendered.splitlines(keepends=True),
+                fromfile="reviewed v0.3.0 contract plus nested-plan overlay",
                 tofile="current contract",
             )
         )

--- a/tests/integration/test_application_exchange_scenario.py
+++ b/tests/integration/test_application_exchange_scenario.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 from pydantic import BaseModel
 
 from pydantic_versions import (
     IrreversibleTransitionError,
+    NestedFamily,
     SchemaFamily,
     SchemaVersion,
     field_default,
     field_removed,
     field_renamed,
+    matching_labels,
 )
 
 SCHEMA_ID = "com.example.pipeline-config"
@@ -85,7 +88,7 @@ class NoCompatibleSchemaVersionError(RuntimeError):
 
 
 def _select_target_version(
-    producer: SchemaFamily[ProducerConfig],
+    producer: SchemaFamily[Any],
     consumer: ConsumerCapabilities,
     *,
     allow_lossy: bool = False,
@@ -159,6 +162,42 @@ def test_exchange_refuses_no_overlap_and_requires_opt_in_for_lossy_output() -> N
         _select_target_version(PRODUCER_SCHEMA, version_one_only)
 
     assert _select_target_version(PRODUCER_SCHEMA, version_one_only, allow_lossy=True) == "1"
+
+
+def test_exchange_selector_accounts_for_nested_loss() -> None:
+    class ProducerCredentials(BaseModel):
+        token: str
+        current_scope: str = "write"
+
+    credentials = SchemaFamily(
+        model=ProducerCredentials,
+        name="com.example.nested-exchange.credentials",
+        versions=(
+            SchemaVersion("1", patches=(field_removed("current_scope"),)),
+            SchemaVersion("2"),
+        ),
+    )
+
+    class NestedProducerConfig(BaseModel):
+        credentials: ProducerCredentials
+
+    producer = SchemaFamily(
+        model=NestedProducerConfig,
+        name="com.example.nested-exchange",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("credentials", credentials, matching_labels()),),
+    )
+    version_one_only = ConsumerCapabilities(schema=producer.name, accepts=("1",))
+
+    plan = producer.plan_render("1")
+    nested_step = next(step for step in plan.steps if step.kind == "nested")
+    assert nested_step.schema_path == "$.credentials"
+    assert nested_step.semantics == "lossy"
+    assert plan.semantics == "lossy"
+
+    with pytest.raises(NoCompatibleSchemaVersionError):
+        _select_target_version(producer, version_one_only)
+    assert _select_target_version(producer, version_one_only, allow_lossy=True) == "1"
 
 
 def test_exchange_supports_transport_owned_version_metadata() -> None:

--- a/tests/integration/test_cross_release_compatibility.py
+++ b/tests/integration/test_cross_release_compatibility.py
@@ -10,17 +10,17 @@ CONTRACT_PATH = Path(__file__).parents[1] / "compatibility" / "v0_3_0_contract.p
 CONTRACT = runpy.run_path(str(CONTRACT_PATH), run_name="compatibility_v0_3_0_contract")
 CONSUMER_SCHEMA = CONTRACT["CONSUMER_SCHEMA"]
 PRODUCER_SCHEMA = CONTRACT["PRODUCER_SCHEMA"]
-build_artifact = CONTRACT["build_artifact"]
 render_artifact = CONTRACT["render_artifact"]
+render_expected_current_artifact = CONTRACT["_render_expected_current_artifact"]
 
 
 def _fixture() -> dict[str, Any]:
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
-def test_current_code_reproduces_the_v0_3_0_stable_contract() -> None:
-    assert render_artifact() == FIXTURE_PATH.read_text(encoding="utf-8")
-    assert build_artifact() == _fixture()
+def test_current_code_matches_the_reviewed_v0_3_0_additive_overlay() -> None:
+    baseline = FIXTURE_PATH.read_text(encoding="utf-8")
+    assert render_artifact() == render_expected_current_artifact(baseline)
 
 
 def test_current_code_consumes_persisted_embedded_and_transport_payloads() -> None:

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -41,6 +41,7 @@ from pydantic_versions.declarations import (
 from pydantic_versions.exceptions import (
     DuplicateSchemaVersionError,
     InvalidMigrationError,
+    IrreversibleTransitionError,
     SchemaCompilationError,
     UnknownSchemaVersionError,
     UnsupportedWireModelError,
@@ -212,7 +213,7 @@ def test_runtime_private_edges() -> None:
         path=("outer", "value"),
         family=parent,
     )
-    assert payload == {"outer": {"value": {}}}
+    assert payload == {"outer": {"value": {"schema_version": "v2"}}}
 
     assert _nested_family_collection_kind(model=Base, path=("value",)) is None
 
@@ -883,35 +884,43 @@ def test_runtime_nested_child_and_family_payload_conversions() -> None:
         ),
     )
 
+    class CollectionParent(BaseModel):
+        tuple_values: tuple[ChildModel, ...]
+        set_values: set[ChildModel]
+        frozenset_values: frozenset[ChildModel]
+
     # _convert_nested_child_family direct tests with tuple, set, frozenset
     item_v1 = HashableDict({"schema_version": "v1", "val": 1})
 
     res_tuple = _convert_nested_child_family(
-        payload=({"sub": item_v1},),
-        path=("sub",),
+        payload={"tuple_values": (item_v1,)},
+        model=CollectionParent,
+        path=("tuple_values",),
         family=child_fam,
         source_label="v1",
         target_label="v2",
     )
-    assert res_tuple[0]["sub"]["val"] == 11
+    assert res_tuple["tuple_values"][0]["val"] == 11
 
     res_set = _convert_nested_child_family(
-        payload={1, 2},
-        path=("sub",),
+        payload={"set_values": {item_v1}},
+        model=CollectionParent,
+        path=("set_values",),
         family=child_fam,
         source_label="v1",
         target_label="v2",
     )
-    assert len(res_set) == 2
+    assert len(res_set["set_values"]) == 1
 
     res_frozenset = _convert_nested_child_family(
-        payload=frozenset([1, 2]),
-        path=("sub",),
+        payload={"frozenset_values": frozenset([item_v1])},
+        model=CollectionParent,
+        path=("frozenset_values",),
         family=child_fam,
         source_label="v1",
         target_label="v2",
     )
-    assert len(res_frozenset) == 2
+    assert len(res_frozenset["frozenset_values"]) == 1
 
     # _convert_nested_family_payload direct tests with tuple, set, frozenset
     payload_tuple = (item_v1,)
@@ -1174,6 +1183,7 @@ def test_runtime_more_nested_family_migration_errors_and_conversions() -> None:
     item_v1 = {"schema_version": "v1", "val": 1}
     res_dict = _convert_nested_child_family(
         payload={"a": {"sub": item_v1}},
+        model=ChildModel,
         path=("sub", "val"),
         family=bad_upgrade_fam,
         source_label="v1",
@@ -1265,6 +1275,7 @@ def test_runtime_nested_cardinality_and_prune_coverage() -> None:
     with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
         _convert_nested_child_family(
             payload={item1, item2},
+            model=fam.model,
             path=(),
             family=fam,
             source_label="v1",
@@ -1274,6 +1285,7 @@ def test_runtime_nested_cardinality_and_prune_coverage() -> None:
     with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
         _convert_nested_child_family(
             payload=frozenset({item1, item2}),
+            model=fam.model,
             path=(),
             family=fam,
             source_label="v1",
@@ -1471,6 +1483,7 @@ def test_runtime_list_tuple_unchanged_conversions() -> None:
     # list unchanged
     res_list1 = _convert_nested_child_family(
         payload=[item],
+        model=fam.model,
         path=(),
         family=fam,
         source_label="v1",
@@ -1489,6 +1502,7 @@ def test_runtime_list_tuple_unchanged_conversions() -> None:
     # tuple unchanged
     res_tup1 = _convert_nested_child_family(
         payload=(item,),
+        model=fam.model,
         path=(),
         family=fam,
         source_label="v1",
@@ -1554,14 +1568,15 @@ def test_runtime_nested_migration_none_transitions_and_metadata_alias() -> None:
     assert res_up is not None
 
     item3 = {"schema_version": "v3", "val": 1}
-    # downgrade v3 -> v1 with None downgrade
-    res_down = _convert_nested_family_payload(
-        family=fam,
-        payload=item3,
-        source_label="v3",
-        target_label="v1",
-    )
-    assert res_down is not None
+    # A missing downgrade on a custom-upgrade edge is unavailable, not an
+    # implicit identity that nested conversion may silently skip.
+    with pytest.raises(IrreversibleTransitionError, match="has no declared downgrade"):
+        _convert_nested_family_payload(
+            family=fam,
+            payload=item3,
+            source_label="v3",
+            target_label="v1",
+        )
 
 
 def test_compiler_patch_validation_errors() -> None:

--- a/tests/unit/test_inventory_and_plans.py
+++ b/tests/unit/test_inventory_and_plans.py
@@ -8,15 +8,16 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from threading import Barrier
-from typing import Any, cast
+from typing import Annotated, Any, cast
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import AliasPath, BaseModel, ConfigDict, Field, create_model
 
 from pydantic_versions import (
     ConversionPlan,
     InvalidMigrationError,
     IrreversibleTransitionError,
+    NestedFamily,
     NestedFamilyDescription,
     PlanStep,
     ProjectionDescription,
@@ -24,6 +25,7 @@ from pydantic_versions import (
     SchemaFamilySelectionError,
     SchemaInventory,
     SchemaVersion,
+    SchemaVersionError,
     TransitionDescription,
     UnknownSchemaVersionError,
     VersionDescription,
@@ -32,9 +34,11 @@ from pydantic_versions import (
     field_default,
     field_removed,
     field_renamed,
+    matching_labels,
     migration,
     validate_versioned,
 )
+from pydantic_versions._runtime import _nested_family_collection_kind
 
 
 class InventoryConfig(BaseModel):
@@ -55,6 +59,21 @@ class PrivacyConfig(BaseModel):
 
 class CollisionConfig(BaseModel):
     value: int = 1
+
+
+class NestedPlanChild(BaseModel):
+    value: int = 1
+
+
+class NestedPlanParent(BaseModel):
+    child: NestedPlanChild
+
+
+class NestedRouteChild(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    value: int = 1
+    internal: str = "current"
 
 
 def _identity(data: dict[str, Any]) -> dict[str, Any]:
@@ -127,6 +146,48 @@ def _structural_family(
             SchemaVersion("2"),
         ),
     )
+
+
+def _deterministic_nested_family() -> SchemaFamily[NestedPlanParent]:
+    child = SchemaFamily(
+        model=NestedPlanChild,
+        name="deterministic_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+    )
+    return SchemaFamily(
+        model=NestedPlanParent,
+        name="deterministic_nested_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        nested=(NestedFamily("child", child, matching_labels()),),
+    )
+
+
+def _nested_shape_value(shape: str, child: BaseModel) -> Any:
+    if shape == "direct":
+        return child
+    if shape == "list":
+        return [child]
+    if shape == "tuple":
+        return (child,)
+    if shape == "set":
+        return {child}
+    if shape == "frozenset":
+        return frozenset((child,))
+    raise AssertionError(f"Unexpected nested test shape: {shape}")
+
+
+def _nested_shape_annotation(shape: str) -> Any:
+    if shape == "direct":
+        return NestedRouteChild
+    if shape == "list":
+        return list[NestedRouteChild]
+    if shape == "tuple":
+        return tuple[NestedRouteChild, ...]
+    if shape == "set":
+        return set[NestedRouteChild]
+    if shape == "frozenset":
+        return frozenset[NestedRouteChild]
+    raise AssertionError(f"Unexpected nested test shape: {shape}")
 
 
 def _step_signature(
@@ -456,6 +517,994 @@ def test_render_plan_is_exact_for_rename_only_and_current_targets() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "shape",
+    ["direct", "list", "tuple", "set", "frozenset"],
+)
+@pytest.mark.parametrize("child_semantics", ["exact", "lossy", "unavailable"])
+def test_nested_plans_aggregate_child_routes_for_supported_shapes(
+    shape: str,
+    child_semantics: str,
+) -> None:
+    child_v1 = SchemaVersion(
+        "1",
+        patches=(field_removed("internal"),) if child_semantics == "lossy" else (),
+    )
+    child_transitions = (
+        (VersionTransition("1", "2", upgrade=_identity),)
+        if child_semantics == "unavailable"
+        else ()
+    )
+    child_family = SchemaFamily(
+        model=NestedRouteChild,
+        name=f"nested_plan_child_{shape}_{child_semantics}",
+        versions=(child_v1, SchemaVersion("2")),
+        transitions=child_transitions,
+    )
+
+    annotation = _nested_shape_annotation(shape)
+    parent_model = create_model(
+        f"NestedPlanParent_{shape}_{child_semantics}",
+        __module__=__name__,
+        child=(annotation, ...),
+    )
+    parent_downgrade = _CallableProbe(f"parent-{shape}-{child_semantics}")
+    parent_family = SchemaFamily(
+        model=parent_model,
+        name=f"nested_plan_parent_{shape}_{child_semantics}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=parent_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    validation = parent_family.plan_validation("1")
+    validation_nested = tuple(step for step in validation.steps if step.kind == "nested")
+    assert tuple(map(_step_signature, validation_nested)) == (
+        ("nested", "1", "2", "$.child", "not_applicable"),
+    )
+    assert validation.steps.index(validation_nested[0]) < next(
+        index for index, step in enumerate(validation.steps) if step.kind == "implicit_identity"
+    )
+    assert validation_nested[0].conditional is True
+
+    compiled = parent_family._compiled_family()
+    render_candidate = compiled.catalog.render_plans[compiled.index("1")]
+    render_nested = tuple(step for step in render_candidate.steps if step.kind == "nested")
+    assert tuple(map(_step_signature, render_nested)) == (
+        ("nested", "2", "1", "$.child", child_semantics),
+    )
+    assert render_candidate.steps.index(render_nested[0]) < next(
+        index
+        for index, step in enumerate(render_candidate.steps)
+        if step.kind == "custom_transition"
+    )
+    assert render_nested[0].conditional is True
+    assert render_candidate.semantics == child_semantics
+    assert len({step.id for step in render_candidate.steps}) == len(render_candidate.steps)
+
+    child = NestedRouteChild(value=7, internal="private")
+    data = parent_model.model_validate({"child": _nested_shape_value(shape, child)})
+    if child_semantics == "unavailable":
+        with pytest.raises(IrreversibleTransitionError, match="nested family"):
+            parent_family.plan_render("1")
+        with pytest.raises(IrreversibleTransitionError, match="nested family"):
+            parent_family.dump(version="1", data=data)
+        assert parent_downgrade.calls == 0
+    else:
+        assert parent_family.plan_render("1") is render_candidate
+        rendered = parent_family.dump(version="1", data=data, include_version=False)
+        assert "child" in rendered
+        assert parent_downgrade.calls == 1
+
+
+@pytest.mark.parametrize("grandchild_semantics", ["lossy", "unavailable"])
+def test_nested_plan_semantics_propagate_through_child_families(
+    grandchild_semantics: str,
+) -> None:
+    grandchild_model = create_model(
+        f"NestedPlanGrandchild_{grandchild_semantics}",
+        __module__=__name__,
+        value=(int, 1),
+        internal=(str, "current"),
+    )
+    grandchild = SchemaFamily(
+        model=grandchild_model,
+        name=f"nested_plan_grandchild_{grandchild_semantics}",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=((field_removed("internal"),) if grandchild_semantics == "lossy" else ()),
+            ),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            (VersionTransition("1", "2", upgrade=_identity),)
+            if grandchild_semantics == "unavailable"
+            else ()
+        ),
+    )
+    child_model = create_model(
+        f"NestedPlanChild_{grandchild_semantics}",
+        __module__=__name__,
+        grandchild=(grandchild_model, ...),
+    )
+    child = SchemaFamily(
+        model=child_model,
+        name=f"nested_plan_child_recursive_{grandchild_semantics}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("grandchild", grandchild, matching_labels()),),
+    )
+    parent_model = create_model(
+        f"NestedPlanRoot_{grandchild_semantics}",
+        __module__=__name__,
+        child=(child_model, ...),
+    )
+    parent = SchemaFamily(
+        model=parent_model,
+        name=f"nested_plan_root_{grandchild_semantics}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child, matching_labels()),),
+    )
+
+    compiled = parent._compiled_family()
+    candidate = compiled.catalog.render_plans[compiled.index("1")]
+    parent_nested = next(step for step in candidate.steps if step.kind == "nested")
+    assert parent_nested.semantics == grandchild_semantics
+    assert candidate.semantics == grandchild_semantics
+    if grandchild_semantics == "unavailable":
+        with pytest.raises(IrreversibleTransitionError, match="nested family"):
+            parent.plan_render("1")
+    else:
+        assert parent.plan_render("1") is candidate
+
+
+def test_three_level_nested_runtime_executes_each_owned_transition_in_order() -> None:
+    events: list[str] = []
+
+    def grandchild_upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("grandchild 1->2")
+        return {**data, "value": data["value"] + 1}
+
+    def grandchild_downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("grandchild 2->1")
+        return {**data, "value": data["value"] - 1}
+
+    class GrandchildPayload(BaseModel):
+        value: int
+
+    grandchild = SchemaFamily(
+        model=GrandchildPayload,
+        name="three_level_runtime_grandchild",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=grandchild_upgrade,
+                downgrade=grandchild_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    def child_upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child 1->2")
+        return {**data, "value": data["value"] + 10}
+
+    def child_downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child 2->1")
+        return {**data, "value": data["value"] - 10}
+
+    class ChildPayload(BaseModel):
+        value: int
+        grandchild: GrandchildPayload
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="three_level_runtime_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=child_upgrade,
+                downgrade=child_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("grandchild", grandchild, matching_labels()),),
+        version_metadata=None,
+    )
+
+    def parent_upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent 1->2")
+        return {**data, "value": data["value"] + 100}
+
+    def parent_downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent 2->1")
+        return {**data, "value": data["value"] - 100}
+
+    class ParentPayload(BaseModel):
+        value: int
+        child: ChildPayload
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="three_level_runtime_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=parent_upgrade,
+                downgrade=parent_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+
+    validated = parent.validate(
+        {
+            "value": 1,
+            "child": {"value": 10, "grandchild": {"value": 100}},
+        },
+        version="1",
+    )
+
+    assert validated.current_model == ParentPayload(
+        value=101,
+        child=ChildPayload(
+            value=20,
+            grandchild=GrandchildPayload(value=101),
+        ),
+    )
+    assert events == ["grandchild 1->2", "child 1->2", "parent 1->2"]
+
+    events.clear()
+    rendered = parent.dump(
+        version="1",
+        data=validated.current_model,
+        include_version=False,
+    )
+
+    assert rendered == {
+        "value": 1,
+        "child": {"value": 10, "grandchild": {"value": 100}},
+    }
+    assert events == ["grandchild 2->1", "child 2->1", "parent 2->1"]
+
+
+def test_nested_render_projects_renamed_child_fields_to_the_target_wire() -> None:
+    class ChildPayload(BaseModel):
+        max_attempts: int = 3
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="renamed_nested_render_child",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_renamed("max_attempts", "attempts"),),
+            ),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="renamed_nested_render_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+
+    rendered = parent.dump(
+        version="1",
+        data=ParentPayload(child=ChildPayload(max_attempts=5)),
+        include_version=False,
+    )
+
+    assert rendered == {"child": {"attempts": 5}}
+    assert parent.validate(rendered, version="1").current_model.child.max_attempts == 5
+
+
+def test_parent_downgrade_receives_canonical_renamed_child_fields() -> None:
+    seen_children: list[dict[str, Any]] = []
+
+    class ChildPayload(BaseModel):
+        max_attempts: int = 3
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="canonical_parent_downgrade_child",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_renamed("max_attempts", "attempts"),),
+            ),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    def parent_downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_children.append(dict(data["child"]))
+        child_payload = dict(data["child"])
+        child_payload["max_attempts"] += 2
+        return {**data, "child": child_payload}
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="canonical_parent_downgrade",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=parent_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+
+    rendered = parent.dump(
+        version="1",
+        data=ParentPayload(child=ChildPayload(max_attempts=5)),
+        include_version=False,
+    )
+
+    assert seen_children == [{"max_attempts": 5}]
+    assert rendered == {"child": {"attempts": 7}}
+
+
+def test_non_monotonic_parent_upgrades_receive_canonical_child_fields() -> None:
+    seen_children: list[tuple[str, dict[str, Any]]] = []
+
+    class ChildPayload(BaseModel):
+        max_attempts: int = 3
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="canonical_non_monotonic_child",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_renamed("max_attempts", "attempts"),),
+            ),
+            SchemaVersion(
+                "2",
+                patches=(field_renamed("max_attempts", "retry_limit"),),
+            ),
+            SchemaVersion("3"),
+        ),
+        version_metadata=None,
+    )
+
+    def first_parent_upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_children.append(("a->b", dict(data["child"])))
+        child_payload = dict(data["child"])
+        child_payload["max_attempts"] += 1
+        return {**data, "child": child_payload}
+
+    def second_parent_upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        seen_children.append(("b->c", dict(data["child"])))
+        child_payload = dict(data["child"])
+        child_payload["max_attempts"] += 1
+        return {**data, "child": child_payload}
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="canonical_non_monotonic_parent",
+        versions=(SchemaVersion("a"), SchemaVersion("b"), SchemaVersion("c")),
+        transitions=(
+            VersionTransition("a", "b", upgrade=first_parent_upgrade),
+            VersionTransition("b", "c", upgrade=second_parent_upgrade),
+        ),
+        nested=(
+            NestedFamily(
+                "child",
+                child,
+                {"a": "2", "b": "1", "c": "3"},
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    validated = parent.validate({"child": {"retry_limit": 5}}, version="a")
+
+    assert seen_children == [
+        ("a->b", {"max_attempts": 5}),
+        ("b->c", {"max_attempts": 6}),
+    ]
+    assert validated.current_model.child.max_attempts == 7
+
+
+def test_nested_model_owned_metadata_rebases_direct_and_collection_values() -> None:
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        schema_version: str = "2"
+        value: int
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="runtime_model_metadata_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    class ParentPayload(BaseModel):
+        direct: ChildPayload
+        listed: list[ChildPayload]
+        tupled: tuple[ChildPayload, ...]
+        set_values: set[ChildPayload]
+        frozen_values: frozenset[ChildPayload]
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="runtime_model_metadata_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(
+            NestedFamily("direct", child, matching_labels()),
+            NestedFamily("listed", child, matching_labels()),
+            NestedFamily("tupled", child, matching_labels()),
+            NestedFamily("set_values", child, matching_labels()),
+            NestedFamily("frozen_values", child, matching_labels()),
+        ),
+        version_metadata=None,
+    )
+    current = ParentPayload(
+        direct=ChildPayload(value=1),
+        listed=[ChildPayload(value=2)],
+        tupled=(ChildPayload(value=3),),
+        set_values={ChildPayload(value=4)},
+        frozen_values=frozenset((ChildPayload(value=5),)),
+    )
+
+    rendered = parent.dump(version="1", data=current, include_version=False)
+
+    assert rendered["direct"]["schema_version"] == "1"
+    for field_name in ("listed", "tupled", "set_values", "frozen_values"):
+        assert rendered[field_name][0]["schema_version"] == "1"
+
+    round_tripped = parent.validate(rendered, version="1").current_model
+    assert round_tripped.direct.schema_version == "2"
+    assert round_tripped.listed[0].schema_version == "2"
+    assert round_tripped.tupled[0].schema_version == "2"
+    assert next(iter(round_tripped.set_values)).schema_version == "2"
+    assert next(iter(round_tripped.frozen_values)).schema_version == "2"
+
+
+def test_optional_annotated_nested_collections_keep_container_metadata_rules() -> None:
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="optional_collection_metadata_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class ParentPayload(BaseModel):
+        listed: Annotated[list[ChildPayload] | None, Field(description="listed")]
+        tupled: Annotated[tuple[ChildPayload, ...] | None, Field(description="tupled")]
+        set_values: Annotated[set[ChildPayload] | None, Field(description="set")]
+        frozen_values: Annotated[
+            frozenset[ChildPayload] | None,
+            Field(description="frozen"),
+        ]
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="optional_collection_metadata_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(
+            NestedFamily("listed", child, matching_labels()),
+            NestedFamily("tupled", child, matching_labels()),
+            NestedFamily("set_values", child, matching_labels()),
+            NestedFamily("frozen_values", child, matching_labels()),
+        ),
+        version_metadata=None,
+    )
+
+    assert [
+        _nested_family_collection_kind(model=ParentPayload, path=(field_name,))
+        for field_name in ("listed", "tupled", "set_values", "frozen_values")
+    ] == ["list", "tuple", "set", "frozenset"]
+
+    rendered = parent.dump(
+        version="1",
+        data=ParentPayload(
+            listed=[ChildPayload(value=1)],
+            tupled=(ChildPayload(value=2),),
+            set_values={ChildPayload(value=3)},
+            frozen_values=frozenset((ChildPayload(value=4),)),
+        ),
+        include_version=False,
+    )
+
+    assert rendered["listed"] == [{"value": 1}]
+    for field_name in ("tupled", "set_values", "frozen_values"):
+        assert rendered[field_name][0]["schema_version"] == "1"
+
+
+def test_optional_annotated_set_detects_nested_migration_collapse() -> None:
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="optional_set_collision_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=lambda data: {**data, "value": 0},
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    class ParentPayload(BaseModel):
+        children: Annotated[
+            set[ChildPayload] | None,
+            Field(description="optional set"),
+        ]
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="optional_set_collision_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("children", child, matching_labels()),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        parent.dump(
+            version="1",
+            data=ParentPayload(
+                children={ChildPayload(value=1), ChildPayload(value=2)},
+            ),
+            include_version=False,
+        )
+
+
+@pytest.mark.parametrize("shape", ["direct", "list", "tuple", "set", "frozenset"])
+def test_nested_metadata_conflicts_preflight_before_source_validation_and_callables(
+    shape: str,
+) -> None:
+    class HashablePayload(dict[str, Any]):
+        __hash__ = object.__hash__
+
+    def nested_value(item: dict[str, Any]) -> Any:
+        if shape == "direct":
+            return item
+        if shape == "list":
+            return [item]
+        if shape == "tuple":
+            return (item,)
+        hashable = HashablePayload(item)
+        if shape == "set":
+            return {hashable}
+        return frozenset((hashable,))
+
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int = 1
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name=f"metadata_preflight_{shape}_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    annotations: dict[str, Any] = {
+        "direct": ChildPayload,
+        "list": list[ChildPayload],
+        "tuple": tuple[ChildPayload, ...],
+        "set": set[ChildPayload],
+        "frozenset": frozenset[ChildPayload],
+    }
+    parent_model = create_model(
+        f"MetadataPreflight{shape.title()}Parent",
+        child=(annotations[shape], ...),
+        required=(int, ...),
+    )
+    parent_upgrade = _CallableProbe(f"metadata-preflight-upgrade-{shape}")
+    parent_downgrade = _CallableProbe(f"metadata-preflight-downgrade-{shape}")
+    parent = SchemaFamily(
+        model=parent_model,
+        name=f"metadata_preflight_{shape}_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=parent_upgrade,
+                downgrade=parent_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+    stale_child = {"schema_version": "2", "value": 1}
+
+    with pytest.raises(SchemaVersionError, match="payload declares '2'"):
+        parent.validate({"child": nested_value(stale_child)}, version="1")
+
+    assert parent_upgrade.calls == 0
+
+    stale_current_child = {"schema_version": "1", "value": 1}
+    with pytest.raises(SchemaVersionError, match="payload declares '1'"):
+        parent.dump(
+            version="1",
+            data={"child": nested_value(stale_current_child)},
+            include_version=False,
+        )
+
+    assert parent_downgrade.calls == 0
+
+
+def test_nested_metadata_preflight_preserves_alias_path_input() -> None:
+    class ChildPayload(BaseModel):
+        value: int
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="metadata_alias_path_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload = Field(validation_alias=AliasPath("payload", "child"))
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="metadata_alias_path_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+    raw = {
+        "payload": {
+            "child": {
+                "schema_version": "1",
+                "value": 7,
+            },
+        },
+    }
+    expected = {
+        "payload": {
+            "child": {
+                "schema_version": "1",
+                "value": 7,
+            },
+        },
+    }
+
+    validated = parent.validate(raw, version="1")
+
+    assert raw == expected
+    assert validated.current_model.child.value == 7
+
+
+def test_nested_metadata_preflight_reads_family_metadata_from_model_extras() -> None:
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="metadata_extra_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload
+
+    parent_upgrade = _CallableProbe("metadata-extra-upgrade")
+    parent_downgrade = _CallableProbe("metadata-extra-downgrade")
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="metadata_extra_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=parent_upgrade,
+                downgrade=parent_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+    stale_source = ChildPayload.model_validate(
+        {"schema_version": "2", "value": 1},
+    )
+    stale_current = ChildPayload.model_validate(
+        {"schema_version": "1", "value": 1},
+    )
+
+    with pytest.raises(SchemaVersionError, match="payload declares '2'"):
+        parent.validate({"child": stale_source}, version="1")
+    with pytest.raises(SchemaVersionError, match="payload declares '1'"):
+        parent.dump(
+            version="1",
+            data={"child": stale_current},
+            include_version=False,
+        )
+
+    assert parent_upgrade.calls == 0
+    assert parent_downgrade.calls == 0
+
+
+@pytest.mark.parametrize("collection_kind", ["set", "frozenset"])
+def test_target_wire_coercion_cannot_collapse_nested_set_cardinality(
+    collection_kind: str,
+) -> None:
+    class ChildPayload(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int | str
+
+    class HistoricalChildWire(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name=f"wire_coercion_{collection_kind}_child",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalChildWire),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+    annotation = set[ChildPayload] if collection_kind == "set" else frozenset[ChildPayload]
+    parent_model = create_model(
+        f"WireCoercion{collection_kind.title()}Parent",
+        children=(annotation, ...),
+    )
+    parent = SchemaFamily(
+        model=parent_model,
+        name=f"wire_coercion_{collection_kind}_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("children", child, matching_labels()),),
+        version_metadata=None,
+    )
+    values = (ChildPayload(value=1), ChildPayload(value="1"))
+    current_collection = set(values) if collection_kind == "set" else frozenset(values)
+
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        parent.dump(
+            version="1",
+            data=parent_model.model_validate({"children": current_collection}),
+            include_version=False,
+        )
+
+
+def test_target_wire_cardinality_check_recurses_through_nested_families() -> None:
+    class GrandchildPayload(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int | str
+
+    class HistoricalGrandchildWire(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    grandchild = SchemaFamily(
+        model=GrandchildPayload,
+        name="recursive_wire_cardinality_grandchild",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalGrandchildWire),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    class ChildPayload(BaseModel):
+        grandchildren: set[GrandchildPayload]
+
+    child = SchemaFamily(
+        model=ChildPayload,
+        name="recursive_wire_cardinality_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("grandchildren", grandchild, matching_labels()),),
+        version_metadata=None,
+    )
+
+    class ParentPayload(BaseModel):
+        child: ChildPayload
+
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="recursive_wire_cardinality_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child, matching_labels()),),
+        version_metadata=None,
+    )
+    current = ParentPayload(
+        child=ChildPayload(
+            grandchildren={
+                GrandchildPayload(value=1),
+                GrandchildPayload(value="1"),
+            },
+        ),
+    )
+
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        parent.dump(version="1", data=current, include_version=False)
+
+
+def test_nested_step_direction_follows_non_monotonic_child_mappings() -> None:
+    child = SchemaFamily(
+        model=NestedPlanChild,
+        name="non_monotonic_direction_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        version_metadata=None,
+    )
+    parent = SchemaFamily(
+        model=NestedPlanParent,
+        name="non_monotonic_direction_parent",
+        versions=(SchemaVersion("a"), SchemaVersion("b"), SchemaVersion("c")),
+        nested=(
+            NestedFamily(
+                "child",
+                child,
+                {"a": "2", "b": "1", "c": "3"},
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    validation_steps = tuple(
+        step for step in parent.plan_validation("a").steps if step.kind == "nested"
+    )
+    assert [
+        (step.source_version, step.target_version, step.direction, step.semantics)
+        for step in validation_steps
+    ] == [
+        ("2", "1", "downgrade", "exact"),
+        ("1", "3", "upgrade", "not_applicable"),
+    ]
+
+    render = parent.plan_render("a")
+    render_steps = tuple(step for step in render.steps if step.kind == "nested")
+    assert [
+        (step.source_version, step.target_version, step.direction, step.semantics)
+        for step in render_steps
+    ] == [
+        ("3", "1", "downgrade", "exact"),
+        ("1", "2", "upgrade", "not_applicable"),
+    ]
+    assert render.semantics == "exact"
+
+
+def test_validation_preflights_every_non_monotonic_child_route() -> None:
+    available_upgrade = _CallableProbe("available-upgrade")
+    available_downgrade = _CallableProbe("available-downgrade")
+    unavailable_upgrade = _CallableProbe("unavailable-upgrade")
+
+    class AvailableChild(BaseModel):
+        value: int
+
+    available = SchemaFamily(
+        model=AvailableChild,
+        name="validation_preflight_available_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=available_upgrade,
+                downgrade=available_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    class UnavailableChild(BaseModel):
+        value: int
+
+    unavailable = SchemaFamily(
+        model=UnavailableChild,
+        name="validation_preflight_unavailable_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(VersionTransition("1", "2", upgrade=unavailable_upgrade),),
+        version_metadata=None,
+    )
+
+    class ParentPayload(BaseModel):
+        available: AvailableChild
+        unavailable: UnavailableChild
+
+    first_parent_upgrade = _CallableProbe("first-parent-upgrade")
+    second_parent_upgrade = _CallableProbe("second-parent-upgrade")
+    parent = SchemaFamily(
+        model=ParentPayload,
+        name="validation_preflight_non_monotonic_parent",
+        versions=(SchemaVersion("a"), SchemaVersion("b"), SchemaVersion("c")),
+        transitions=(
+            VersionTransition("a", "b", upgrade=first_parent_upgrade),
+            VersionTransition("b", "c", upgrade=second_parent_upgrade),
+        ),
+        nested=(
+            NestedFamily(
+                "available",
+                available,
+                {"a": "2", "b": "1", "c": "3"},
+            ),
+            NestedFamily(
+                "unavailable",
+                unavailable,
+                {"a": "2", "b": "1", "c": "3"},
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    plan = parent.plan_validation("a")
+    nested_steps = tuple(step for step in plan.steps if step.kind == "nested")
+    assert [
+        (step.schema_path, step.source_version, step.target_version, step.direction, step.semantics)
+        for step in nested_steps[:2]
+    ] == [
+        ("$.available", "2", "1", "downgrade", "exact"),
+        ("$.unavailable", "2", "1", "downgrade", "unavailable"),
+    ]
+
+    with pytest.raises(IrreversibleTransitionError, match="has no complete route"):
+        parent.validate(
+            {
+                "available": {"value": 1},
+                "unavailable": {"value": 2},
+            },
+            version="a",
+        )
+
+    assert available_upgrade.calls == 0
+    assert available_downgrade.calls == 0
+    assert unavailable_upgrade.calls == 0
+    assert first_parent_upgrade.calls == 0
+    assert second_parent_upgrade.calls == 0
+
+
 def test_impossible_render_route_fails_only_when_it_crosses_the_one_way_edge() -> None:
     upgrade = _CallableProbe("private-upgrade")
     family = _inventory_family(upgrade=upgrade, name="one_way")
@@ -590,6 +1639,40 @@ def test_plan_json_is_deterministic_across_processes() -> None:
 
     assert completed.returncode == 0, completed.stderr
     assert completed.stdout.strip() == local
+
+
+def test_nested_plan_json_is_deterministic_across_processes() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    family = _deterministic_nested_family()
+    local = json.dumps(
+        {
+            "validation": family.plan_validation("1").to_dict(),
+            "render": family.plan_render("1").to_dict(),
+        },
+        separators=(",", ":"),
+    )
+    script = (
+        "import json\n"
+        "from tests.unit.test_inventory_and_plans import _deterministic_nested_family\n"
+        "family = _deterministic_nested_family()\n"
+        "print(json.dumps({"
+        "'validation': family.plan_validation('1').to_dict(),"
+        "'render': family.plan_render('1').to_dict(),"
+        "}, separators=(',', ':')))\n"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == local
+    assert any(step.kind == "nested" for step in family.plan_validation("1").steps)
+    assert any(step.kind == "nested" for step in family.plan_render("1").steps)
 
 
 def test_step_ids_resist_sanitized_family_and_label_collisions() -> None:

--- a/tests/unit/test_nested_runtime_paths.py
+++ b/tests/unit/test_nested_runtime_paths.py
@@ -1,0 +1,459 @@
+from typing import Any, Self, cast
+
+import pytest
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, model_validator
+
+from pydantic_versions import (
+    InvalidMigrationError,
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    SchemaVersionError,
+    VersionTransition,
+    field_renamed,
+    matching_labels,
+)
+
+
+@pytest.mark.parametrize("opaque_version", ["1", "2"])
+def test_nested_runtime_does_not_search_unrelated_mapping_values(
+    opaque_version: str,
+) -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="exact_path_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=lambda data: {**data, "value": data["value"] + 10},
+            ),
+        ),
+    )
+
+    class Parent(BaseModel):
+        child: Child | None = None
+        opaque: dict[str, Any]
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="exact_path_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+    opaque = {"child": {"schema_version": opaque_version, "value": 1}}
+
+    result = parent_family.validate(
+        {"schema_version": "1", "opaque": opaque},
+    )
+
+    assert result.current_model.child is None
+    assert result.current_model.opaque == opaque
+
+
+def test_nested_projection_and_pruning_ignore_an_opaque_sibling() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="exact_projection_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        children: list[Child] | None = None
+        opaque: dict[str, Any]
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="exact_projection_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+    )
+    opaque = {"children": [{"schema_version": "2", "value": 1}]}
+
+    rendered = parent_family.dump(
+        version="2",
+        data={"opaque": opaque},
+        exclude_none=True,
+    )
+
+    assert rendered["opaque"] == opaque
+
+
+def test_nested_metadata_preflight_uses_second_alias_choice() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="alias_choice_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(validation_alias=AliasChoices("preferred", "fallback"))
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="alias_choice_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(SchemaVersionError, match="expects version '1'"):
+        parent_family.validate(
+            {
+                "schema_version": "1",
+                "fallback": {"schema_version": "2", "value": 1},
+            },
+        )
+
+
+def test_nested_metadata_preflight_follows_alias_path_list_index() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="alias_path_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(validation_alias=AliasPath("envelope", 1))
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="alias_path_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(SchemaVersionError, match="expects version '1'"):
+        parent_family.validate(
+            {
+                "schema_version": "1",
+                "envelope": [None, {"schema_version": "2", "value": 1}],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_config", "child_payloads", "expected_value"),
+    [
+        (
+            ConfigDict(validate_by_name=True, extra="ignore"),
+            {
+                "child": {"schema_version": "1", "value": 7},
+                "serialized": {"schema_version": "2", "value": 99},
+            },
+            7,
+        ),
+        (
+            ConfigDict(
+                validate_by_alias=False,
+                validate_by_name=True,
+                extra="ignore",
+            ),
+            {
+                "child": {"schema_version": "1", "value": 7},
+                "accepted": {"schema_version": "2", "value": 98},
+                "serialized": {"schema_version": "2", "value": 99},
+            },
+            7,
+        ),
+        (
+            ConfigDict(
+                validate_by_alias=True,
+                validate_by_name=False,
+                extra="ignore",
+            ),
+            {
+                "accepted": {"schema_version": "1", "value": 7},
+                "child": {"schema_version": "2", "value": 98},
+                "serialized": {"schema_version": "2", "value": 99},
+            },
+            7,
+        ),
+        (
+            ConfigDict(
+                validate_by_alias=True,
+                validate_by_name=True,
+                extra="ignore",
+            ),
+            {
+                "child": {"schema_version": "1", "value": 7},
+                "accepted": {"schema_version": "2", "value": 99},
+            },
+            None,
+        ),
+    ],
+    ids=["serialization-ignored", "name-only", "alias-only", "alias-precedence"],
+)
+def test_nested_metadata_preflight_honors_validation_alias_policy(
+    model_config: ConfigDict,
+    child_payloads: dict[str, dict[str, int | str]],
+    expected_value: int | None,
+) -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="validation_alias_policy_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    parent_config = model_config
+
+    class Parent(BaseModel):
+        model_config = parent_config
+
+        child: Child = Field(alias="serialized", validation_alias="accepted")
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="validation_alias_policy_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+    payload: dict[str, Any] = {"schema_version": "1", **child_payloads}
+    if expected_value is None:
+        with pytest.raises(SchemaVersionError, match="expects version '1'"):
+            parent_family.validate(payload)
+        return
+
+    result = parent_family.validate(payload)
+    assert result.current_model.child.value == expected_value
+
+
+@pytest.mark.parametrize("model_input", [False, True], ids=["mapping", "unrelated-model"])
+def test_nested_render_metadata_preflight_preserves_structural_alias_input(
+    model_input: bool,
+) -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="structural_preflight_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(validation_alias="accepted")
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="structural_preflight_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    class Envelope(BaseModel):
+        accepted: dict[str, Any]
+
+    payload = {"accepted": {"schema_version": "1", "value": 7}}
+    data: dict[str, Any] | Envelope = Envelope.model_validate(payload) if model_input else payload
+
+    with pytest.raises(SchemaVersionError, match="expects version '2'"):
+        parent_family.dump(version="1", data=cast(Any, data))
+
+
+@pytest.mark.parametrize("direction", ["render", "validate"])
+@pytest.mark.parametrize("injected_kind", ["declared-subclass", "unrelated"])
+def test_nested_route_handles_parent_injected_child_model(
+    direction: str,
+    injected_kind: str,
+) -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    class InjectedChild(Child):
+        callback_only: bool = True
+
+    class UnrelatedChild(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name=f"injected_{direction}_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=lambda data: {**data, "value": data["value"] + 1},
+                downgrade=lambda data: {**data, "value": data["value"] - 1},
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                upgrade=lambda data: {**data, "value": data["value"] + 10},
+                downgrade=lambda data: {**data, "value": data["value"] - 10},
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    def inject_child(data: dict[str, Any]) -> dict[str, Any]:
+        injected = (
+            InjectedChild(value=100)
+            if injected_kind == "declared-subclass"
+            else UnrelatedChild(value=100)
+        )
+        return {**data, "child": injected}
+
+    def identity(data: dict[str, Any]) -> dict[str, Any]:
+        return data
+
+    first_upgrade = inject_child if direction == "validate" else identity
+    second_downgrade = inject_child if direction == "render" else identity
+    parent_family = SchemaFamily(
+        model=Parent,
+        name=f"injected_{direction}_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2"), SchemaVersion("3")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=first_upgrade,
+                downgrade=identity,
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                upgrade=identity,
+                downgrade=second_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+        version_metadata=None,
+    )
+
+    if injected_kind == "unrelated":
+        with pytest.raises(InvalidMigrationError, match="expected current model 'Child'"):
+            if direction == "render":
+                parent_family.dump(
+                    version="1",
+                    data=Parent(child=Child(value=50)),
+                )
+            else:
+                parent_family.validate(
+                    {"child": {"value": 50}},
+                    version="1",
+                )
+        return
+
+    if direction == "render":
+        rendered = parent_family.dump(
+            version="1",
+            data=Parent(child=Child(value=50)),
+        )
+        assert rendered == {"child": {"value": 99}}
+        return
+
+    result = parent_family.validate(
+        {"child": {"value": 50}},
+        version="1",
+    )
+
+    assert result.current_model.child.value == 110
+    assert result.current_model.child.__pydantic_extra__ == {}
+
+
+@pytest.mark.parametrize("model_input", [False, True], ids=["mapping", "model"])
+def test_nested_render_validates_parent_and_child_only_once(model_input: bool) -> None:
+    validation_counts = {"parent": 0, "child": 0}
+    transition_events: list[str] = []
+
+    class Child(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        current_value: int
+
+        @model_validator(mode="after")
+        def count_validation(self) -> Self:
+            validation_counts["child"] += 1
+            return self
+
+    def downgrade_child(data: dict[str, Any]) -> dict[str, Any]:
+        assert data == {"current_value": 5}
+        transition_events.append("child")
+        return data
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="once_only_child",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("current_value", "legacy_value"),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade_child,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    class Parent(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        child: Child
+
+        @model_validator(mode="after")
+        def count_validation(self) -> Self:
+            validation_counts["parent"] += 1
+            return self
+
+    def downgrade_parent(data: dict[str, Any]) -> dict[str, Any]:
+        assert data == {"child": {"current_value": 5}}
+        transition_events.append("parent")
+        return data
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="once_only_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade_parent,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+    mapping = {"child": {"current_value": 5}}
+    if model_input:
+        data: Parent | dict[str, Any] = Parent.model_validate(mapping)
+        validation_counts.update(parent=0, child=0)
+    else:
+        data = mapping
+
+    rendered = parent_family.dump(version="1", data=data)
+
+    assert rendered == {
+        "child": {"legacy_value": 5, "schema_version": "1"},
+        "schema_version": "1",
+    }
+    assert validation_counts == {"parent": 1, "child": 1}
+    assert transition_events == ["child", "parent"]

--- a/tests/unit/test_schema_family.py
+++ b/tests/unit/test_schema_family.py
@@ -292,6 +292,39 @@ def test_nested_mapping_declaration_copies_the_caller_mapping() -> None:
     }
 
 
+def test_nested_mapping_must_anchor_the_current_child_version() -> None:
+    class ChildConfig(BaseModel):
+        value: int = 1
+
+    child = SchemaFamily(
+        model=ChildConfig,
+        name="current_anchor_child",
+        versions=(SchemaVersion("legacy"), SchemaVersion("current")),
+    )
+
+    class ParentConfig(BaseModel):
+        child: ChildConfig
+
+    parent = SchemaFamily(
+        model=ParentConfig,
+        name="current_anchor_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(
+            NestedFamily(
+                "child",
+                child,
+                {"1": "current", "2": "legacy"},
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        SchemaCompilationError,
+        match="current parent label '2' to current child label 'current'",
+    ):
+        parent.compile()
+
+
 def test_compile_is_lazy_idempotent_and_cache_stable() -> None:
     class LazyConfig(BaseModel):
         value: int = 1


### PR DESCRIPTION
## Summary

- add deterministic nested-family steps to validation and render plans and propagate child loss/unavailability to the owning parent route
- execute explicit child migrations before each parent edge while keeping callback payloads in canonical current names, then project the complete nested subtree once at the target boundary
- preflight unavailable routes and conflicting nested metadata before validation or user callbacks
- traverse only compiled field/alias paths, preserve set cardinality, and keep authoritative parent/child validation exactly once

## Safety and compatibility

- preserves the immutable 0.3.0 fixture and applies only the reviewed additive nested-step overlay
- honors Pydantic validation alias/name policy for raw mappings and structurally accepted models
- prevents opaque sibling mappings and serialization-only aliases from impersonating declared nested fields
- continues multi-edge routes across callback-injected current child models while excluding subclass-only fields and rejecting unrelated models
- leaves decorator-discovered nested boundaries explicitly tracked by #77

## Validation

- `uv run make ci` — 369 passed, 93.04% coverage
- `uv run python tests/compatibility/v0_3_0_contract.py --check`
- `uv run make docs-build-strict`
- `uv run python scripts/check_conventional_commits.py --range origin/main..HEAD`
- `git diff --check origin/main...HEAD`
- independent focused review of the three discovered alias/model/multi-edge regressions — 10 passed, no findings

Closes #63