### PR TITLE
fix(compatibility): complete decorator nested boundaries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transitions, then projected the complete subtree at the final wire boundary.
   Child metadata is rebased to its mapped label, conflicting raw labels fail
   preflight, and set cardinality is checked again after target wire coercion.
+- Completed decorator-discovered child conversion across built-in containers,
+  string-key mappings, ordinary wrappers, nested decorator families, and
+  authoritative union branches. Child routes now migrate and project before
+  parent transitions, reject stale metadata and ambiguous callback mutations,
+  participate in deterministic plans, and fail closed for unsupported shapes.
 
 ### Removed
 - Removed the unused `VersionedValidationError` placeholder from the public

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -40,6 +40,61 @@ boundaries can appear while traversing a multi-segment path. Mapping values and
 heterogeneous branches are intentionally rejected during compilation rather
 than accepted with payload-dependent behavior.
 
+The `@versioned_schema` compatibility decorator also discovers child models
+that have their own decorator-created family with the exact same labels. These
+implicit boundaries are separate from explicit `NestedFamily` declarations:
+they do not appear in `SchemaInventory.nested`, but conversion plans include
+conditional child-before-parent steps for them. Discovery traverses ordinary
+Pydantic model wrappers, `Annotated` and optional annotations, general or
+discriminated unions whose selected arm remains recoverable, built-in `list`,
+`tuple`, `set`, and `frozenset` containers, fixed tuple positions, and
+`dict[str, value]`, including nested combinations of those shapes. An explicit
+declaration suppresses discovery at
+that exact leaf only, so an ordinary wrapper can contain an explicitly mapped
+child and a decorator-discovered sibling.
+
+A decorator-discovered child may itself use explicit `NestedFamily`
+declarations. The inverse composition fails closed: an explicit
+`NestedFamily` child may not retain implicit decorator-discovered descendants.
+Declare those descendant routes explicitly on the child with
+`versioned_schema(..., nested=...)` so the complete conversion boundary is
+visible to the compiler.
+
+Union selection comes from the already validated parent model and is carried
+through conversion without validating the child a second time. A parent
+transition may reorder surviving child mappings within one dispatch site
+because their identities move with them. Moving or swapping an existing child
+identity across fields or dispatch sites is rejected. Dictionary keys are
+stable occurrence anchors when no dynamic collection occurs above or below
+that mapping boundary. An exact current
+child-model instance may deliberately replace an occurrence and establish a
+new branch. If a transition loses, duplicates, reuses, or replaces overlapping
+union occurrences with untyped copied mappings, conversion raises
+`InvalidMigrationError` before the next transition runs. Set and frozenset
+cardinality is checked again after target-wire validation.
+
+Decorator discovery fails closed when it encounters an abstract or custom
+container, a mapping whose declared or runtime key is not exactly `str`, a
+child hidden in a type alias or unresolved generic, an unsafe recursive
+wrapper, non-isomorphic union traversal shapes, or runtime-unrecoverable union
+arms.
+Examples of unrecoverable arms include `list[A] | list[B]`, an abstract
+`Mapping` competing with `dict[str, Child]`, and a `TypedDict` competing with a
+decorator child. Incompatible union metadata contracts and an explicit path
+below a decorator-owned child boundary are also rejected.
+Different parent and child labels still require an explicit
+`NestedFamily` mapping. An explicit historical parent wire model must likewise
+declare these child boundaries explicitly; the compiler does not partially
+rewrite a user-supplied wire class.
+
+An ordinary wrapper that must be projected for a decorator child must be a
+complete, resolved, object-shaped Pydantic model. Rebuild forward references
+with `model_rebuild()` before compilation. Projected wrappers may not be a
+`RootModel` or carry typed extras, model-level serializers, unsafe
+configuration, or custom schema hooks that automatic generation would
+otherwise weaken or discard. Those models remain supported as unchanged field
+annotations when no decorator route requires their projection.
+
 An excluded field is also absent from the generated wire model. This is the
 supported way to keep server-internal state on the authoritative model while
 using that model as the source for a document contract. The exclusion is not
@@ -61,9 +116,12 @@ declared mapping or envelope when they must cross the conversion boundary.
 Zero-argument factories remain safe when the field annotation is unchanged. A
 decorator-owned child annotation can replace the child class itself as a
 factory, and a direct child instance is projected without running its
-serializers. Opaque factories for a projected child are rejected because they
-could construct the authoritative child and run its behavior on historical
-input. Any factory that consumes already validated field data is also rejected:
+serializers. Projected direct-child, container, and ordinary-wrapper defaults
+are rebuilt from declared fields only; extras and subclass-only state never
+cross the wire through a default. Opaque factories for a projected route are
+rejected because they could construct authoritative models and run their
+behavior on historical input. Any factory that consumes already validated
+field data is also rejected:
 automatic wire models intentionally omit current-model validators, so copying
 its materialized result could prevent the authoritative current factory from
 seeing the final values. Typed `__pydantic_extra__` values and schema or runtime

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -35,6 +35,20 @@ type UpgradeKind = Literal["implicit_identity", "custom_transition"]
 type DowngradeKind = Literal["implicit_identity", "custom_transition", "unavailable"]
 type WireModelKind = Literal["current", "generated", "explicit"]
 type _NestedLabelPairs = tuple[tuple[str, str], ...]
+type _NestedCollectionKind = Literal["list", "tuple", "set", "frozenset", "mapping"]
+type _DecoratorTraversalKind = Literal[
+    "field",
+    "union_arm",
+    "each",
+    "mapping_values",
+    "tuple_index",
+]
+
+
+@dataclass(frozen=True)
+class _DecoratorTraversalStep:
+    kind: _DecoratorTraversalKind
+    value: str
 
 
 @dataclass(frozen=True)
@@ -91,6 +105,35 @@ class _CompiledNestedFamily:
 
 
 @dataclass(frozen=True)
+class _CompiledDecoratorNestedFamily:
+    """A decorator-owned child route discovered from the authoritative annotation tree."""
+
+    path: tuple[str, ...]
+    family: SchemaFamily[Any]
+    traversal: tuple[_DecoratorTraversalStep, ...]
+    collection_kind: _NestedCollectionKind | None
+
+    @property
+    def identity(self) -> tuple[str, ...]:
+        return (
+            *(f"{step.kind}:{step.value}" for step in self.traversal),
+            "child",
+            self.family.model.__module__,
+            self.family.model.__qualname__,
+            self.family.name,
+        )
+
+    def child_label(self, parent_label: str) -> str:
+        if parent_label in tuple(version.label for version in self.family.versions):
+            return parent_label
+        msg = (
+            f"Decorator nested route for path {self.path!r} has no matching child label "
+            f"for {parent_label!r}"
+        )
+        raise SchemaCompilationError(msg)
+
+
+@dataclass(frozen=True)
 class _CompiledFamily:
     model: type[BaseModel]
     name: str
@@ -100,6 +143,7 @@ class _CompiledFamily:
     missing_version: str | None
     catalog: _PlanningCatalog
     nested: tuple[_CompiledNestedFamily, ...]
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...]
 
     @property
     def labels(self) -> tuple[str, ...]:
@@ -243,6 +287,16 @@ def _validate_compilation_boundary(
                 f"Nested family declaration at path {path!r} for {name!r} targets model "
                 f"{expected!r}, but declared child family {child_family.name!r} owns "
                 f"model {declared!r}"
+            )
+            raise UnsupportedWireModelError(msg)
+
+        child_compiled = child_family._compiled_family()
+        if child_compiled.decorator_nested:
+            msg = (
+                f"Nested family declaration at path {path!r} for {name!r} targets child "
+                f"family {child_family.name!r}, which still contains decorator-discovered "
+                "nested routes; declare those child routes explicitly with "
+                "versioned_schema(..., nested=...)"
             )
             raise UnsupportedWireModelError(msg)
 

--- a/src/pydantic_versions/_planning.py
+++ b/src/pydantic_versions/_planning.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_versions._compiler import (
+    _CompiledDecoratorNestedFamily,
     _CompiledFamily,
     _CompiledField,
     _CompiledNestedFamily,
@@ -44,6 +45,7 @@ def _build_planning_catalog(
     versions: tuple[_CompiledVersion, ...],
     transitions: tuple[_CompiledTransition, ...],
     nested: tuple[_CompiledNestedFamily, ...] = (),
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...] = (),
 ) -> _PlanningCatalog:
     version_descriptions = tuple(_describe_version(version) for version in versions)
     transition_descriptions = tuple(_describe_transition(transition) for transition in transitions)
@@ -64,6 +66,7 @@ def _build_planning_catalog(
             versions,
             transitions,
             nested,
+            decorator_nested,
             source_index=source_index,
         )
         for source_index in range(len(versions))
@@ -74,6 +77,7 @@ def _build_planning_catalog(
             versions,
             transitions,
             nested,
+            decorator_nested,
             target_index=target_index,
         )
         for target_index in range(len(versions))
@@ -163,6 +167,7 @@ def _build_validation_plan(
     versions: tuple[_CompiledVersion, ...],
     transitions: tuple[_CompiledTransition, ...],
     nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     *,
     source_index: int,
 ) -> ConversionPlan:
@@ -223,6 +228,16 @@ def _build_validation_plan(
                 edge_ordinal=edge_index,
             )
         )
+        steps.extend(
+            _decorator_nested_steps(
+                family,
+                decorator_nested,
+                operation="validate",
+                parent_source_version=transition.source,
+                parent_target_version=transition.target,
+                edge_ordinal=edge_index,
+            )
+        )
         kind: StepKind = transition.upgrade_kind
         semantics: StepSemantics = "exact" if kind == "implicit_identity" else "not_applicable"
         steps.append(
@@ -267,6 +282,7 @@ def _build_render_plan(
     versions: tuple[_CompiledVersion, ...],
     transitions: tuple[_CompiledTransition, ...],
     nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     *,
     target_index: int,
 ) -> ConversionPlan:
@@ -293,6 +309,16 @@ def _build_render_plan(
             _nested_steps(
                 family,
                 nested,
+                operation="render",
+                parent_source_version=transition.target,
+                parent_target_version=transition.source,
+                edge_ordinal=edge_index,
+            )
+        )
+        steps.extend(
+            _decorator_nested_steps(
+                family,
+                decorator_nested,
                 operation="render",
                 parent_source_version=transition.target,
                 parent_target_version=transition.source,
@@ -442,6 +468,94 @@ def _nested_steps(
     return tuple(steps)
 
 
+def _decorator_nested_steps(
+    family: SchemaFamily[Any],
+    nested: tuple[_CompiledDecoratorNestedFamily, ...],
+    *,
+    operation: Literal["validate", "render"],
+    parent_source_version: str,
+    parent_target_version: str,
+    edge_ordinal: int,
+) -> tuple[PlanStep, ...]:
+    steps: list[PlanStep] = []
+    for site_ordinal, declarations in enumerate(_decorator_nested_sites(nested)):
+        first = declarations[0]
+        source_version = first.child_label(parent_source_version)
+        target_version = first.child_label(parent_target_version)
+        if source_version == target_version:
+            continue
+        semantics = _aggregate_semantics(
+            tuple(
+                _nested_route_semantics(
+                    declaration.family._compiled_family(),
+                    source_version=source_version,
+                    target_version=target_version,
+                )
+                for declaration in declarations
+            )
+        )
+        child_compiled = first.family._compiled_family()
+        direction: Literal["upgrade", "downgrade"] = (
+            "upgrade"
+            if child_compiled.index(source_version) < child_compiled.index(target_version)
+            else "downgrade"
+        )
+        identity = tuple(
+            component
+            for declaration in declarations
+            for component in (
+                "branch",
+                *declaration.identity,
+            )
+        )
+        steps.append(
+            _step(
+                family,
+                operation=operation,
+                direction=direction,
+                kind="nested",
+                source_version=source_version,
+                target_version=target_version,
+                schema_path=_schema_path(first.path),
+                semantics=semantics,
+                ordinal=edge_ordinal,
+                identity_details=(
+                    "decorator",
+                    parent_source_version,
+                    parent_target_version,
+                    str(site_ordinal),
+                    *identity,
+                    "conditional",
+                ),
+                conditional=True,
+            )
+        )
+    return tuple(steps)
+
+
+def _decorator_nested_sites(
+    nested: tuple[_CompiledDecoratorNestedFamily, ...],
+) -> tuple[tuple[_CompiledDecoratorNestedFamily, ...], ...]:
+    paths: list[tuple[str, ...]] = []
+    grouped: list[list[_CompiledDecoratorNestedFamily]] = []
+    for declaration in nested:
+        if declaration.path not in paths:
+            paths.append(declaration.path)
+            grouped.append([])
+        grouped[paths.index(declaration.path)].append(declaration)
+    return tuple(tuple(site) for site in grouped)
+
+
+def _aggregate_semantics(values: tuple[StepSemantics, ...]) -> StepSemantics:
+    if "unavailable" in values:
+        return "unavailable"
+    if "lossy" in values:
+        return "lossy"
+    if "exact" in values:
+        return "exact"
+    return "not_applicable"
+
+
 def _nested_route_semantics(
     compiled: _CompiledFamily,
     *,
@@ -460,6 +574,7 @@ def _nested_route_semantics(
             risks.extend(
                 _nested_route_risks(
                     compiled.nested,
+                    compiled.decorator_nested,
                     parent_source_version=transition.source,
                     parent_target_version=transition.target,
                 )
@@ -474,6 +589,7 @@ def _nested_route_semantics(
             risks.extend(
                 _nested_route_risks(
                     compiled.nested,
+                    compiled.decorator_nested,
                     parent_source_version=transition.target,
                     parent_target_version=transition.source,
                 )
@@ -495,6 +611,7 @@ def _nested_route_semantics(
 
 def _nested_route_risks(
     nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     *,
     parent_source_version: str,
     parent_target_version: str,
@@ -509,6 +626,21 @@ def _nested_route_risks(
             declaration.family._compiled_family(),
             source_version=source_version,
             target_version=target_version,
+        )
+        if semantics in ("lossy", "unavailable"):
+            risks.append(semantics)
+    for declarations in _decorator_nested_sites(decorator_nested):
+        semantics = _aggregate_semantics(
+            tuple(
+                _nested_route_semantics(
+                    declaration.family._compiled_family(),
+                    source_version=declaration.child_label(parent_source_version),
+                    target_version=declaration.child_label(parent_target_version),
+                )
+                for declaration in declarations
+                if declaration.child_label(parent_source_version)
+                != declaration.child_label(parent_target_version)
+            )
         )
         if semantics in ("lossy", "unavailable"):
             risks.append(semantics)

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from functools import partial
 from types import NoneType, UnionType
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, cast, get_args, get_origin
@@ -16,6 +17,7 @@ from pydantic import (
 from pydantic_core import SchemaValidator, core_schema, to_jsonable_python
 
 from pydantic_versions._compiler import (
+    _CompiledDecoratorNestedFamily,
     _CompiledFamily,
     _CompiledVersion,
 )
@@ -33,6 +35,17 @@ from pydantic_versions.exceptions import (
 
 if TYPE_CHECKING:
     from pydantic_versions.family import SchemaFamily
+
+
+@dataclass
+class _DecoratorRouteSelection:
+    route: _CompiledDecoratorNestedFamily
+    location: tuple[str | int, ...]
+    relative_location: tuple[str | int, ...]
+    site_routes: tuple[_CompiledDecoratorNestedFamily, ...]
+    label: str
+    parent: _DecoratorRouteSelection | None = None
+    value_identity: int | None = None
 
 
 def _runtime_label(value: object, *, family_name: str) -> str:
@@ -153,6 +166,234 @@ def _safe_annotation_instance(value: Any, annotation: Any) -> bool:
         return False
 
 
+def _select_decorator_routes(
+    value: BaseModel,
+    *,
+    compiled: _CompiledFamily,
+    parent_label: str,
+    source_version: _CompiledVersion | None,
+    location_prefix: tuple[str | int, ...] = (),
+    parent_selection: _DecoratorRouteSelection | None = None,
+) -> tuple[_DecoratorRouteSelection, ...]:
+    if not compiled.decorator_nested:
+        return ()
+    root_names = {
+        route.path[0]: (
+            route.path[0]
+            if source_version is None
+            else source_version.projection.field(route.path[0]).version_name
+        )
+        for route in compiled.decorator_nested
+    }
+    selected: list[_DecoratorRouteSelection] = []
+    for route in compiled.decorator_nested:
+        if root_names[route.path[0]] is None:
+            continue
+        for nested_value, location in _walk_authoritative_decorator_route(
+            value,
+            annotation=type(value),
+            route=route,
+            root_names=root_names,
+        ):
+            expected = (route.family.model, route.family.model_for(parent_label))
+            if isinstance(nested_value, expected):
+                site = _decorator_dispatch_site(route)
+                selection = _DecoratorRouteSelection(
+                    route=route,
+                    location=(*location_prefix, *location),
+                    relative_location=location,
+                    site_routes=tuple(
+                        candidate
+                        for candidate in compiled.decorator_nested
+                        if _decorator_dispatch_site(candidate) == site
+                    ),
+                    label=route.child_label(parent_label),
+                    parent=parent_selection,
+                )
+                selected.append(selection)
+                child_compiled = route.family._compiled_family()
+                child_source = (
+                    None
+                    if isinstance(nested_value, route.family.model)
+                    else child_compiled.version(selection.label)
+                )
+                selected.extend(
+                    _select_decorator_routes(
+                        nested_value,
+                        compiled=child_compiled,
+                        parent_label=selection.label,
+                        source_version=child_source,
+                        location_prefix=selection.location,
+                        parent_selection=selection,
+                    )
+                )
+    return tuple(selected)
+
+
+def _walk_authoritative_decorator_route(
+    value: Any,
+    *,
+    annotation: Any,
+    route: _CompiledDecoratorNestedFamily,
+    root_names: Mapping[str, str | None],
+) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
+    states: list[tuple[Any, Any, tuple[str | int, ...]]] = [(value, annotation, ())]
+    for step_index, step in enumerate(route.traversal):
+        next_states: list[tuple[Any, Any, tuple[str | int, ...]]] = []
+        for current, current_annotation, location in states:
+            normalized_annotation = _strip_annotated(current_annotation)
+            if step.kind == "field":
+                if not isinstance(current, BaseModel):
+                    continue
+                actual_name = root_names.get(step.value) if step_index == 0 else step.value
+                if actual_name is None:
+                    continue
+                model = type(current)
+                field_info = model.model_fields.get(actual_name)
+                if field_info is None or actual_name not in current.__dict__:
+                    continue
+                next_states.append(
+                    (
+                        current.__dict__[actual_name],
+                        field_info.annotation,
+                        (*location, step.value),
+                    )
+                )
+                continue
+            if step.kind == "union_arm":
+                if get_origin(normalized_annotation) not in (Union, UnionType):
+                    continue
+                arguments = get_args(normalized_annotation)
+                ordinal = int(step.value)
+                if ordinal >= len(arguments):
+                    continue
+                selected = _matching_declared_annotation(normalized_annotation, current)
+                candidate = _strip_annotated(arguments[ordinal])
+                if _strip_annotated(selected) != candidate:
+                    continue
+                next_states.append((current, arguments[ordinal], location))
+                continue
+            if step.kind == "each":
+                if not isinstance(current, list | tuple | set | frozenset):
+                    continue
+                arguments = get_args(normalized_annotation)
+                if not arguments:
+                    continue
+                item_annotation = arguments[0]
+                next_states.extend(
+                    (item, item_annotation, (*location, ordinal))
+                    for ordinal, item in enumerate(current)
+                )
+                continue
+            if step.kind == "tuple_index":
+                if not isinstance(current, tuple | list):
+                    continue
+                arguments = get_args(normalized_annotation)
+                ordinal = int(step.value)
+                if ordinal >= len(current) or ordinal >= len(arguments):
+                    continue
+                next_states.append((current[ordinal], arguments[ordinal], (*location, ordinal)))
+                continue
+            if step.kind == "mapping_values":
+                if not isinstance(current, Mapping):
+                    continue
+                arguments = get_args(normalized_annotation)
+                if len(arguments) != 2:
+                    continue
+                next_states.extend(
+                    (item, arguments[1], (*location, key))
+                    for key, item in current.items()
+                    if isinstance(key, str | int)
+                )
+        states = next_states
+        if not states:
+            break
+    return tuple((item, location) for item, _, location in states)
+
+
+def _raw_decorator_route_values(
+    payload: Any,
+    *,
+    model: type[BaseModel],
+    route: _CompiledDecoratorNestedFamily,
+    root_names: Mapping[str, str | None],
+) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
+    states: list[tuple[Any, Any, tuple[str | int, ...]]] = [(payload, model, ())]
+    for step_index, step in enumerate(route.traversal):
+        next_states: list[tuple[Any, Any, tuple[str | int, ...]]] = []
+        for current, current_annotation, location in states:
+            normalized_annotation = _strip_annotated(current_annotation)
+            if step.kind == "field":
+                if isinstance(current, BaseModel):
+                    current = _extract_preflight_fields(current)
+                if not isinstance(current, Mapping):
+                    continue
+                actual_name = root_names.get(step.value) if step_index == 0 else step.value
+                if actual_name is None:
+                    continue
+                if not isinstance(normalized_annotation, type) or not issubclass(
+                    normalized_annotation,
+                    BaseModel,
+                ):
+                    continue
+                field_info = normalized_annotation.model_fields.get(actual_name)
+                if field_info is None:
+                    continue
+                found, field_value = _declared_field_payload_value(
+                    current,
+                    field_name=actual_name,
+                    field_info=field_info,
+                    model_config=normalized_annotation.model_config,
+                    prefer_aliases=True,
+                    include_serialization_aliases=False,
+                )
+                if found:
+                    next_states.append(
+                        (field_value, field_info.annotation, (*location, step.value))
+                    )
+                continue
+            if step.kind == "union_arm":
+                if get_origin(normalized_annotation) not in (Union, UnionType):
+                    continue
+                arguments = get_args(normalized_annotation)
+                ordinal = int(step.value)
+                if ordinal < len(arguments):
+                    next_states.append((current, arguments[ordinal], location))
+                continue
+            if step.kind == "each":
+                if not isinstance(current, list | tuple | set | frozenset):
+                    continue
+                arguments = get_args(normalized_annotation)
+                if arguments:
+                    next_states.extend(
+                        (item, arguments[0], (*location, ordinal))
+                        for ordinal, item in enumerate(current)
+                    )
+                continue
+            if step.kind == "tuple_index":
+                if not isinstance(current, list | tuple):
+                    continue
+                arguments = get_args(normalized_annotation)
+                ordinal = int(step.value)
+                if ordinal < len(current) and ordinal < len(arguments):
+                    next_states.append((current[ordinal], arguments[ordinal], (*location, ordinal)))
+                continue
+            if step.kind == "mapping_values":
+                if not isinstance(current, Mapping):
+                    continue
+                arguments = get_args(normalized_annotation)
+                if len(arguments) == 2:
+                    next_states.extend(
+                        (item, arguments[1], (*location, key))
+                        for key, item in current.items()
+                        if isinstance(key, str)
+                    )
+        states = next_states
+        if not states:
+            break
+    return tuple((item, location) for item, _, location in states)
+
+
 def _field_crosses_wire_boundary(field_info: Any) -> bool:
     for value in (field_info.exclude, field_info.exclude_if):
         if value is None or value is False:
@@ -231,10 +472,27 @@ def _validate_family[T: BaseModel](
     )
     source = compiled.version(source_version)
     source_model = source.model.model_validate(data)
+    decorator_selections = _select_decorator_routes(
+        source_model,
+        compiled=compiled,
+        parent_label=source_version,
+        source_version=source,
+    )
+    _preflight_selected_decorator_version_metadata(
+        payload=data,
+        compiled=compiled,
+        parent_label=source_version,
+        selections=decorator_selections,
+    )
     payload = _to_current_names(
         compiled,
         source,
         _extract_declared_fields(source_model),
+    )
+    payload = _normalize_selected_decorator_payloads(
+        payload=payload,
+        selections=decorator_selections,
+        parent_label=source_version,
     )
 
     migrations_applied: list[tuple[str, str]] = []
@@ -248,6 +506,17 @@ def _validate_family[T: BaseModel](
             target_label=transition.target,
             source_payload_is_canonical=nested_payload_is_canonical,
         )
+        payload = _apply_selected_decorator_migrations(
+            payload=payload,
+            selections=decorator_selections,
+            target_label=transition.target,
+        )
+        decorator_selections = _reconcile_decorator_selections(
+            payload=payload,
+            selections=decorator_selections,
+            compiled=compiled,
+            discover_new=False,
+        )
         nested_payload_is_canonical = True
         if transition.upgrade is None:
             continue
@@ -256,13 +525,40 @@ def _validate_family[T: BaseModel](
             msg = f"Migration {transition.source!r} -> {transition.target!r} must return a dict"
             raise InvalidMigrationError(msg)
         payload = migrated
+        decorator_selections = _reconcile_decorator_selections(
+            payload=payload,
+            selections=decorator_selections,
+            compiled=compiled,
+            discover_new=True,
+        )
         migrations_applied.append((transition.source, transition.target))
 
+    payload = _apply_selected_decorator_migrations(
+        payload=payload,
+        selections=decorator_selections,
+        target_label=compiled.current_version,
+    )
+    decorator_selections = _reconcile_decorator_selections(
+        payload=payload,
+        selections=decorator_selections,
+        compiled=compiled,
+        discover_new=False,
+    )
     payload = _project_nested_family_payloads(
         payload=payload,
         compiled=compiled,
         parent_label=compiled.current_version,
         wire_boundary=False,
+    )
+    payload = _project_selected_decorator_payloads(
+        payload=payload,
+        selections=decorator_selections,
+        parent_label=compiled.current_version,
+        wire_boundary=False,
+    )
+    payload = _materialize_selected_decorator_models(
+        payload=payload,
+        selections=decorator_selections,
     )
     current_model = family.model.model_validate(
         _current_validation_input(family.model, payload),
@@ -301,8 +597,9 @@ def _dump_family[T: BaseModel](
 
     if data is None:
         payload = {}
+        decorator_selections: tuple[_DecoratorRouteSelection, ...] = ()
     else:
-        payload = _validated_current_render_payload(
+        payload, decorator_selections = _validated_current_render_payload(
             family=family,
             compiled=compiled,
             data=data,
@@ -322,6 +619,17 @@ def _dump_family[T: BaseModel](
                 target_label=transition.source,
                 source_payload_is_canonical=nested_payload_is_canonical,
             )
+            payload = _apply_selected_decorator_migrations(
+                payload=payload,
+                selections=decorator_selections,
+                target_label=transition.source,
+            )
+            decorator_selections = _reconcile_decorator_selections(
+                payload=payload,
+                selections=decorator_selections,
+                compiled=compiled,
+                discover_new=False,
+            )
             nested_payload_is_canonical = True
             if transition.downgrade is None:
                 continue
@@ -333,10 +641,33 @@ def _dump_family[T: BaseModel](
                 )
                 raise InvalidMigrationError(msg)
             payload = migrated
+            decorator_selections = _reconcile_decorator_selections(
+                payload=payload,
+                selections=decorator_selections,
+                compiled=compiled,
+                discover_new=True,
+            )
 
+    payload = _apply_selected_decorator_migrations(
+        payload=payload,
+        selections=decorator_selections,
+        target_label=requested,
+    )
+    decorator_selections = _reconcile_decorator_selections(
+        payload=payload,
+        selections=decorator_selections,
+        compiled=compiled,
+        discover_new=False,
+    )
     payload = _project_nested_family_payloads(
         payload=payload,
         compiled=compiled,
+        parent_label=requested,
+        wire_boundary=True,
+    )
+    payload = _project_selected_decorator_payloads(
+        payload=payload,
+        selections=decorator_selections,
         parent_label=requested,
         wire_boundary=True,
     )
@@ -356,6 +687,7 @@ def _dump_family[T: BaseModel](
         validated_model=target_model,
         compiled=compiled,
         parent_label=requested,
+        selections=decorator_selections,
     )
     if "mode" in dump_kwargs:
         dumped = target_model.model_dump(**dump_kwargs)
@@ -391,7 +723,7 @@ def _validated_current_render_payload[T: BaseModel](
     family: SchemaFamily[T],
     compiled: _CompiledFamily,
     data: T | Mapping[str, Any],
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], tuple[_DecoratorRouteSelection, ...]]:
     current_version = compiled.version(compiled.current_version)
     current_wire = current_version.model
     if isinstance(data, family.model):
@@ -438,7 +770,19 @@ def _validated_current_render_payload[T: BaseModel](
         raise TypeError(msg)
 
     _validate_base_model_render_metadata(compiled, current_model)
-    return _to_current_names(
+    selections = _select_decorator_routes(
+        current_model,
+        compiled=compiled,
+        parent_label=compiled.current_version,
+        source_version=None,
+    )
+    _preflight_selected_decorator_version_metadata(
+        payload=data,
+        compiled=compiled,
+        parent_label=compiled.current_version,
+        selections=selections,
+    )
+    payload = _to_current_names(
         compiled,
         current_version,
         _extract_declared_fields(
@@ -446,6 +790,8 @@ def _validated_current_render_payload[T: BaseModel](
             declared_model=family.model,
         ),
     )
+    _refresh_decorator_selection_identities(payload, selections)
+    return payload, selections
 
 
 def _validate_base_model_render_metadata(
@@ -910,6 +1256,821 @@ def _remove_model_metadata_output_aliases(
             payload.pop(candidate, None)
 
 
+def _normalize_selected_decorator_payloads(
+    *,
+    payload: dict[str, Any],
+    selections: tuple[_DecoratorRouteSelection, ...],
+    parent_label: str,
+) -> dict[str, Any]:
+    normalized = payload
+    # Historical ancestor field names must become canonical before a
+    # descendant's canonical location is reachable.  Conversion and final
+    # projection remain child-first, but input-name normalization is the
+    # inverse traversal.
+    for selection in _decorator_selections_parent_first(selections):
+        child_compiled = selection.route.family._compiled_family()
+        child_label = selection.route.child_label(parent_label)
+        normalized = _transform_payload_at_location(
+            normalized,
+            location=selection.location,
+            transform=partial(
+                _normalize_decorator_value,
+                compiled=child_compiled,
+                child_label=child_label,
+            ),
+        )
+        _refresh_decorator_selection_identity(normalized, selection)
+    return normalized
+
+
+def _normalize_decorator_value(
+    value: Any,
+    *,
+    compiled: _CompiledFamily,
+    child_label: str,
+) -> Any:
+    if isinstance(value, BaseModel):
+        value = _extract_declared_fields(value)
+    if not isinstance(value, Mapping):
+        return value
+    normalized = _to_current_names(
+        compiled,
+        compiled.version(child_label),
+        dict(value),
+    )
+    return _normalize_validated_explicit_nested_payloads(
+        payload=normalized,
+        compiled=compiled,
+        parent_label=child_label,
+    )
+
+
+def _normalize_validated_explicit_nested_payloads(
+    *,
+    payload: dict[str, Any],
+    compiled: _CompiledFamily,
+    parent_label: str,
+) -> dict[str, Any]:
+    """Canonicalize explicit descendants already validated by a wire model."""
+    normalized = payload
+    for nested in compiled.nested:
+        normalized = _transform_declared_payload_at_path(
+            normalized,
+            model=compiled.model,
+            path=nested.path,
+            transform=partial(
+                _normalize_validated_nested_family_value,
+                family=nested.family,
+                child_label=nested.child_label(parent_label),
+            ),
+        )
+    return normalized
+
+
+def _normalize_validated_nested_family_value(
+    value: Any,
+    *,
+    family: SchemaFamily[Any],
+    child_label: str,
+) -> Any:
+    if value is None:
+        return value
+    if isinstance(value, BaseModel):
+        value = _extract_declared_fields(value)
+    if isinstance(value, list | tuple | set | frozenset):
+        # Transition payloads intentionally use JSON-shaped lists for every
+        # supported collection.  The source wire model already validated each
+        # item, so normalizing here must not invoke child validators again.
+        return [
+            _normalize_validated_nested_family_value(
+                item,
+                family=family,
+                child_label=child_label,
+            )
+            for item in value
+        ]
+    if not isinstance(value, Mapping):
+        return value
+    child_compiled = family._compiled_family()
+    normalized = _to_current_names(
+        child_compiled,
+        child_compiled.version(child_label),
+        dict(value),
+    )
+    return _normalize_validated_explicit_nested_payloads(
+        payload=normalized,
+        compiled=child_compiled,
+        parent_label=child_label,
+    )
+
+
+def _apply_selected_decorator_migrations(
+    *,
+    payload: dict[str, Any],
+    selections: tuple[_DecoratorRouteSelection, ...],
+    target_label: str,
+) -> dict[str, Any]:
+    converted = payload
+    for selection in _decorator_selections_child_first(selections):
+        nested_source = selection.label
+        nested_target = selection.route.child_label(target_label)
+        if nested_source == nested_target:
+            continue
+
+        converted = _transform_payload_at_location(
+            converted,
+            location=selection.location,
+            transform=partial(
+                _convert_decorator_value,
+                family=selection.route.family,
+                source_label=nested_source,
+                target_label=nested_target,
+                collection_kind=_decorator_collection_kind(selection.route),
+            ),
+        )
+        selection.label = nested_target
+        _refresh_decorator_selection_identity(converted, selection)
+    return converted
+
+
+def _convert_decorator_value(
+    value: Any,
+    *,
+    family: SchemaFamily[Any],
+    source_label: str,
+    target_label: str,
+    collection_kind: Literal["list", "tuple", "set", "frozenset"] | None,
+) -> Any:
+    return _convert_nested_family_payload(
+        family=family,
+        payload=value,
+        source_label=source_label,
+        target_label=target_label,
+        source_payload_is_canonical=True,
+        normalize_unchanged=True,
+        collection_kind=collection_kind,
+    )
+
+
+def _project_selected_decorator_payloads(
+    *,
+    payload: dict[str, Any],
+    selections: tuple[_DecoratorRouteSelection, ...],
+    parent_label: str,
+    wire_boundary: bool,
+) -> dict[str, Any]:
+    projected = payload
+    for selection in _decorator_selections_child_first(selections):
+        target_label = selection.route.child_label(parent_label)
+
+        projected = _transform_payload_at_location(
+            projected,
+            location=selection.location,
+            transform=partial(
+                _project_decorator_value,
+                family=selection.route.family,
+                target_label=target_label,
+                wire_boundary=wire_boundary,
+                collection_kind=_decorator_collection_kind(selection.route),
+            ),
+        )
+        _refresh_decorator_selection_identity(projected, selection)
+    return projected
+
+
+def _project_decorator_value(
+    value: Any,
+    *,
+    family: SchemaFamily[Any],
+    target_label: str,
+    wire_boundary: bool,
+    collection_kind: Literal["list", "tuple", "set", "frozenset"] | None,
+) -> Any:
+    return _project_nested_family_payload(
+        family=family,
+        payload=value,
+        target_label=target_label,
+        wire_boundary=wire_boundary,
+        collection_kind=collection_kind,
+    )
+
+
+def _materialize_selected_decorator_models(
+    *,
+    payload: dict[str, Any],
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> dict[str, Any]:
+    materialized = payload
+    for selection in _decorator_selections_child_first(selections):
+        materialized = _transform_payload_at_location(
+            materialized,
+            location=selection.location,
+            transform=partial(
+                _materialize_decorator_model,
+                model=selection.route.family.model,
+            ),
+        )
+        _refresh_decorator_selection_identity(materialized, selection)
+    return materialized
+
+
+def _materialize_decorator_model(value: Any, *, model: type[BaseModel]) -> Any:
+    if type(value) is model:
+        return value
+    if not isinstance(value, Mapping):
+        return value
+    validation_input = _current_validation_input(model, dict(value))
+    if model.model_config.get("revalidate_instances") == "always":
+        # Preserve the authoritative branch as an exact instance, but let the
+        # final parent validation perform the one real validation required by
+        # the model's explicit revalidation policy.
+        return model.model_construct(**validation_input)
+    return model.model_validate(
+        validation_input,
+        by_name=True,
+    )
+
+
+def _decorator_collection_kind(
+    route: _CompiledDecoratorNestedFamily,
+) -> Literal["list", "tuple", "set", "frozenset"] | None:
+    if route.collection_kind == "mapping":
+        return None
+    return route.collection_kind
+
+
+def _transform_payload_at_location(
+    payload: Any,
+    *,
+    location: tuple[str | int, ...],
+    transform: Callable[[Any], Any],
+) -> Any:
+    if not location:
+        return transform(payload)
+    head, *remaining = location
+    tail = tuple(remaining)
+    if isinstance(payload, BaseModel):
+        return _transform_payload_at_location(
+            _extract_declared_fields(payload),
+            location=location,
+            transform=transform,
+        )
+    if isinstance(payload, Mapping):
+        if head not in payload:
+            return payload
+        current = payload[head]
+        transformed = _transform_payload_at_location(
+            current,
+            location=tail,
+            transform=transform,
+        )
+        if transformed is current:
+            return payload
+        copied = dict(payload)
+        copied[head] = transformed
+        return copied
+    if isinstance(payload, list | tuple) and isinstance(head, int):
+        if head < 0 or head >= len(payload):
+            return payload
+        current = payload[head]
+        transformed = _transform_payload_at_location(
+            current,
+            location=tail,
+            transform=transform,
+        )
+        if transformed is current:
+            return payload
+        copied_items = list(payload)
+        copied_items[head] = transformed
+        return copied_items if isinstance(payload, list) else tuple(copied_items)
+    return payload
+
+
+def _payload_at_location(
+    payload: Any,
+    location: tuple[str | int, ...],
+) -> tuple[bool, Any]:
+    current = payload
+    for part in location:
+        if isinstance(current, Mapping):
+            if part not in current:
+                return False, None
+            current = current[part]
+            continue
+        if isinstance(current, list | tuple) and isinstance(part, int):
+            if part < 0 or part >= len(current):
+                return False, None
+            current = current[part]
+            continue
+        return False, None
+    return True, current
+
+
+def _refresh_decorator_selection_identities(
+    payload: Any,
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> None:
+    for selection in selections:
+        _refresh_decorator_selection_identity(payload, selection)
+
+
+def _refresh_decorator_selection_identity(
+    payload: Any,
+    selection: _DecoratorRouteSelection,
+) -> None:
+    found, value = _payload_at_location(payload, selection.location)
+    selection.value_identity = (
+        id(value) if found and isinstance(value, Mapping | BaseModel) else None
+    )
+
+
+def _decorator_selection_depth(selection: _DecoratorRouteSelection) -> int:
+    depth = 0
+    parent = selection.parent
+    while parent is not None:
+        depth += 1
+        parent = parent.parent
+    return depth
+
+
+def _decorator_selections_child_first(
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> tuple[_DecoratorRouteSelection, ...]:
+    return tuple(
+        sorted(
+            selections,
+            key=_decorator_selection_depth,
+            reverse=True,
+        )
+    )
+
+
+def _decorator_selections_parent_first(
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> tuple[_DecoratorRouteSelection, ...]:
+    return tuple(sorted(selections, key=_decorator_selection_depth))
+
+
+def _decorator_dispatch_site(
+    route: _CompiledDecoratorNestedFamily,
+) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (step.kind, "*") if step.kind == "union_arm" else (step.kind, step.value)
+        for step in route.traversal
+    )
+
+
+def _walk_decorator_payload_candidates(
+    payload: Any,
+    route: _CompiledDecoratorNestedFamily,
+) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
+    states: list[tuple[Any, tuple[str | int, ...]]] = [(payload, ())]
+    for step in route.traversal:
+        next_states: list[tuple[Any, tuple[str | int, ...]]] = []
+        for current, location in states:
+            if step.kind == "field":
+                if isinstance(current, BaseModel):
+                    if step.value not in current.__dict__:
+                        continue
+                    next_states.append((current.__dict__[step.value], (*location, step.value)))
+                elif isinstance(current, Mapping) and step.value in current:
+                    next_states.append((current[step.value], (*location, step.value)))
+                continue
+            if step.kind == "union_arm":
+                next_states.append((current, location))
+                continue
+            if step.kind == "each":
+                if not isinstance(current, list | tuple | set | frozenset):
+                    continue
+                next_states.extend(
+                    (item, (*location, ordinal)) for ordinal, item in enumerate(current)
+                )
+                continue
+            if step.kind == "tuple_index":
+                if not isinstance(current, list | tuple):
+                    continue
+                ordinal = int(step.value)
+                if ordinal < len(current):
+                    next_states.append((current[ordinal], (*location, ordinal)))
+                continue
+            if step.kind == "mapping_values":
+                if not isinstance(current, Mapping):
+                    continue
+                if any(not isinstance(key, str) for key in current):
+                    msg = (
+                        "Parent migration introduced a non-string decorator nested "
+                        f"mapping key at path {route.path!r}"
+                    )
+                    raise InvalidMigrationError(msg)
+                next_states.extend(
+                    (item, (*location, key))
+                    for key, item in current.items()
+                    if isinstance(key, str)
+                )
+        states = next_states
+        if not states:
+            break
+    return tuple(
+        (value, location) for value, location in states if isinstance(value, Mapping | BaseModel)
+    )
+
+
+def _route_has_mapping_anchor(route: _CompiledDecoratorNestedFamily) -> bool:
+    if not any(step.kind == "mapping_values" for step in route.traversal):
+        return False
+    # A mapping key is only an occurrence anchor when the complete route to it
+    # is structurally stable.  A dynamic collection on either side of the
+    # mapping can reorder while retaining the same inner key, so anchoring the
+    # new absolute location would silently transfer a union branch identity.
+    return not any(step.kind == "each" for step in route.traversal)
+
+
+def _reconcile_decorator_selections(
+    *,
+    payload: dict[str, Any],
+    selections: tuple[_DecoratorRouteSelection, ...],
+    compiled: _CompiledFamily,
+    discover_new: bool,
+) -> tuple[_DecoratorRouteSelection, ...]:
+    if not selections:
+        if not discover_new:
+            return selections
+        return _discover_typed_decorator_selections(
+            payload=payload,
+            compiled=compiled,
+            selections=selections,
+        )
+
+    selected_by_site: dict[
+        tuple[int, tuple[tuple[str, str], ...]],
+        list[_DecoratorRouteSelection],
+    ] = {}
+    for selection in selections:
+        site = _decorator_dispatch_site(selection.route)
+        selected_by_site.setdefault((id(selection.parent), site), []).append(selection)
+
+    identity_sites = {
+        selection.value_identity: site_key
+        for site_key, site_selections in selected_by_site.items()
+        for selection in site_selections
+        if selection.value_identity is not None
+    }
+    replaced_owner_ids: set[int] = set()
+    groups = tuple(
+        sorted(
+            selected_by_site.items(),
+            key=lambda item: _decorator_selection_depth(item[1][0]),
+        )
+    )
+    for site_key, previous in groups:
+        if any(
+            _selection_has_replaced_ancestor(selection, replaced_owner_ids)
+            for selection in previous
+        ):
+            continue
+        declarations = previous[0].site_routes
+        parent = previous[0].parent
+        if parent is None:
+            base_payload = payload
+            location_prefix: tuple[str | int, ...] = ()
+        else:
+            found, base_payload = _payload_at_location(payload, parent.location)
+            if not found:
+                msg = (
+                    "Parent migration removed a decorator nested owner occurrence at "
+                    f"path {parent.route.path!r}"
+                )
+                raise InvalidMigrationError(msg)
+            location_prefix = parent.location
+        candidates = [
+            (value, (*location_prefix, *relative_location), relative_location)
+            for value, relative_location in _walk_decorator_payload_candidates(
+                base_payload,
+                declarations[0],
+            )
+        ]
+        if any(
+            id(value) in identity_sites and identity_sites[id(value)] != site_key
+            for value, _, _ in candidates
+        ):
+            msg = (
+                "Parent migration moved a decorator nested occurrence across dispatch "
+                f"sites at path {declarations[0].path!r}"
+            )
+            raise InvalidMigrationError(msg)
+        if len(candidates) < len(previous):
+            msg = (
+                "Parent migration changed decorator nested occurrence cardinality at "
+                f"path {declarations[0].path!r}; typed replacements must remain one-to-one"
+            )
+            raise InvalidMigrationError(msg)
+
+        remaining_candidates = list(enumerate(candidates))
+        remaining_previous = list(previous)
+
+        # Object identity is the authoritative occurrence token. It permits a
+        # heterogeneous list to reorder without rediscovering its union branch.
+        for selection in tuple(remaining_previous):
+            if selection.value_identity is None:
+                continue
+            matches = [
+                (index, candidate)
+                for index, candidate in remaining_candidates
+                if id(candidate[0]) == selection.value_identity
+            ]
+            if len(matches) > 1:
+                msg = (
+                    "Parent migration reused one decorator nested occurrence at "
+                    f"path {selection.route.path!r}"
+                )
+                raise InvalidMigrationError(msg)
+            if not matches:
+                continue
+            candidate_index, (value, location, relative_location) = matches[0]
+            selection.location = location
+            selection.relative_location = relative_location
+            selection.value_identity = id(value)
+            remaining_previous.remove(selection)
+            remaining_candidates = [
+                item for item in remaining_candidates if item[0] != candidate_index
+            ]
+
+        # An exact current-model instance is an explicit, authoritative branch
+        # replacement and may establish a new route without validation.
+        for candidate_index, (value, location, relative_location) in tuple(remaining_candidates):
+            if not remaining_previous:
+                break
+            if not isinstance(value, BaseModel):
+                continue
+            matching = tuple(route for route in declarations if type(value) is route.family.model)
+            if len(matching) != 1:
+                msg = (
+                    "Parent migration supplied a typed decorator nested replacement "
+                    f"with no unique family at path {declarations[0].path!r}"
+                )
+                raise InvalidMigrationError(msg)
+            route = matching[0]
+            replaced = next(
+                (selection for selection in remaining_previous if selection.location == location),
+                remaining_previous[0],
+            )
+            replaced.route = route
+            replaced.location = location
+            replaced.relative_location = relative_location
+            replaced.label = route.family.current_version
+            replaced.value_identity = id(value)
+            replaced_owner_ids.add(id(replaced))
+            remaining_previous.remove(replaced)
+            remaining_candidates = [
+                item for item in remaining_candidates if item[0] != candidate_index
+            ]
+
+        if not remaining_previous:
+            if remaining_candidates and not all(
+                len(tuple(route for route in declarations if type(value) is route.family.model))
+                == 1
+                for _, (value, _, _) in remaining_candidates
+            ):
+                msg = (
+                    "Parent migration changed decorator nested occurrence cardinality at "
+                    f"path {declarations[0].path!r}; new occurrences must be exact "
+                    "current-model instances"
+                )
+                raise InvalidMigrationError(msg)
+            continue
+
+        # Dictionary keys are stable anchors even if a callback copies the
+        # nested value. List/set positions and bare union fields are not.
+        if all(_route_has_mapping_anchor(selection.route) for selection in remaining_previous):
+            anchored = {selection.location: selection for selection in remaining_previous}
+            if len(anchored) == len(remaining_previous) and all(
+                location in anchored for _, (_, location, _) in remaining_candidates
+            ):
+                for _, (value, location, relative_location) in remaining_candidates:
+                    selection = anchored[location]
+                    selection.relative_location = relative_location
+                    selection.value_identity = id(value)
+                continue
+
+        remaining_families = {selection.route.family for selection in remaining_previous}
+        declared_families = {route.family for route in declarations}
+        if len(remaining_families) == 1 and len(declared_families) == 1:
+            if len(remaining_candidates) != len(remaining_previous):
+                msg = (
+                    "Parent migration changed decorator nested occurrence cardinality at "
+                    f"path {declarations[0].path!r}; typed replacements must remain "
+                    "one-to-one"
+                )
+                raise InvalidMigrationError(msg)
+            for selection, (_, (value, location, relative_location)) in zip(
+                remaining_previous,
+                remaining_candidates,
+                strict=True,
+            ):
+                selection.location = location
+                selection.relative_location = relative_location
+                selection.value_identity = id(value)
+            continue
+
+        msg = (
+            "Parent migration replaced overlapping decorator nested union values "
+            f"with ambiguous raw mappings at path {declarations[0].path!r}; use exact "
+            "current-model instances to establish branch identity"
+        )
+        raise InvalidMigrationError(msg)
+
+    retained = tuple(
+        selection
+        for selection in selections
+        if not _selection_has_replaced_ancestor(selection, replaced_owner_ids)
+    )
+    _validate_unique_decorator_selection_identities(retained)
+    if not discover_new:
+        return retained
+    discovered = _discover_typed_decorator_selections(
+        payload=payload,
+        compiled=compiled,
+        selections=retained,
+    )
+    _validate_unique_decorator_selection_identities(discovered)
+    return discovered
+
+
+def _selection_has_replaced_ancestor(
+    selection: _DecoratorRouteSelection,
+    replaced_owner_ids: set[int],
+) -> bool:
+    parent = selection.parent
+    while parent is not None:
+        if id(parent) in replaced_owner_ids:
+            return True
+        parent = parent.parent
+    return False
+
+
+def _validate_unique_decorator_selection_identities(
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> None:
+    locations_by_identity: dict[int, tuple[str | int, ...]] = {}
+    for selection in selections:
+        identity = selection.value_identity
+        if identity is None:
+            continue
+        prior_location = locations_by_identity.get(identity)
+        if prior_location is not None and prior_location != selection.location:
+            msg = (
+                "Parent migration reused one decorator nested occurrence at "
+                f"path {selection.route.path!r}"
+            )
+            raise InvalidMigrationError(msg)
+        locations_by_identity[identity] = selection.location
+
+
+def _discover_typed_decorator_selections(
+    *,
+    payload: dict[str, Any],
+    compiled: _CompiledFamily,
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> tuple[_DecoratorRouteSelection, ...]:
+    discovered = list(selections)
+
+    def visit_owner(
+        owner_payload: Any,
+        owner_compiled: _CompiledFamily,
+        *,
+        location_prefix: tuple[str | int, ...],
+        parent: _DecoratorRouteSelection | None,
+    ) -> None:
+        sites: dict[
+            tuple[tuple[str, str], ...],
+            list[_CompiledDecoratorNestedFamily],
+        ] = {}
+        for route in owner_compiled.decorator_nested:
+            sites.setdefault(_decorator_dispatch_site(route), []).append(route)
+
+        for routes in sites.values():
+            declarations = tuple(routes)
+            for value, relative_location in _walk_decorator_payload_candidates(
+                owner_payload,
+                declarations[0],
+            ):
+                location = (*location_prefix, *relative_location)
+                if any(
+                    selection.parent is parent and selection.location == location
+                    for selection in discovered
+                ):
+                    continue
+                matches = tuple(
+                    route for route in declarations if type(value) is route.family.model
+                )
+                if len(matches) != 1:
+                    if isinstance(value, Mapping) and not _route_has_non_child_mapping_arm(
+                        owner_compiled.model,
+                        declarations[0],
+                    ):
+                        msg = (
+                            "Parent migration introduced an untyped decorator nested "
+                            f"mapping at path {declarations[0].path!r}; use an exact "
+                            "current-model instance to establish branch identity"
+                        )
+                        raise InvalidMigrationError(msg)
+                    continue
+                route = matches[0]
+                if any(
+                    selection.value_identity == id(value) and selection.location != location
+                    for selection in discovered
+                ):
+                    msg = (
+                        "Parent migration reused one decorator nested occurrence at "
+                        f"path {route.path!r}"
+                    )
+                    raise InvalidMigrationError(msg)
+                discovered.append(
+                    _DecoratorRouteSelection(
+                        route=route,
+                        location=location,
+                        relative_location=relative_location,
+                        site_routes=declarations,
+                        label=route.family.current_version,
+                        parent=parent,
+                        value_identity=id(value),
+                    )
+                )
+
+        children = tuple(selection for selection in discovered if selection.parent is parent)
+        for child in children:
+            found, child_payload = _payload_at_location(payload, child.location)
+            if not found:
+                continue
+            visit_owner(
+                child_payload,
+                child.route.family._compiled_family(),
+                location_prefix=child.location,
+                parent=child,
+            )
+
+    visit_owner(payload, compiled, location_prefix=(), parent=None)
+    return tuple(discovered)
+
+
+def _route_has_non_child_mapping_arm(
+    model: type[BaseModel],
+    route: _CompiledDecoratorNestedFamily,
+) -> bool:
+    annotation: Any = model
+    for step in route.traversal:
+        normalized = _strip_annotated(annotation)
+        if step.kind == "field":
+            if not isinstance(normalized, type) or not issubclass(normalized, BaseModel):
+                return False
+            field_info = normalized.model_fields.get(step.value)
+            if field_info is None:
+                return False
+            annotation = field_info.annotation
+            continue
+        if step.kind == "union_arm":
+            arguments = get_args(normalized)
+            ordinal = int(step.value)
+            if ordinal >= len(arguments):
+                return False
+            if any(
+                _annotation_accepts_raw_mapping(argument)
+                for index, argument in enumerate(arguments)
+                if index != ordinal
+            ):
+                return True
+            annotation = arguments[ordinal]
+            continue
+        arguments = get_args(normalized)
+        if step.kind in ("each", "mapping_values"):
+            if not arguments:
+                return False
+            annotation = arguments[1] if step.kind == "mapping_values" else arguments[0]
+            continue
+        if step.kind == "tuple_index":
+            ordinal = int(step.value)
+            if ordinal >= len(arguments):
+                return False
+            annotation = arguments[ordinal]
+    return False
+
+
+def _annotation_accepts_raw_mapping(annotation: Any) -> bool:
+    normalized = _strip_annotated(annotation)
+    if normalized is Any:
+        return True
+    origin = get_origin(normalized)
+    if origin in (Union, UnionType):
+        return any(_annotation_accepts_raw_mapping(item) for item in get_args(normalized))
+    runtime_type = origin if isinstance(origin, type) else normalized
+    if not isinstance(runtime_type, type):
+        return False
+    try:
+        return issubclass(dict, runtime_type)
+    except TypeError:
+        return False
+
+
 def _apply_nested_family_migrations(
     *,
     payload: dict[str, Any],
@@ -973,7 +2134,7 @@ def _preflight_nested_version_metadata(
     compiled: _CompiledFamily,
     parent_label: str,
 ) -> None:
-    if not compiled.nested:
+    if not compiled.nested and not compiled.decorator_nested:
         return
     parent_version = compiled.version(parent_label)
     payload_is_canonical = False
@@ -1023,6 +2184,95 @@ def _preflight_nested_version_metadata(
                     compiled=child_compiled,
                     parent_label=expected,
                 )
+
+    root_names = {
+        route.path[0]: parent_version.projection.field(route.path[0]).version_name
+        for route in compiled.decorator_nested
+    }
+    for route in compiled.decorator_nested:
+        expected = route.child_label(parent_label)
+        child_compiled = route.family._compiled_family()
+        for item, _ in _raw_decorator_route_values(
+            payload,
+            model=parent_version.model,
+            route=route,
+            root_names=root_names,
+        ):
+            if isinstance(item, BaseModel):
+                item = _extract_preflight_fields(item)
+            if not isinstance(item, Mapping):
+                continue
+            found, declared = _declared_nested_version_metadata(
+                payload=item,
+                compiled=child_compiled,
+                source_label=expected,
+            )
+            if found and declared != expected:
+                msg = (
+                    f"Decorator nested family {route.family.name!r} at path {route.path!r} "
+                    f"expects version {expected!r} for parent label {parent_label!r}, "
+                    f"but the payload declares {declared!r}"
+                )
+                raise SchemaVersionError(msg)
+            _preflight_nested_version_metadata(
+                payload=item,
+                compiled=child_compiled,
+                parent_label=expected,
+            )
+
+
+def _preflight_selected_decorator_version_metadata(
+    *,
+    payload: Any,
+    compiled: _CompiledFamily,
+    parent_label: str,
+    selections: tuple[_DecoratorRouteSelection, ...],
+) -> None:
+    if not selections:
+        return
+    parent_version = compiled.version(parent_label)
+    if isinstance(payload, BaseModel):
+        payload = _extract_preflight_fields(payload)
+    if not isinstance(payload, Mapping):
+        return
+    canonical = _to_current_names(compiled, parent_version, dict(payload))
+    for selection in _decorator_selections_parent_first(selections):
+        route = selection.route
+        found_raw, raw = _payload_at_location(canonical, selection.location)
+        if not found_raw:
+            continue
+        if isinstance(raw, BaseModel):
+            raw = _extract_preflight_fields(raw)
+        if not isinstance(raw, Mapping):
+            continue
+        expected = route.child_label(parent_label)
+        child_compiled = route.family._compiled_family()
+        found, declared = _declared_nested_version_metadata(
+            payload=raw,
+            compiled=child_compiled,
+            source_label=expected,
+        )
+        if found and declared != expected:
+            msg = (
+                f"Decorator nested family {route.family.name!r} at path {route.path!r} "
+                f"expects version {expected!r} for parent label {parent_label!r}, "
+                f"but the payload declares {declared!r}"
+            )
+            raise SchemaVersionError(msg)
+        _preflight_nested_version_metadata(
+            payload=raw,
+            compiled=child_compiled,
+            parent_label=expected,
+        )
+        canonical = _transform_payload_at_location(
+            canonical,
+            location=selection.location,
+            transform=partial(
+                _normalize_decorator_value,
+                compiled=child_compiled,
+                child_label=expected,
+            ),
+        )
 
 
 def _extract_preflight_fields(
@@ -1675,8 +2925,10 @@ def _validate_nested_collection_cardinality(
     validated_model: BaseModel,
     compiled: _CompiledFamily,
     parent_label: str,
+    selections: tuple[_DecoratorRouteSelection, ...],
 ) -> None:
-    if not compiled.nested:
+    del selections
+    if not compiled.nested and not compiled.decorator_nested:
         return
     validated_payload = _extract_declared_fields(validated_model)
     _validate_nested_collection_cardinality_payloads(
@@ -1685,6 +2937,46 @@ def _validate_nested_collection_cardinality(
         compiled=compiled,
         parent_label=parent_label,
     )
+
+
+def _decorator_set_cardinalities(
+    payload: Any,
+    route: _CompiledDecoratorNestedFamily,
+) -> dict[int, tuple[int, ...]]:
+    states: list[Any] = [payload]
+    cardinalities: dict[int, list[int]] = {}
+    for step_index, step in enumerate(route.traversal):
+        next_states: list[Any] = []
+        for current in states:
+            if step.kind == "field":
+                if isinstance(current, BaseModel) and step.value in current.__dict__:
+                    next_states.append(current.__dict__[step.value])
+                elif isinstance(current, Mapping) and step.value in current:
+                    next_states.append(current[step.value])
+                continue
+            if step.kind == "union_arm":
+                next_states.append(current)
+                continue
+            if step.kind == "each":
+                if not isinstance(current, list | tuple | set | frozenset):
+                    continue
+                if step.value in ("set", "frozenset"):
+                    cardinalities.setdefault(step_index, []).append(len(current))
+                next_states.extend(current)
+                continue
+            if step.kind == "tuple_index":
+                if not isinstance(current, list | tuple):
+                    continue
+                ordinal = int(step.value)
+                if ordinal < len(current):
+                    next_states.append(current[ordinal])
+                continue
+            if step.kind == "mapping_values" and isinstance(current, Mapping):
+                next_states.extend(current.values())
+        states = next_states
+        if not states:
+            break
+    return {index: tuple(values) for index, values in cardinalities.items()}
 
 
 def _validate_nested_collection_cardinality_payloads(
@@ -1748,13 +3040,73 @@ def _validate_nested_collection_cardinality_payloads(
             item for value in validated_values for item in _nested_payload_items(value)
         )
         child_compiled = nested.family._compiled_family()
-        if child_compiled.nested:
+        if child_compiled.nested or child_compiled.decorator_nested:
             _validate_nested_collection_cardinality_payloads(
                 input_payloads=child_input,
                 validated_payloads=child_validated,
                 compiled=child_compiled,
                 parent_label=nested.child_label(parent_label),
             )
+
+    canonical_input = tuple(
+        _to_current_names(compiled, target, payload) if isinstance(payload, Mapping) else payload
+        for payload in input_payloads
+    )
+    canonical_validated = tuple(
+        _to_current_names(compiled, target, payload) if isinstance(payload, Mapping) else payload
+        for payload in validated_payloads
+    )
+    for route in compiled.decorator_nested:
+        set_steps = tuple(
+            index
+            for index, step in enumerate(route.traversal)
+            if step.kind == "each" and step.value in ("set", "frozenset")
+        )
+        before_maps = tuple(
+            _decorator_set_cardinalities(payload, route) for payload in canonical_input
+        )
+        after_maps = tuple(
+            _decorator_set_cardinalities(payload, route) for payload in canonical_validated
+        )
+        for step_index in set_steps:
+            expected = sorted(
+                value
+                for cardinalities in before_maps
+                for value in cardinalities.get(step_index, ())
+            )
+            actual = sorted(
+                value for cardinalities in after_maps for value in cardinalities.get(step_index, ())
+            )
+            collapsed = len(actual) < len(expected) or any(
+                observed < original for original, observed in zip(expected, actual, strict=False)
+            )
+            if collapsed:
+                msg = (
+                    f"Nested migration for family {route.family.name!r} cannot preserve "
+                    "set cardinality after target wire validation at path "
+                    f"{route.path!r}"
+                )
+                raise InvalidMigrationError(msg)
+
+        child_compiled = route.family._compiled_family()
+        if not child_compiled.nested and not child_compiled.decorator_nested:
+            continue
+        child_input = tuple(
+            value
+            for payload in canonical_input
+            for value, _ in _walk_decorator_payload_candidates(payload, route)
+        )
+        child_validated = tuple(
+            value
+            for payload in canonical_validated
+            for value, _ in _walk_decorator_payload_candidates(payload, route)
+        )
+        _validate_nested_collection_cardinality_payloads(
+            input_payloads=child_input,
+            validated_payloads=child_validated,
+            compiled=child_compiled,
+            parent_label=route.child_label(parent_label),
+        )
 
 
 def _target_nested_path(

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import is_dataclass
 from functools import reduce
@@ -19,6 +19,7 @@ from typing import (
     cast,
     get_args,
     get_origin,
+    is_typeddict,
 )
 from typing import (
     TypeAliasType as StdlibTypeAliasType,
@@ -47,9 +48,12 @@ from pydantic_core import PydanticUndefined
 from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
 
 from pydantic_versions._compiler import (
+    _CompiledDecoratorNestedFamily,
     _CompiledNestedFamily,
+    _DecoratorTraversalStep,
     _generated_model_name,
     _identifier_component,
+    _NestedCollectionKind,
     _stable_digest,
     _VersionProjection,
 )
@@ -247,14 +251,23 @@ def _build_model_for_projection(
     projection: _VersionProjection,
     wire_model: type[BaseModel] | None,
     nested: tuple[_CompiledNestedFamily, ...] = (),
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...] = (),
 ) -> type[BaseModel]:
     if wire_model is not None:
+        if decorator_nested:
+            _raise_projection_unsupported(
+                family,
+                projection,
+                "explicit wire models cannot contain decorator-discovered child families; "
+                "declare explicit NestedFamily boundaries instead",
+            )
         return _validate_explicit_wire_model(family, projection, wire_model)
     try:
         return _build_model_for_projection_unchecked(
             family,
             projection,
             nested=nested,
+            decorator_nested=decorator_nested,
         )
     except UnsupportedWireModelError:
         raise
@@ -341,6 +354,7 @@ def _build_model_for_projection_unchecked(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
     nested: tuple[_CompiledNestedFamily, ...] = (),
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...] = (),
 ) -> type[BaseModel]:
     model_metadata_field = _model_metadata_field(family)
     used_nested: set[tuple[str, ...]] = set()
@@ -396,6 +410,7 @@ def _build_model_for_projection_unchecked(
             projection.label,
             family,
             nested=nested,
+            decorator_nested=decorator_nested,
             field_path=(compiled_field.current_name,),
             used_nested=used_nested,
             field_name=compiled_field.current_name,
@@ -435,6 +450,7 @@ def _build_model_for_projection_unchecked(
             annotation,
             family,
             nested=nested,
+            decorator_nested=decorator_nested,
             field_path=(compiled_field.current_name,),
             used_nested=used_nested,
             field_name=compiled_field.current_name,
@@ -1373,6 +1389,13 @@ def _raise_unsupported(family: SchemaFamily[Any], detail: str) -> None:
     raise UnsupportedWireModelError(msg)
 
 
+def _safe_runtime_subclass(candidate: type[Any], target: type[Any]) -> bool:
+    try:
+        return issubclass(candidate, target)
+    except TypeError:
+        return False
+
+
 def _raise_projection_unsupported(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
@@ -1410,6 +1433,30 @@ def _find_nested_families_under_path(
         family
         for family in nested
         if len(family.path) > len(field_path) and family.path[: len(field_path)] == field_path
+    )
+
+
+def _find_decorator_family_for_model(
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
+    field_path: tuple[str, ...],
+    annotation: Any,
+) -> _CompiledDecoratorNestedFamily | None:
+    if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+        return None
+    for route in decorator_nested:
+        if route.path == field_path and route.family.model is annotation:
+            return route
+    return None
+
+
+def _find_decorator_families_under_path(
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
+    field_path: tuple[str, ...],
+) -> tuple[_CompiledDecoratorNestedFamily, ...]:
+    return tuple(
+        route
+        for route in decorator_nested
+        if len(route.path) > len(field_path) and route.path[: len(field_path)] == field_path
     )
 
 
@@ -1466,13 +1513,467 @@ def _validate_nested_projection_coverage(
         _raise_projection_unsupported(family, projection, msg)
 
 
+def _compile_decorator_nested_families(
+    owner: SchemaFamily[Any],
+    explicit: tuple[_CompiledNestedFamily, ...],
+) -> tuple[_CompiledDecoratorNestedFamily, ...]:
+    """Discover the compatibility decorator's implicit child-family boundaries."""
+    if not owner._decorator_created:
+        return ()
+
+    explicit_paths = frozenset(declaration.path for declaration in explicit)
+    discovered: list[_CompiledDecoratorNestedFamily] = []
+
+    def visit(
+        annotation: Any,
+        *,
+        field_path: tuple[str, ...],
+        traversal: tuple[_DecoratorTraversalStep, ...],
+        collection_kind: _NestedCollectionKind | None,
+        model_stack: tuple[type[BaseModel], ...],
+    ) -> None:
+        if field_path in explicit_paths:
+            return
+        if isinstance(annotation, _TYPE_ALIAS_TYPES):
+            if _annotation_has_decorator_child(owner, annotation):
+                _raise_unsupported(
+                    owner,
+                    f"decorator child at path {field_path!r} is hidden in a type alias",
+                )
+            return
+        if isinstance(annotation, TypeVar):
+            if _annotation_has_decorator_child(owner, annotation):
+                _raise_unsupported(
+                    owner,
+                    f"decorator child at path {field_path!r} is hidden behind an "
+                    "unresolved type parameter",
+                )
+            return
+        if is_typeddict(annotation):
+            if _annotation_has_decorator_child(owner, annotation):
+                _raise_unsupported(
+                    owner,
+                    f"decorator child at path {field_path!r} uses a TypedDict boundary",
+                )
+            return
+
+        origin = get_origin(annotation)
+        if origin is Annotated:
+            arguments = get_args(annotation)
+            if arguments:
+                visit(
+                    arguments[0],
+                    field_path=field_path,
+                    traversal=traversal,
+                    collection_kind=collection_kind,
+                    model_stack=model_stack,
+                )
+            return
+
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            hidden = next(
+                (
+                    path
+                    for path in explicit_paths
+                    if len(path) > len(field_path) and path[: len(field_path)] == field_path
+                ),
+                None,
+            )
+            if hidden is not None:
+                from pydantic_versions.family import _default_family_for_model
+
+                registered = _default_family_for_model(annotation)
+                if registered is not None and registered._decorator_created:
+                    _raise_unsupported(
+                        owner,
+                        f"explicit NestedFamily path {hidden!r} descends beneath decorator "
+                        f"child boundary {field_path!r}",
+                    )
+            child = _compat_child_family(owner, annotation)
+            if child is not None:
+                discovered.append(
+                    _CompiledDecoratorNestedFamily(
+                        path=field_path,
+                        family=child,
+                        traversal=traversal,
+                        collection_kind=collection_kind,
+                    )
+                )
+                return
+            has_decorator_child = _annotation_has_decorator_child(owner, annotation)
+            # An incomplete wrapper can conceal a decorator child behind an
+            # unresolved ForwardRef, so it must fail closed even before route
+            # discovery can prove that a projection is required.
+            if has_decorator_child or not getattr(annotation, "__pydantic_complete__", False):
+                _validate_ordinary_wrapper_model(owner, annotation, field_path=field_path)
+            if annotation in model_stack:
+                if has_decorator_child:
+                    _raise_unsupported(
+                        owner,
+                        f"decorator child beneath recursive model path {field_path!r} "
+                        "cannot be projected safely",
+                    )
+                return
+            for nested_name, field_info in annotation.model_fields.items():
+                if not _decorator_field_crosses_wire_boundary(field_info):
+                    continue
+                visit(
+                    field_info.annotation,
+                    field_path=(*field_path, nested_name),
+                    traversal=(
+                        *traversal,
+                        _DecoratorTraversalStep("field", nested_name),
+                    ),
+                    collection_kind=collection_kind,
+                    model_stack=(*model_stack, annotation),
+                )
+            return
+
+        arguments = get_args(annotation)
+        if origin in (Union, UnionType):
+            branch_shapes: list[tuple[tuple[tuple[str, str], ...], ...]] = []
+            branch_routes: list[tuple[_CompiledDecoratorNestedFamily, ...]] = []
+            branch_arguments: list[Any] = []
+            for ordinal, argument in enumerate(arguments):
+                if argument is type(None):
+                    continue
+                branch_arguments.append(argument)
+                start = len(discovered)
+                visit(
+                    argument,
+                    field_path=field_path,
+                    traversal=(
+                        *traversal,
+                        _DecoratorTraversalStep("union_arm", str(ordinal)),
+                    ),
+                    collection_kind=collection_kind,
+                    model_stack=model_stack,
+                )
+                branch_routes.append(tuple(discovered[start:]))
+                branch_shapes.append(
+                    tuple(
+                        sorted(
+                            tuple(
+                                (step.kind, "*")
+                                if step.kind == "union_arm"
+                                else (step.kind, step.value)
+                                for step in route.traversal[len(traversal) + 1 :]
+                            )
+                            for route in discovered[start:]
+                        )
+                    )
+                )
+            populated = tuple(shape for shape in branch_shapes if shape)
+            if len(populated) > 1 and any(shape != populated[0] for shape in populated[1:]):
+                _raise_unsupported(
+                    owner,
+                    f"decorator children beneath union path {field_path!r} use "
+                    "non-isomorphic traversal shapes",
+                )
+            union_routes = tuple(route for routes in branch_routes for route in routes)
+            if union_routes:
+                if any(is_typeddict(argument) for argument in branch_arguments):
+                    _raise_unsupported(
+                        owner,
+                        f"decorator children beneath union path {field_path!r} use a "
+                        "runtime-unrecoverable TypedDict arm",
+                    )
+                runtime_container_arms: list[tuple[type[Any] | None, bool]] = []
+                for argument, routes in zip(branch_arguments, branch_routes, strict=True):
+                    normalized = argument
+                    while get_origin(normalized) is Annotated:
+                        normalized = get_args(normalized)[0]
+                    runtime_origin = get_origin(normalized)
+                    runtime_container = (
+                        runtime_origin
+                        if isinstance(runtime_origin, type)
+                        else normalized
+                        if isinstance(normalized, type) and normalized is not Any
+                        else None
+                    )
+                    runtime_container_arms.append((runtime_container, bool(routes)))
+                for left_index, (left, left_has_routes) in enumerate(runtime_container_arms):
+                    if left is None:
+                        continue
+                    for right, right_has_routes in runtime_container_arms[left_index + 1 :]:
+                        if right is None or not (left_has_routes or right_has_routes):
+                            continue
+                        if not (
+                            _safe_runtime_subclass(left, right)
+                            or _safe_runtime_subclass(right, left)
+                        ):
+                            continue
+                        _raise_unsupported(
+                            owner,
+                            f"decorator children beneath union path {field_path!r} use "
+                            "runtime-indistinguishable container arms",
+                        )
+                routes_by_site: dict[
+                    tuple[tuple[str, str], ...],
+                    list[_CompiledDecoratorNestedFamily],
+                ] = {}
+                for route in union_routes:
+                    site = tuple(
+                        (step.kind, "*") if step.kind == "union_arm" else (step.kind, step.value)
+                        for step in route.traversal
+                    )
+                    routes_by_site.setdefault(site, []).append(route)
+                for routes in routes_by_site.values():
+                    first_contract = _decorator_metadata_contract(routes[0].family)
+                    if any(
+                        _decorator_metadata_contract(route.family) != first_contract
+                        for route in routes[1:]
+                    ):
+                        _raise_unsupported(
+                            owner,
+                            f"decorator children beneath union path {field_path!r} use "
+                            "incompatible version-metadata contracts",
+                        )
+            return
+        if origin in (list, set, frozenset):
+            if len(arguments) != 1:
+                if _annotation_has_decorator_child(owner, annotation):
+                    _raise_unsupported(
+                        owner,
+                        f"decorator child at path {field_path!r} uses an "
+                        "unparameterized or ambiguous collection",
+                    )
+                return
+            kind = cast(_NestedCollectionKind, origin.__name__)
+            visit(
+                arguments[0],
+                field_path=field_path,
+                traversal=(*traversal, _DecoratorTraversalStep("each", kind)),
+                collection_kind=kind,
+                model_stack=model_stack,
+            )
+            return
+        if origin is tuple:
+            if not arguments:
+                if _annotation_has_decorator_child(owner, annotation):
+                    _raise_unsupported(
+                        owner,
+                        f"decorator child at path {field_path!r} uses an unparameterized tuple",
+                    )
+                return
+            if len(arguments) == 2 and arguments[1] is Ellipsis:
+                visit(
+                    arguments[0],
+                    field_path=field_path,
+                    traversal=(
+                        *traversal,
+                        _DecoratorTraversalStep("each", "tuple"),
+                    ),
+                    collection_kind="tuple",
+                    model_stack=model_stack,
+                )
+                return
+            for ordinal, argument in enumerate(arguments):
+                visit(
+                    argument,
+                    field_path=field_path,
+                    traversal=(
+                        *traversal,
+                        _DecoratorTraversalStep("tuple_index", str(ordinal)),
+                    ),
+                    collection_kind="tuple",
+                    model_stack=model_stack,
+                )
+            return
+        if origin is dict:
+            if len(arguments) != 2:
+                if _annotation_has_decorator_child(owner, annotation):
+                    _raise_unsupported(
+                        owner,
+                        f"decorator child at path {field_path!r} uses an unparameterized mapping",
+                    )
+                return
+            key_annotation, value_annotation = arguments
+            if _annotation_has_decorator_child(owner, key_annotation):
+                _raise_unsupported(
+                    owner,
+                    f"decorator child at path {field_path!r} cannot be used as a mapping key",
+                )
+            if (
+                _annotation_has_decorator_child(owner, value_annotation)
+                and key_annotation is not str
+            ):
+                _raise_unsupported(
+                    owner,
+                    f"decorator child at path {field_path!r} requires exact string mapping keys",
+                )
+            visit(
+                value_annotation,
+                field_path=field_path,
+                traversal=(
+                    *traversal,
+                    _DecoratorTraversalStep("mapping_values", "dict"),
+                ),
+                collection_kind="mapping",
+                model_stack=model_stack,
+            )
+            return
+        if (
+            origin is not None
+            and isinstance(origin, type)
+            and (
+                issubclass(origin, Mapping)
+                or issubclass(origin, Sequence)
+                or issubclass(origin, Iterable)
+            )
+        ):
+            if _annotation_has_decorator_child(owner, annotation):
+                _raise_unsupported(
+                    owner,
+                    f"decorator child at path {field_path!r} uses unsupported abstract "
+                    f"container {origin.__module__}.{origin.__qualname__}",
+                )
+            return
+        if arguments and _annotation_has_decorator_child(owner, annotation):
+            _raise_unsupported(
+                owner,
+                f"decorator child at path {field_path!r} uses an unsupported generic wrapper",
+            )
+
+    for field_name, field_info in owner.model.model_fields.items():
+        if not _decorator_field_crosses_wire_boundary(field_info):
+            continue
+        visit(
+            field_info.annotation,
+            field_path=(field_name,),
+            traversal=(_DecoratorTraversalStep("field", field_name),),
+            collection_kind=None,
+            model_stack=(owner.model,),
+        )
+    return tuple(discovered)
+
+
+def _decorator_field_crosses_wire_boundary(field_info: Any) -> bool:
+    attributes = field_info.asdict()["attributes"]
+    return not any(
+        key in attributes and _has_effect(attributes[key]) for key in _OMITTED_FIELD_ATTRIBUTES
+    )
+
+
+def _decorator_metadata_contract(family: SchemaFamily[Any]) -> tuple[Any, ...]:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner == "family":
+        return (metadata,)
+    if not isinstance(metadata.path, str):  # pragma: no cover - declaration invariant
+        return (metadata,)
+    field_info = family.model.model_fields.get(metadata.path)
+    if field_info is None:  # pragma: no cover - inferred owner invariant
+        return (metadata,)
+    return (
+        metadata,
+        field_info.alias,
+        field_info.validation_alias,
+        field_info.serialization_alias,
+    )
+
+
+def _annotation_has_decorator_child(
+    owner: SchemaFamily[Any],
+    annotation: Any,
+    *,
+    seen: set[int] | None = None,
+) -> bool:
+    visited = set() if seen is None else seen
+    if id(annotation) in visited:
+        return False
+    visited.add(id(annotation))
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        return _annotation_has_decorator_child(owner, annotation.__value__, seen=visited)
+    if isinstance(annotation, TypeVar):
+        return any(
+            _annotation_has_decorator_child(owner, value, seen=visited)
+            for value in _type_parameter_values(annotation)
+        )
+    if is_typeddict(annotation):
+        return any(
+            _annotation_has_decorator_child(owner, value, seen=visited)
+            for value in annotation.__annotations__.values()
+        )
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        arguments = get_args(annotation)
+        return bool(arguments) and _annotation_has_decorator_child(
+            owner,
+            arguments[0],
+            seen=visited,
+        )
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        if _compat_child_family(owner, annotation) is not None:
+            return True
+        return any(
+            _annotation_has_decorator_child(owner, field_info.annotation, seen=visited)
+            for field_info in annotation.model_fields.values()
+        )
+    return any(
+        _annotation_has_decorator_child(owner, argument, seen=visited)
+        for argument in get_args(annotation)
+    )
+
+
+def _validate_ordinary_wrapper_model(
+    owner: SchemaFamily[Any],
+    model: type[BaseModel],
+    *,
+    field_path: tuple[str, ...],
+) -> None:
+    context = f"ordinary wrapper {_model_display(model)!r} at path {field_path!r}"
+    if getattr(model, "__pydantic_root_model__", False):
+        _raise_unsupported(owner, f"{context} is a RootModel and is not object-shaped")
+    if not getattr(model, "__pydantic_complete__", False):
+        _raise_unsupported(
+            owner,
+            f"{context} is incomplete; resolve forward references and call "
+            "model_rebuild() before compilation",
+        )
+    generic_metadata = getattr(model, "__pydantic_generic_metadata__", None)
+    if isinstance(generic_metadata, Mapping) and generic_metadata.get("parameters"):
+        _raise_unsupported(owner, f"{context} has unresolved generic parameters")
+    decorators = getattr(model, "__pydantic_decorators__", None)
+    if decorators is not None and getattr(decorators, "model_serializers", None):
+        _raise_unsupported(owner, f"{context} uses a model-level serializer")
+    for hook in _CUSTOM_MODEL_HOOKS:
+        hook_owner = _first_defining_class(model, hook)
+        if hook_owner is not None and hook_owner is not BaseModel:
+            _raise_unsupported(owner, f"{context} uses custom model hook {hook}")
+
+    config: Mapping[str, Any] = model.model_config
+    unknown = sorted(set(config) - _KNOWN_CONFIG_KEYS)
+    if unknown:
+        _raise_unsupported(
+            owner,
+            f"{context} sets unsupported model configuration: {', '.join(unknown)}",
+        )
+    for key, value in config.items():
+        if key in _REJECTED_CONFIG_KEYS and _has_effect(value):
+            _raise_unsupported(owner, f"{context} uses model configuration {key!r}")
+    schema_extra = config.get("json_schema_extra")
+    if schema_extra is not None and not isinstance(schema_extra, Mapping):
+        _raise_unsupported(owner, f"{context} uses callable model JSON Schema mutation")
+
+    if config.get("extra") == "allow":
+        for base in model.__mro__:
+            if base is BaseModel:
+                continue
+            if "__pydantic_extra__" in base.__dict__.get("__annotations__", {}):
+                _raise_unsupported(owner, f"{context} declares typed extra values")
+
+
 def _compat_child_family(
     owner: SchemaFamily[Any],
     annotation: Any,
 ) -> SchemaFamily[Any] | None:
     if not owner._decorator_created:
         return None
-    if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+    if (
+        not isinstance(annotation, type)
+        or is_typeddict(annotation)
+        or not issubclass(annotation, BaseModel)
+    ):
         return None
     from pydantic_versions.family import _default_family_for_model
 
@@ -1513,6 +2014,7 @@ def _rewrite_annotation(
     family: SchemaFamily[Any],
     *,
     nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     field_path: tuple[str, ...],
     used_nested: set[tuple[str, ...]],
     field_name: str,
@@ -1533,9 +2035,13 @@ def _rewrite_annotation(
         used_nested.add(child.path)
         family_model = child.family.model_for(child.child_label(version))
         return _set_element_wire_model(family_model) if in_set_element else family_model
-    child = _compat_child_family(family, annotation) if allow_child_projection else None
-    if child is not None:
-        family_model = child.model_for(version)
+    decorator_child = (
+        _find_decorator_family_for_model(decorator_nested, field_path, annotation)
+        if allow_child_projection
+        else None
+    )
+    if decorator_child is not None:
+        family_model = decorator_child.family.model_for(version)
         return _set_element_wire_model(family_model) if in_set_element else family_model
 
     if isinstance(annotation, _TYPE_ALIAS_TYPES):
@@ -1548,7 +2054,11 @@ def _rewrite_annotation(
         and issubclass(annotation, BaseModel)
     ):
         nested_families = _find_nested_families_under_path(nested, field_path)
-        if nested_families:
+        decorator_families = _find_decorator_families_under_path(
+            decorator_nested,
+            field_path,
+        )
+        if nested_families or decorator_families:
             return _rewrite_nested_model(
                 annotation,
                 version,
@@ -1556,6 +2066,7 @@ def _rewrite_annotation(
                 field_name=field_name,
                 field_path=field_path,
                 nested=nested_families,
+                decorator_nested=decorator_families,
                 in_set_element=in_set_element,
                 nested_projection_cache=nested_projection_cache,
                 nested_projection_stack=nested_projection_stack,
@@ -1574,6 +2085,7 @@ def _rewrite_annotation(
             version,
             family,
             nested=nested,
+            decorator_nested=decorator_nested,
             field_path=field_path,
             used_nested=used_nested,
             field_name=field_name,
@@ -1614,6 +2126,7 @@ def _rewrite_annotation(
             field_path=field_path,
             allow_child_projection=allow_child_projection and legacy_container,
             nested=nested,
+            decorator_nested=decorator_nested,
             used_nested=used_nested,
             nested_projection_cache=nested_projection_cache,
             nested_projection_stack=nested_projection_stack,
@@ -1632,6 +2145,8 @@ def _rewrite_annotation(
         return copy_with(args)
     try:
         return origin[args]
+    except UnsupportedWireModelError:
+        raise
     except Exception as exc:
         msg = (
             f"Automatic wire model for family {family.name!r} and model "
@@ -1649,6 +2164,7 @@ def _rewrite_nested_model(
     field_name: str,
     field_path: tuple[str, ...],
     nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     nested_projection_cache: dict[tuple[int, tuple[str, ...], str], type[BaseModel] | None],
     nested_projection_stack: set[tuple[int, tuple[str, ...], str]],
     used_nested: set[tuple[str, ...]],
@@ -1686,6 +2202,7 @@ def _rewrite_nested_model(
                 version,
                 owner,
                 nested=nested,
+                decorator_nested=decorator_nested,
                 field_path=field_path + (source_name,),
                 used_nested=used_nested,
                 field_name=source_name,
@@ -1702,6 +2219,7 @@ def _rewrite_nested_model(
                 rewritten_annotation,
                 owner,
                 nested=nested,
+                decorator_nested=decorator_nested,
                 field_path=field_path + (source_name,),
                 used_nested=used_nested,
                 field_name=source_name,
@@ -1719,6 +2237,8 @@ def _rewrite_nested_model(
             **fields,
         )
         nested_projection.model_rebuild(force=True)
+    except UnsupportedWireModelError:
+        raise
     except Exception as exc:
         msg = (
             f"Automatic wire model for family {owner.name!r}, version {version!r}, and model "
@@ -1823,6 +2343,7 @@ def _rewrite_nested_default(
     family: SchemaFamily[Any],
     *,
     nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     field_path: tuple[str, ...],
     used_nested: set[tuple[str, ...]],
     field_name: str,
@@ -1830,41 +2351,273 @@ def _rewrite_nested_default(
 ) -> None:
     if original_annotation == version_annotation:
         return
-    declaration = _find_nested_family_for_path(nested, field_path)
-    if declaration is not None:
-        used_nested.add(declaration.path)
-        child = declaration.family
-        version_annotation = child.model_for(declaration.child_label(version))
-    else:
-        child = _compat_child_family(family, original_annotation)
-    if child is None or not (
-        isinstance(version_annotation, type) and issubclass(version_annotation, BaseModel)
-    ):
-        return
+    original_model = _default_model_annotation(original_annotation)
+    target_model = _default_model_annotation(version_annotation)
     default_factory = attributes.get("default_factory")
-    if default_factory is original_annotation:
-        attributes["default_factory"] = version_annotation
-    elif callable(default_factory):
+    original_base = original_annotation
+    while get_origin(original_base) is Annotated:
+        original_base = get_args(original_base)[0]
+    original_origin = get_origin(original_base)
+    if (
+        original_model is not None
+        and target_model is not None
+        and default_factory is original_model
+    ):
+        attributes["default_factory"] = target_model
+    elif callable(default_factory) and not (
+        original_origin in (list, tuple, set, frozenset, dict)
+        and default_factory is original_origin
+    ):
         _raise_unsupported(
             family,
-            f"field {field_name!r} uses an opaque factory for a projected nested model",
+            f"field {field_name!r} uses an opaque factory for a projected nested value",
         )
     default = attributes.get("default", PydanticUndefined)
     if default is PydanticUndefined or default is None:
         return
-    try:
-        is_default_from_source = isinstance(default, original_annotation)
-    except TypeError:
-        return
-    if is_default_from_source:
-        attributes["default"] = _project_child_default_value(
-            default,
-            source_model=original_annotation,
-            target_model=version_annotation,
-            child=child,
-            owner=family,
+    attributes["default"] = _project_nested_default_member(
+        default,
+        original_annotation=original_annotation,
+        version_annotation=version_annotation,
+        owner=family,
+        nested=nested,
+        decorator_nested=decorator_nested,
+        field_path=field_path,
+        used_nested=used_nested,
+        version=version,
+    )
+
+
+def _default_model_annotation(annotation: Any) -> type[BaseModel] | None:
+    current = annotation
+    while get_origin(current) is Annotated:
+        current = get_args(current)[0]
+    if isinstance(current, type) and issubclass(current, BaseModel):
+        return current
+    return None
+
+
+def _project_nested_model_default_value(
+    value: Any,
+    *,
+    source_model: type[BaseModel],
+    target_model: type[BaseModel],
+    owner: SchemaFamily[Any],
+    nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
+    field_path: tuple[str, ...],
+    used_nested: set[tuple[str, ...]],
+    version: str,
+) -> BaseModel:
+    if not isinstance(value, source_model):
+        _raise_unsupported(owner, "a projected wrapper default changed type unexpectedly")
+
+    projected: dict[str, Any] = {}
+    for name, source_field in source_model.model_fields.items():
+        if name not in value.__dict__:
+            continue
+        target_field = target_model.model_fields.get(name)
+        if target_field is None:
+            continue
+        projected[name] = _project_nested_default_member(
+            value.__dict__[name],
+            original_annotation=source_field.annotation,
+            version_annotation=target_field.annotation,
+            owner=owner,
+            nested=nested,
+            decorator_nested=decorator_nested,
+            field_path=(*field_path, name),
+            used_nested=used_nested,
             version=version,
         )
+
+    factory_fields = sorted(
+        name
+        for name, field_info in target_model.model_fields.items()
+        if name not in projected and field_info.default_factory is not None
+    )
+    if factory_fields:
+        _raise_unsupported(
+            owner,
+            "a projected wrapper default would execute default factories during "
+            f"compilation: {', '.join(factory_fields)}",
+        )
+    target_fields = set(target_model.model_fields)
+    fields_set = {name for name in value.model_fields_set if name in target_fields}
+    return target_model.model_construct(_fields_set=fields_set, **projected)
+
+
+def _project_nested_default_member(
+    value: Any,
+    *,
+    original_annotation: Any,
+    version_annotation: Any,
+    owner: SchemaFamily[Any],
+    nested: tuple[_CompiledNestedFamily, ...],
+    decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
+    field_path: tuple[str, ...],
+    used_nested: set[tuple[str, ...]],
+    version: str,
+) -> Any:
+    original = original_annotation
+    while get_origin(original) is Annotated:
+        original = get_args(original)[0]
+    target = version_annotation
+    while get_origin(target) is Annotated:
+        target = get_args(target)[0]
+    if value is None:
+        return None
+
+    source_model = _default_model_annotation(original)
+    target_model = _default_model_annotation(target)
+    declaration = _find_nested_family_for_path(nested, field_path)
+    if declaration is not None and source_model is not None:
+        used_nested.add(declaration.path)
+        target_label = declaration.child_label(version)
+        return _project_child_default_value(
+            value,
+            source_model=source_model,
+            target_model=(
+                target_model
+                if target_model is not None
+                else declaration.family.model_for(target_label)
+            ),
+            child=declaration.family,
+            owner=owner,
+            version=target_label,
+        )
+    decorator_child = _find_decorator_family_for_model(
+        decorator_nested,
+        field_path,
+        source_model,
+    )
+    if decorator_child is not None and source_model is not None:
+        target_label = decorator_child.child_label(version)
+        return _project_child_default_value(
+            value,
+            source_model=source_model,
+            target_model=(
+                target_model
+                if target_model is not None
+                else decorator_child.family.model_for(target_label)
+            ),
+            child=decorator_child.family,
+            owner=owner,
+            version=target_label,
+        )
+    if source_model is not None and target_model is not None and source_model is not target_model:
+        return _project_nested_model_default_value(
+            value,
+            source_model=source_model,
+            target_model=target_model,
+            owner=owner,
+            nested=nested,
+            decorator_nested=decorator_nested,
+            field_path=field_path,
+            used_nested=used_nested,
+            version=version,
+        )
+
+    original_origin = get_origin(original)
+    target_origin = get_origin(target)
+    if original_origin in (Union, UnionType) and target_origin in (Union, UnionType):
+        original_arguments = get_args(original)
+        target_arguments = get_args(target)
+        selected = _default_union_ordinal(value, original_arguments)
+        if selected is None or selected >= len(target_arguments):
+            _raise_unsupported(owner, "a projected nested default has an ambiguous union arm")
+        assert selected is not None
+        return _project_nested_default_member(
+            value,
+            original_annotation=original_arguments[selected],
+            version_annotation=target_arguments[selected],
+            owner=owner,
+            nested=nested,
+            decorator_nested=decorator_nested,
+            field_path=field_path,
+            used_nested=used_nested,
+            version=version,
+        )
+    if original_origin in (list, set, frozenset) and target_origin is original_origin:
+        source_item = get_args(original)[0]
+        target_item = get_args(target)[0]
+        items = [
+            _project_nested_default_member(
+                item,
+                original_annotation=source_item,
+                version_annotation=target_item,
+                owner=owner,
+                nested=nested,
+                decorator_nested=decorator_nested,
+                field_path=field_path,
+                used_nested=used_nested,
+                version=version,
+            )
+            for item in value
+        ]
+        return original_origin(items)
+    if original_origin is tuple and target_origin is tuple:
+        source_arguments = get_args(original)
+        target_arguments = get_args(target)
+        if len(source_arguments) == 2 and source_arguments[1] is Ellipsis:
+            source_arguments = (source_arguments[0],) * len(value)
+            target_arguments = (target_arguments[0],) * len(value)
+        return tuple(
+            _project_nested_default_member(
+                item,
+                original_annotation=source_item,
+                version_annotation=target_item,
+                owner=owner,
+                nested=nested,
+                decorator_nested=decorator_nested,
+                field_path=field_path,
+                used_nested=used_nested,
+                version=version,
+            )
+            for item, source_item, target_item in zip(
+                value,
+                source_arguments,
+                target_arguments,
+                strict=True,
+            )
+        )
+    if original_origin is dict and target_origin is dict:
+        source_arguments = get_args(original)
+        target_arguments = get_args(target)
+        return {
+            key: _project_nested_default_member(
+                item,
+                original_annotation=source_arguments[1],
+                version_annotation=target_arguments[1],
+                owner=owner,
+                nested=nested,
+                decorator_nested=decorator_nested,
+                field_path=field_path,
+                used_nested=used_nested,
+                version=version,
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _default_union_ordinal(value: Any, arguments: tuple[Any, ...]) -> int | None:
+    for ordinal, argument in enumerate(arguments):
+        candidate = argument
+        while get_origin(candidate) is Annotated:
+            candidate = get_args(candidate)[0]
+        if isinstance(candidate, type) and type(value) is candidate:
+            return ordinal
+    matches: list[int] = []
+    for ordinal, argument in enumerate(arguments):
+        candidate = argument
+        while get_origin(candidate) is Annotated:
+            candidate = get_args(candidate)[0]
+        origin = get_origin(candidate)
+        runtime_type = origin if isinstance(origin, type) else candidate
+        if isinstance(runtime_type, type) and isinstance(value, runtime_type):
+            matches.append(ordinal)
+    return matches[0] if len(matches) == 1 else None
 
 
 def _project_child_default_value(
@@ -1879,17 +2632,19 @@ def _project_child_default_value(
     if not isinstance(value, source_model):  # pragma: no cover - narrowed by the caller
         _raise_unsupported(owner, "a projected nested default changed type unexpectedly")
     fields_set = value.model_fields_set
-    extra = value.__pydantic_extra__ or {}
     payload = {
-        name: value.__dict__[name] if name in value.__dict__ else extra[name]
+        name: value.__dict__[name]
         for name in fields_set
-        if name in value.__dict__ or name in extra
+        if name in source_model.model_fields and name in value.__dict__
     }
 
     from pydantic_versions._runtime import _remove_version_field, _to_version_names
 
     target_version = child._compiled_family().version(version)
     projected = _to_version_names(target_version, payload)
+    projected = {
+        name: item for name, item in projected.items() if name in target_model.model_fields
+    }
     safe_factory_fields: set[str] = set()
     metadata = child.version_metadata
     if metadata is not None and metadata.owner == "model":

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -16,7 +16,7 @@ from pydantic_versions._compiler import (
     _validate_family_declarations,
     _validate_required_field_introductions,
 )
-from pydantic_versions._planning import _build_planning_catalog
+from pydantic_versions._planning import _build_planning_catalog, _schema_path
 from pydantic_versions._runtime import (
     _dump_family,
     _runtime_label,
@@ -24,6 +24,7 @@ from pydantic_versions._runtime import (
 )
 from pydantic_versions._wire import (
     _build_model_for_projection,
+    _compile_decorator_nested_families,
     _validate_automatic_wire_model,
 )
 from pydantic_versions.declarations import (
@@ -146,6 +147,7 @@ class SchemaFamily[T: BaseModel]:
                     nested=self.nested,
                 )
                 _validate_automatic_wire_model(self)
+                decorator_nested = _compile_decorator_nested_families(self, nested)
                 projections = tuple(
                     _compile_projection(self.model, declaration) for declaration in self.versions
                 )
@@ -163,6 +165,7 @@ class SchemaFamily[T: BaseModel]:
                             projection,
                             declaration.wire_model,
                             nested=nested,
+                            decorator_nested=decorator_nested,
                         ),
                         wire_model_kind=(
                             "current"
@@ -193,6 +196,7 @@ class SchemaFamily[T: BaseModel]:
                     compiled_versions,
                     compiled_transitions,
                     nested,
+                    decorator_nested,
                 )
                 self._compiled = _CompiledFamily(
                     model=self.model,
@@ -203,6 +207,7 @@ class SchemaFamily[T: BaseModel]:
                     missing_version=self.missing_version,
                     catalog=catalog,
                     nested=nested,
+                    decorator_nested=decorator_nested,
                 )
             finally:
                 self._compiling = False
@@ -237,14 +242,28 @@ class SchemaFamily[T: BaseModel]:
             blocked = next(step for step in candidate.steps if step.semantics == "unavailable")
             if blocked.kind == "nested":
                 nested = next(
-                    description
-                    for description in compiled.catalog.inventory.nested
-                    if description.schema_path == blocked.schema_path
+                    (
+                        description
+                        for description in compiled.catalog.inventory.nested
+                        if description.schema_path == blocked.schema_path
+                    ),
+                    None,
                 )
+                if nested is None:
+                    decorator_names = tuple(
+                        dict.fromkeys(
+                            route.family.name
+                            for route in compiled.decorator_nested
+                            if _schema_path(route.path) == blocked.schema_path
+                        )
+                    )
+                    nested_name = " | ".join(decorator_names)
+                else:
+                    nested_name = nested.family
                 msg = (
                     f"Schema family {self.name!r} cannot render "
                     f"{candidate.source_version!r} -> {candidate.target_version!r}: "
-                    f"nested family {nested.family!r} at path {blocked.schema_path!r} "
+                    f"nested family {nested_name!r} at path {blocked.schema_path!r} "
                     f"has no complete route {blocked.source_version!r} -> "
                     f"{blocked.target_version!r}"
                 )

--- a/tests/unit/test_decorator_nested_boundaries.py
+++ b/tests/unit/test_decorator_nested_boundaries.py
@@ -1,0 +1,1211 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from pydantic_versions import (
+    InvalidMigrationError,
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    SchemaVersionError,
+    UnsupportedWireModelError,
+    VersionTransition,
+    dump_versioned,
+    field_renamed,
+    matching_labels,
+    model_for_version,
+    schema_version,
+    validate_versioned,
+    versioned_schema,
+)
+
+
+def test_decorator_child_uses_its_historical_wire_projection() -> None:
+    @versioned_schema(name="auto_direct_child", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        value: int
+
+    @versioned_schema(name="auto_direct_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        child: Child
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(child=Child(value=7)),
+    )
+
+    assert rendered == {
+        "child": {"legacy_value": 7, "schema_version": "1"},
+        "schema_version": "1",
+    }
+    validated = validate_versioned(Parent, rendered)
+    assert validated.current_model == Parent(child=Child(value=7))
+
+
+def test_overlapping_union_preserves_authoritative_typed_branch() -> None:
+    calls: list[str] = []
+
+    def a_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        calls.append("a1")
+        return {**data, "value": f"{data['value']}:a1"}
+
+    def a_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        calls.append("a2")
+        return {**data, "value": f"{data['value']}:a2"}
+
+    def b_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        calls.append("b1")
+        return {**data, "value": f"{data['value']}:b1"}
+
+    def b_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        calls.append("b2")
+        return {**data, "value": f"{data['value']}:b2"}
+
+    @versioned_schema(
+        name="overlap_a",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=a_to_one, downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=a_to_two, downgrade_semantics="exact"),
+        ),
+    )
+    class A(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="overlap_b",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=b_to_one, downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=b_to_two, downgrade_semantics="exact"),
+        ),
+    )
+    class B(BaseModel):
+        value: str
+
+    def reverse_items(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "items": list(reversed(data["items"]))}
+
+    @versioned_schema(
+        name="overlap_parent",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=lambda data: data,
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                downgrade=reverse_items,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    class Parent(BaseModel):
+        items: list[A | B]
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(items=[A(value="first"), B(value="second")]),
+    )
+
+    assert rendered["items"] == [
+        {"value": "second:b2:b1", "schema_version": "1"},
+        {"value": "first:a2:a1", "schema_version": "1"},
+    ]
+    assert calls == ["a2", "b2", "a1", "b1"]
+
+
+def test_decorator_children_traverse_builtin_containers_and_wrappers() -> None:
+    @versioned_schema(name="shape_child", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class Wrapper(BaseModel):
+        child: Child
+
+    @versioned_schema(name="shape_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        direct: Child
+        listed: list[Child]
+        variadic: tuple[Child, ...]
+        fixed: tuple[Child, Child]
+        mapped: dict[str, Child]
+        wrapped: Wrapper
+        deep: list[dict[str, Wrapper]]
+        set_values: set[Child]
+        frozen_values: frozenset[Child]
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(
+            direct=Child(value=1),
+            listed=[Child(value=2)],
+            variadic=(Child(value=3),),
+            fixed=(Child(value=4), Child(value=5)),
+            mapped={"key": Child(value=6)},
+            wrapped=Wrapper(child=Child(value=7)),
+            deep=[{"key": Wrapper(child=Child(value=8))}],
+            set_values={Child(value=9)},
+            frozen_values=frozenset({Child(value=10)}),
+        ),
+    )
+
+    assert rendered["direct"]["legacy_value"] == 1
+    assert rendered["listed"][0]["legacy_value"] == 2
+    assert rendered["variadic"][0]["legacy_value"] == 3
+    assert [item["legacy_value"] for item in rendered["fixed"]] == [4, 5]
+    assert rendered["mapped"]["key"]["legacy_value"] == 6
+    assert rendered["wrapped"]["child"]["legacy_value"] == 7
+    assert rendered["deep"][0]["key"]["child"]["legacy_value"] == 8
+    assert rendered["set_values"][0]["legacy_value"] == 9
+    assert rendered["frozen_values"][0]["legacy_value"] == 10
+    assert validate_versioned(Parent, rendered).current_model.direct.value == 1
+
+
+def test_discriminated_union_preflights_stale_metadata_and_runs_validator_once() -> None:
+    events: list[str] = []
+    transitions: list[str] = []
+
+    @versioned_schema(name="tagged_a", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class A(BaseModel):
+        kind: Literal["a"] = "a"
+        value: int
+
+    @versioned_schema(name="tagged_b", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class B(BaseModel):
+        kind: Literal["b"] = "b"
+        value: int
+
+        @field_validator("value")
+        @classmethod
+        def record_validation(cls, value: int) -> int:
+            events.append("b")
+            return value
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        transitions.append("parent")
+        return data
+
+    @versioned_schema(
+        name="tagged_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(VersionTransition("1", "2", upgrade=upgrade),),
+    )
+    class Parent(BaseModel):
+        item: A | B = Field(discriminator="kind")
+
+    stale = {
+        "schema_version": "1",
+        "item": {
+            "schema_version": "2",
+            "kind": "b",
+            "legacy_value": 7,
+        },
+    }
+    with pytest.raises(SchemaVersionError, match="payload declares '2'"):
+        validate_versioned(Parent, stale)
+    assert transitions == []
+    assert events == []
+
+    result = validate_versioned(
+        Parent,
+        {
+            "schema_version": "1",
+            "item": {
+                "schema_version": "1",
+                "kind": "b",
+                "legacy_value": 7,
+            },
+        },
+    )
+    assert isinstance(result.current_model.item, B)
+    assert result.current_model.item.value == 7
+    assert events == ["b"]
+    assert transitions == ["parent"]
+
+
+def test_overlapping_union_rejects_ambiguous_raw_copies_before_next_callback() -> None:
+    probes: list[str] = []
+
+    @versioned_schema(name="copied_a", versions=("1", "2", "3"), current="3")
+    class A(BaseModel):
+        value: int
+
+    @versioned_schema(name="copied_b", versions=("1", "2", "3"), current="3")
+    class B(BaseModel):
+        value: int
+
+    def copy_children(data: dict[str, Any]) -> dict[str, Any]:
+        probes.append("copy")
+        return {**data, "items": [dict(item) for item in data["items"]]}
+
+    def must_not_run(data: dict[str, Any]) -> dict[str, Any]:
+        probes.append("later")
+        return data
+
+    @versioned_schema(
+        name="copied_parent",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", upgrade=copy_children),
+            VersionTransition("2", "3", upgrade=must_not_run),
+        ),
+    )
+    class Parent(BaseModel):
+        items: list[A | B]
+
+    source = model_for_version(Parent, "1").model_validate(
+        {
+            "items": [
+                model_for_version(A, "1").model_validate({"value": 1}),
+                model_for_version(B, "1").model_validate({"value": 2}),
+            ]
+        }
+    )
+
+    with pytest.raises(InvalidMigrationError, match="ambiguous raw mappings"):
+        validate_versioned(Parent, source, version="1")
+    assert probes == ["copy"]
+
+
+def test_historical_overlapping_union_materializes_the_authoritative_current_branch_once() -> None:
+    events: list[str] = []
+
+    def upgrade_a(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:a"}
+
+    def upgrade_b(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:b"}
+
+    @versioned_schema(
+        name="materialized_a",
+        versions=("1", "2"),
+        current="2",
+        transitions=(VersionTransition("1", "2", upgrade=upgrade_a),),
+    )
+    class A(BaseModel):
+        value: str
+
+        @field_validator("value")
+        @classmethod
+        def count_a(cls, value: str) -> str:
+            events.append("a")
+            return value
+
+    @versioned_schema(
+        name="materialized_b",
+        versions=("1", "2"),
+        current="2",
+        transitions=(VersionTransition("1", "2", upgrade=upgrade_b),),
+    )
+    class B(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: str
+
+        @field_validator("value")
+        @classmethod
+        def count_b(cls, value: str) -> str:
+            events.append("b")
+            return value
+
+    @versioned_schema(name="materialized_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        item: A | B
+
+    historical_b = model_for_version(B, "1").model_validate({"value": "x"})
+    historical_parent = model_for_version(Parent, "1").model_validate({"item": historical_b})
+    result = validate_versioned(Parent, historical_parent, version="1")
+
+    assert type(result.current_model.item) is B
+    assert result.current_model.item.value == "x:b"
+    assert events == ["b"]
+
+
+def test_single_family_raw_duplication_raises_typed_cardinality_error() -> None:
+    @versioned_schema(name="duplicated_single_child", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        value: int
+
+    def duplicate(data: dict[str, Any]) -> dict[str, Any]:
+        item = data["items"][0]
+        return {**data, "items": [dict(item), dict(item)]}
+
+    @versioned_schema(
+        name="duplicated_single_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=duplicate, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        items: list[Child]
+
+    with pytest.raises(InvalidMigrationError, match="one-to-one"):
+        dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(items=[Child(value=1)]),
+        )
+
+
+def test_parent_callback_cannot_move_occurrence_identity_across_dispatch_sites() -> None:
+    def mark(suffix: str):
+        def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+            return {**data, "value": f"{data['value']}:{suffix}"}
+
+        return downgrade
+
+    @versioned_schema(
+        name="cross_site_a",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=mark("a1"), downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=mark("a2"), downgrade_semantics="exact"),
+        ),
+    )
+    class A(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="cross_site_b",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=mark("b1"), downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=mark("b2"), downgrade_semantics="exact"),
+        ),
+    )
+    class B(BaseModel):
+        value: str
+
+    def swap(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "left": data["right"], "right": data["left"]}
+
+    @versioned_schema(
+        name="cross_site_parent",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=lambda data: data, downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=swap, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        left: A
+        right: B
+
+    with pytest.raises(InvalidMigrationError, match="across dispatch sites"):
+        dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(left=A(value="left"), right=B(value="right")),
+        )
+
+
+def test_exact_typed_replacement_on_final_parent_edge_is_fully_downgraded() -> None:
+    def downgrade_b(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:b1"}
+
+    @versioned_schema(name="replace_a", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_a"),))
+    class A(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="replace_b",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=downgrade_b,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    @schema_version("1", patches=(field_renamed("value", "legacy_b"),))
+    class B(BaseModel):
+        value: str
+
+    def replace_with_typed_b(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "item": B(value="replacement")}
+
+    @versioned_schema(
+        name="replace_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=replace_with_typed_b,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    class Parent(BaseModel):
+        item: A | B
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(item=A(value="original")),
+    )
+
+    assert rendered["item"] == {
+        "legacy_b": "replacement:b1",
+        "schema_version": "1",
+    }
+
+
+def test_mapping_keys_anchor_copied_overlapping_union_values() -> None:
+    def a_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:a1"}
+
+    def a_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:a2"}
+
+    def b_to_one(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:b1"}
+
+    def b_to_two(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:b2"}
+
+    @versioned_schema(
+        name="mapped_a",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=a_to_one, downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=a_to_two, downgrade_semantics="exact"),
+        ),
+    )
+    class MappedA(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="mapped_b",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=b_to_one, downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=b_to_two, downgrade_semantics="exact"),
+        ),
+    )
+    class MappedB(BaseModel):
+        value: str
+
+    def copy_values(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "items": {key: dict(value) for key, value in data["items"].items()}}
+
+    @versioned_schema(
+        name="mapped_union_parent",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=lambda data: data,
+                downgrade_semantics="exact",
+            ),
+            VersionTransition(
+                "2",
+                "3",
+                downgrade=copy_values,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    class Parent(BaseModel):
+        items: dict[str, MappedA | MappedB]
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(
+            items={
+                "a": MappedA(value="first"),
+                "b": MappedB(value="second"),
+            }
+        ),
+    )
+
+    assert rendered["items"]["a"]["value"] == "first:a2:a1"
+    assert rendered["items"]["b"]["value"] == "second:b2:b1"
+
+
+def test_mapping_keys_do_not_anchor_beneath_a_reordered_dynamic_parent() -> None:
+    def mark(suffix: str):
+        def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+            return {**data, "value": f"{data['value']}:{suffix}"}
+
+        return downgrade
+
+    @versioned_schema(
+        name="dynamic_anchor_a",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=mark("a1"), downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=mark("a2"), downgrade_semantics="exact"),
+        ),
+    )
+    class A(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="dynamic_anchor_b",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=mark("b1"), downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=mark("b2"), downgrade_semantics="exact"),
+        ),
+    )
+    class B(BaseModel):
+        value: str
+
+    def reorder_copies(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **data,
+            "items": [
+                {key: dict(value) for key, value in group.items()}
+                for group in reversed(data["items"])
+            ],
+        }
+
+    @versioned_schema(
+        name="dynamic_anchor_parent",
+        versions=("1", "2", "3"),
+        current="3",
+        transitions=(
+            VersionTransition("1", "2", downgrade=lambda data: data, downgrade_semantics="exact"),
+            VersionTransition("2", "3", downgrade=reorder_copies, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        items: list[dict[str, A | B]]
+
+    with pytest.raises(InvalidMigrationError, match="ambiguous raw mappings"):
+        dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(
+                items=[
+                    {"x": A(value="first")},
+                    {"x": B(value="second")},
+                ]
+            ),
+        )
+
+
+def test_decorator_set_projection_rejects_target_cardinality_collapse() -> None:
+    def collapse(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": 0}
+
+    @versioned_schema(
+        name="collapse_child",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=collapse,
+                downgrade_semantics="lossy",
+            ),
+        ),
+    )
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    @versioned_schema(name="collapse_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        children: set[Child]
+
+    with pytest.raises(InvalidMigrationError, match="set cardinality"):
+        dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(children={Child(value=1), Child(value=2)}),
+        )
+
+
+def test_decorator_boundaries_recurse_across_decorated_families() -> None:
+    @versioned_schema(name="recursive_grandchild", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Grandchild(BaseModel):
+        value: int
+
+    @versioned_schema(name="recursive_child", versions=("1", "2"), current="2")
+    @schema_version(
+        "1",
+        patches=(field_renamed("grandchildren", "old_grandchildren"),),
+    )
+    class Child(BaseModel):
+        grandchildren: list[Grandchild]
+
+    @versioned_schema(name="recursive_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        child: Child
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(child=Child(grandchildren=[Grandchild(value=11)])),
+    )
+
+    assert rendered["child"]["old_grandchildren"] == [{"legacy_value": 11, "schema_version": "1"}]
+    assert validate_versioned(Parent, rendered).current_model.child.grandchildren[0].value == 11
+
+
+def test_decorator_children_project_wrapper_defaults_without_running_opaque_factories() -> None:
+    @versioned_schema(name="wrapper_default_child", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 7
+
+    class InstanceWrapper(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        child: Child = Child()
+
+    @versioned_schema(
+        name="wrapper_instance_default_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class InstanceParent(BaseModel):
+        wrapper: InstanceWrapper = InstanceWrapper(secret="must-not-cross-wire")
+
+    class FactoryWrapper(BaseModel):
+        child: Child = Field(default_factory=Child)
+
+    @versioned_schema(
+        name="wrapper_factory_default_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class FactoryParent(BaseModel):
+        wrapper: FactoryWrapper = Field(default_factory=FactoryWrapper)
+
+    expected = {
+        "wrapper": {"child": {"legacy_value": 7, "schema_version": "1"}},
+        "schema_version": "1",
+    }
+    assert model_for_version(InstanceParent, "1")().model_dump() == expected
+    assert dump_versioned(InstanceParent, version="1") == expected
+    assert model_for_version(FactoryParent, "1")().model_dump() == expected
+    assert dump_versioned(FactoryParent, version="1") == expected
+
+    @versioned_schema(
+        name="direct_extra_default_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class DirectExtraParent(BaseModel):
+        child: Child = Child(secret="must-not-cross-wire")
+
+    direct_expected = {
+        "child": {"legacy_value": 7, "schema_version": "1"},
+        "schema_version": "1",
+    }
+    assert model_for_version(DirectExtraParent, "1")().model_dump() == direct_expected
+    assert dump_versioned(DirectExtraParent, version="1") == direct_expected
+
+
+def test_decorator_children_project_defaults_through_every_builtin_shape() -> None:
+    @versioned_schema(name="container_default_child", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class Wrapper(BaseModel):
+        child: Child
+
+    @versioned_schema(
+        name="container_default_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        listed: list[Child] = [Child(value=1)]
+        variadic: tuple[Child, ...] = (Child(value=2),)
+        fixed: tuple[Child, str] = (Child(value=3), "fixed")
+        mapped: dict[str, Child] = {"x": Child(value=4)}
+        optional: Child | None = Child(value=5)
+        setted: set[Child] = {Child(value=6)}
+        frozen: frozenset[Child] = frozenset({Child(value=7)})
+        deep: list[dict[str, Wrapper]] = [{"x": Wrapper(child=Child(value=8))}]
+
+    expected_values = {
+        "listed": [{"legacy_value": 1, "schema_version": "1"}],
+        "variadic": [{"legacy_value": 2, "schema_version": "1"}],
+        "fixed": [{"legacy_value": 3, "schema_version": "1"}, "fixed"],
+        "mapped": {"x": {"legacy_value": 4, "schema_version": "1"}},
+        "optional": {"legacy_value": 5, "schema_version": "1"},
+        "setted": [{"legacy_value": 6, "schema_version": "1"}],
+        "frozen": [{"legacy_value": 7, "schema_version": "1"}],
+        "deep": [{"x": {"child": {"legacy_value": 8, "schema_version": "1"}}}],
+        "schema_version": "1",
+    }
+    assert model_for_version(Parent, "1")().model_dump(mode="json") == expected_values
+    assert dump_versioned(Parent, version="1") == expected_values
+
+    factory_calls: list[str] = []
+
+    def opaque_children() -> list[Child]:
+        factory_calls.append("called")
+        return [Child(value=9)]
+
+    @versioned_schema(
+        name="opaque_container_default_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class OpaqueParent(BaseModel):
+        children: list[Child] = Field(default_factory=opaque_children)
+
+    with pytest.raises(UnsupportedWireModelError, match="opaque factory"):
+        model_for_version(OpaqueParent, "1")
+    assert factory_calls == []
+
+
+def test_parent_callback_can_introduce_exact_typed_decorator_branches() -> None:
+    def downgrade_child(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": f"{data['value']}:child"}
+
+    @versioned_schema(
+        name="introduced_typed_child",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=downgrade_child, downgrade_semantics="exact"),
+        ),
+    )
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        value: str
+
+    def introduce(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            **data,
+            "items": [
+                *data["items"],
+                Child(value="introduced"),
+            ],
+        }
+
+    @versioned_schema(
+        name="introduced_typed_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=introduce, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        items: list[int | Child]
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(items=[Child(value="existing"), 0]),
+    )
+
+    assert rendered == {
+        "items": [
+            {"legacy_value": "existing:child", "schema_version": "1"},
+            0,
+            {"legacy_value": "introduced:child", "schema_version": "1"},
+        ],
+        "schema_version": "1",
+    }
+
+
+def test_parent_callback_rejects_untyped_decorator_branch_introduction() -> None:
+    def downgrade_child(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 10}
+
+    @versioned_schema(
+        name="untyped_introduction_child",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=downgrade_child, downgrade_semantics="exact"),
+        ),
+    )
+    class Child(BaseModel):
+        value: int
+
+    def introduce_raw(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "item": {"value": 9}}
+
+    @versioned_schema(
+        name="untyped_introduction_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=introduce_raw, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        item: int | Child
+
+    with pytest.raises(InvalidMigrationError, match="untyped decorator nested mapping"):
+        dump_versioned(Parent, version="1", data=Parent(item=0))
+
+
+def test_parent_callback_rejects_reused_exact_typed_introductions() -> None:
+    @versioned_schema(name="reused_introduction_child", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        value: int
+
+    def introduce_reused(data: dict[str, Any]) -> dict[str, Any]:
+        child = Child(value=9)
+        return {**data, "items": [child, child]}
+
+    @versioned_schema(
+        name="reused_introduction_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=introduce_reused, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        items: list[int | Child]
+
+    with pytest.raises(InvalidMigrationError, match="reused one decorator nested occurrence"):
+        dump_versioned(Parent, version="1", data=Parent(items=[0, 1]))
+
+
+def test_exact_typed_owner_replacement_rebinds_its_recursive_subtree() -> None:
+    def mark_b(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 10}
+
+    @versioned_schema(name="replacement_grand_a", versions=("1", "2"), current="2")
+    class GrandA(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="replacement_grand_b",
+        versions=("1", "2"),
+        current="2",
+        transitions=(VersionTransition("1", "2", downgrade=mark_b, downgrade_semantics="exact"),),
+    )
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class GrandB(BaseModel):
+        value: int
+
+    @versioned_schema(name="replacement_owner_a", versions=("1", "2"), current="2")
+    class A(BaseModel):
+        grand: GrandA
+
+    @versioned_schema(name="replacement_owner_b", versions=("1", "2"), current="2")
+    class B(BaseModel):
+        grand: GrandB
+
+    def replace_owner(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "item": B(grand=GrandB(value=2))}
+
+    @versioned_schema(
+        name="replacement_recursive_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=replace_owner, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        item: A | B
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(item=A(grand=GrandA(value=1))),
+    )
+
+    assert rendered == {
+        "item": {
+            "grand": {"legacy_value": 12, "schema_version": "1"},
+            "schema_version": "1",
+        },
+        "schema_version": "1",
+    }
+
+
+def test_recursive_decorator_set_cardinality_is_checked_after_target_coercion() -> None:
+    def collapse_by_coercion(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": "1" if data["value"] == 1 else 1}
+
+    @versioned_schema(
+        name="recursive_collapse_grand",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1", "2", downgrade=collapse_by_coercion, downgrade_semantics="lossy"
+            ),
+        ),
+    )
+    class Grand(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    @versioned_schema(name="recursive_collapse_child", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        grandchildren: set[Grand]
+
+    @versioned_schema(name="recursive_collapse_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        child: Child
+
+    with pytest.raises(InvalidMigrationError, match="set cardinality"):
+        dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(child=Child(grandchildren={Grand(value=1), Grand(value=2)})),
+        )
+
+
+def test_parent_callback_rejects_non_string_decorator_mapping_keys() -> None:
+    @versioned_schema(name="non_string_key_child", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        value: str
+
+    def inject_numeric_key(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "children": {1: {"value": "new"}}}
+
+    @versioned_schema(
+        name="non_string_key_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition("1", "2", downgrade=inject_numeric_key, downgrade_semantics="exact"),
+        ),
+    )
+    class Parent(BaseModel):
+        model_config = ConfigDict(coerce_numbers_to_str=True)
+
+        children: dict[str, Child]
+
+    with pytest.raises(InvalidMigrationError, match="non-string"):
+        dump_versioned(Parent, version="1", data=Parent(children={}))
+
+
+def test_decorator_to_explicit_set_cardinality_recurses_after_target_coercion() -> None:
+    class Grand(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int | str
+
+    class GrandV1(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    grand_family = SchemaFamily(
+        model=Grand,
+        name="decorator_explicit_grand",
+        versions=(SchemaVersion("1", wire_model=GrandV1), SchemaVersion("2")),
+    )
+
+    @versioned_schema(
+        name="decorator_explicit_child",
+        versions=("1", "2"),
+        current="2",
+        nested=(NestedFamily("grandchildren", grand_family, matching_labels()),),
+    )
+    class Child(BaseModel):
+        grandchildren: set[Grand]
+
+    @versioned_schema(name="decorator_explicit_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        child: Child
+
+    with pytest.raises(InvalidMigrationError, match="set cardinality"):
+        dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(
+                child=Child(
+                    grandchildren={Grand(value=1), Grand(value="1")},
+                )
+            ),
+        )
+
+
+def test_decorator_to_explicit_nested_family_round_trips_historical_names() -> None:
+    def upgrade_grand(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 10}
+
+    def downgrade_grand(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] - 10}
+
+    class Grand(BaseModel):
+        value: int
+
+    grand_family = SchemaFamily(
+        model=Grand,
+        name="decorator_explicit_roundtrip_grand",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("value", "legacy_value"),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=upgrade_grand,
+                downgrade=downgrade_grand,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    @versioned_schema(
+        name="decorator_explicit_roundtrip_child",
+        versions=("1", "2"),
+        current="2",
+        nested=(NestedFamily("grand", grand_family, matching_labels()),),
+    )
+    class Child(BaseModel):
+        grand: Grand
+
+    @versioned_schema(
+        name="decorator_explicit_roundtrip_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        child: Child
+
+    current = Parent(child=Child(grand=Grand(value=11)))
+    rendered = dump_versioned(Parent, version="1", data=current)
+
+    assert rendered == {
+        "child": {
+            "grand": {"legacy_value": 1, "schema_version": "1"},
+            "schema_version": "1",
+        },
+        "schema_version": "1",
+    }
+    assert validate_versioned(Parent, rendered).current_model == current
+
+
+def test_recursive_union_stale_metadata_fails_before_validation_or_callbacks() -> None:
+    events: list[str] = []
+
+    @versioned_schema(name="stale_recursive_grand_a", versions=("1", "2"), current="2")
+    class GrandA(BaseModel):
+        value: int
+
+        @field_validator("value")
+        @classmethod
+        def count_grand_a(cls, value: int) -> int:
+            events.append("grand-a")
+            return value
+
+    @versioned_schema(name="stale_recursive_grand_b", versions=("1", "2"), current="2")
+    class GrandB(BaseModel):
+        value: int
+
+    @versioned_schema(name="stale_recursive_a", versions=("1", "2"), current="2")
+    class A(BaseModel):
+        grand: GrandA
+
+    @versioned_schema(name="stale_recursive_b", versions=("1", "2"), current="2")
+    class B(BaseModel):
+        grand: GrandB
+
+    @versioned_schema(name="stale_recursive_child", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        item: A | B
+
+    @versioned_schema(name="stale_recursive_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        child: Child
+
+    historical = {
+        "schema_version": "1",
+        "child": {
+            "schema_version": "1",
+            "item": {
+                "schema_version": "1",
+                "grand": {"schema_version": "2", "value": 1},
+            },
+        },
+    }
+    with pytest.raises(SchemaVersionError, match="declares '2'"):
+        validate_versioned(Parent, historical, version="1")
+
+    current = {
+        "schema_version": "2",
+        "child": {
+            "schema_version": "2",
+            "item": {
+                "schema_version": "2",
+                "grand": {"schema_version": "1", "value": 1},
+            },
+        },
+    }
+    with pytest.raises(SchemaVersionError, match="declares '1'"):
+        dump_versioned(Parent, version="1", data=current)
+    assert events == []
+
+
+def test_decorator_child_model_owned_metadata_round_trips() -> None:
+    @versioned_schema(name="model_metadata_child", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        schema_version: str = "2"
+        value: int
+
+    @versioned_schema(name="model_metadata_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        child: Child
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(child=Child(value=12)),
+    )
+
+    assert rendered["child"] == {"schema_version": "1", "legacy_value": 12}
+    result = validate_versioned(Parent, rendered)
+    assert result.current_model.child.schema_version == "2"
+    assert result.current_model.child.value == 12

--- a/tests/unit/test_decorator_nested_compilation.py
+++ b/tests/unit/test_decorator_nested_compilation.py
@@ -1,0 +1,700 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Generic, TypedDict, TypeVar
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field, RootModel, create_model, model_serializer
+
+from pydantic_versions import (
+    IrreversibleTransitionError,
+    NestedFamily,
+    SchemaCompilationError,
+    SchemaFamily,
+    SchemaVersion,
+    UnsupportedWireModelError,
+    VersionTransition,
+    dump_versioned,
+    field_renamed,
+    matching_labels,
+    model_for_version,
+    schema_version,
+    versioned_schema,
+)
+
+
+def _decorated_family(model: type[BaseModel]) -> SchemaFamily[Any]:
+    # The decorator's model-oriented public API deliberately hides its default family;
+    # unit-level planning assertions need the exact family that backs those public calls.
+    from pydantic_versions.family import _default_family_for_model
+
+    family = _default_family_for_model(model)
+    assert family is not None
+    return family
+
+
+def test_exact_explicit_nested_sibling_does_not_suppress_decorator_route() -> None:
+    @versioned_schema(
+        name="compilation_sibling_decorator_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class CompilationSiblingDecoratorChild77(BaseModel):
+        value: int
+
+    class CompilationSiblingExplicitChild77(BaseModel):
+        value: int
+
+    explicit_child = SchemaFamily(
+        model=CompilationSiblingExplicitChild77,
+        name="compilation_sibling_explicit_child_77",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_renamed("value", "legacy_explicit_value"),),
+            ),
+            SchemaVersion("2"),
+        ),
+    )
+
+    class CompilationSiblingWrapper77(BaseModel):
+        decorator_child: CompilationSiblingDecoratorChild77
+        explicit_child: CompilationSiblingExplicitChild77
+
+    @versioned_schema(
+        name="compilation_sibling_parent_77",
+        versions=("1", "2"),
+        current="2",
+        nested=(
+            NestedFamily(
+                ("wrapper", "explicit_child"),
+                explicit_child,
+                matching_labels(),
+            ),
+        ),
+    )
+    class CompilationSiblingParent77(BaseModel):
+        wrapper: CompilationSiblingWrapper77
+
+    model_for_version(CompilationSiblingParent77, "1")
+    family = _decorated_family(CompilationSiblingParent77)
+
+    assert tuple((nested.schema_path, nested.family) for nested in family.describe().nested) == (
+        ("$.wrapper.explicit_child", "compilation_sibling_explicit_child_77"),
+    )
+
+    plan = family.plan_validation("1")
+    repeated = family.plan_validation("1")
+    step_ids = tuple(step.id for step in plan.steps)
+    assert repeated is plan
+    assert tuple(step.id for step in repeated.steps) == step_ids
+    assert len(set(step_ids)) == len(step_ids)
+
+    decorator_index = next(
+        index
+        for index, step in enumerate(plan.steps)
+        if step.kind == "nested" and step.schema_path == "$.wrapper.decorator_child"
+    )
+    parent_index = next(
+        index
+        for index, step in enumerate(plan.steps)
+        if step.schema_path == "$"
+        and step.source_version == "1"
+        and step.target_version == "2"
+        and step.kind == "implicit_identity"
+    )
+    assert decorator_index < parent_index
+    decorator_step = plan.steps[decorator_index]
+    assert decorator_step.conditional is True
+    assert decorator_step.semantics == "not_applicable"
+    render_step = next(
+        step
+        for step in family.plan_render("1").steps
+        if step.kind == "nested" and step.schema_path == "$.wrapper.decorator_child"
+    )
+    assert render_step.conditional is True
+    assert render_step.semantics == "exact"
+
+    rendered = dump_versioned(
+        CompilationSiblingParent77,
+        version="1",
+        data=CompilationSiblingParent77(
+            wrapper=CompilationSiblingWrapper77(
+                decorator_child=CompilationSiblingDecoratorChild77(value=1),
+                explicit_child=CompilationSiblingExplicitChild77(value=2),
+            )
+        ),
+    )
+    assert rendered["wrapper"]["decorator_child"]["legacy_value"] == 1
+    assert rendered["wrapper"]["explicit_child"]["legacy_explicit_value"] == 2
+
+
+def test_builtin_string_key_dict_discovers_decorator_child() -> None:
+    @versioned_schema(
+        name="compilation_dict_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationDictChild77(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="compilation_dict_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationDictParent77(BaseModel):
+        children: dict[str, CompilationDictChild77]
+
+    model_for_version(CompilationDictParent77, "1")
+    plan = _decorated_family(CompilationDictParent77).plan_validation("1")
+
+    assert any(step.kind == "nested" and step.schema_path == "$.children" for step in plan.steps)
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation_factory", "message"),
+    (
+        (
+            "mapping",
+            lambda child: Mapping[str, child],
+            "unsupported abstract container collections.abc.Mapping",
+        ),
+        (
+            "sequence",
+            lambda child: Sequence[child],
+            "unsupported abstract container collections.abc.Sequence",
+        ),
+        (
+            "non_string_dict",
+            lambda child: dict[int, child],
+            "requires exact string mapping keys",
+        ),
+    ),
+)
+def test_unsupported_decorator_child_containers_fail_closed(
+    case: str,
+    annotation_factory: Any,
+    message: str,
+) -> None:
+    @versioned_schema(
+        name=f"compilation_unsupported_{case}_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationUnsupportedContainerChild77(BaseModel):
+        value: int
+
+    annotation = annotation_factory(CompilationUnsupportedContainerChild77)
+    parent = create_model(
+        f"CompilationUnsupported{case.title().replace('_', '')}Parent77",
+        children=(annotation, ...),
+    )
+    parent = versioned_schema(
+        name=f"compilation_unsupported_{case}_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )(parent)
+
+    with pytest.raises(SchemaCompilationError, match=message) as error:
+        model_for_version(parent, "1")
+
+    assert f"compilation_unsupported_{case}_parent_77" in str(error.value)
+    assert "('children',)" in str(error.value)
+
+
+def test_non_isomorphic_union_topology_fails_closed() -> None:
+    @versioned_schema(
+        name="compilation_union_topology_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationUnionTopologyChild77(BaseModel):
+        value: int
+
+    class CompilationUnionDirectWrapper77(BaseModel):
+        child: CompilationUnionTopologyChild77
+
+    class CompilationUnionListWrapper77(BaseModel):
+        child: list[CompilationUnionTopologyChild77]
+
+    @versioned_schema(
+        name="compilation_union_topology_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationUnionTopologyParent77(BaseModel):
+        payload: CompilationUnionDirectWrapper77 | CompilationUnionListWrapper77
+
+    with pytest.raises(
+        SchemaCompilationError,
+        match="non-isomorphic traversal shapes",
+    ) as error:
+        model_for_version(CompilationUnionTopologyParent77, "1")
+
+    assert "compilation_union_topology_parent_77" in str(error.value)
+    assert "('payload',)" in str(error.value)
+
+
+def test_recursive_wrapper_containing_decorator_child_fails_closed() -> None:
+    @versioned_schema(
+        name="compilation_recursive_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationRecursiveChild77(BaseModel):
+        value: int
+
+    class CompilationRecursiveWrapper77(BaseModel):
+        child: CompilationRecursiveChild77 | None = None
+        next_wrapper: CompilationRecursiveWrapper77 | None = None
+
+    CompilationRecursiveWrapper77.model_rebuild(
+        _types_namespace={
+            "CompilationRecursiveChild77": CompilationRecursiveChild77,
+            "CompilationRecursiveWrapper77": CompilationRecursiveWrapper77,
+        },
+    )
+
+    @versioned_schema(
+        name="compilation_recursive_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationRecursiveParent77(BaseModel):
+        wrapper: CompilationRecursiveWrapper77
+
+    with pytest.raises(
+        SchemaCompilationError,
+        match="decorator child beneath recursive model path",
+    ) as error:
+        model_for_version(CompilationRecursiveParent77, "1")
+
+    assert "compilation_recursive_parent_77" in str(error.value)
+    assert "next_wrapper" in str(error.value)
+
+
+def test_explicit_descendant_beneath_decorator_child_fails_closed() -> None:
+    class CompilationExplicitDescendantLeaf77(BaseModel):
+        value: int
+
+    leaf_family = SchemaFamily(
+        model=CompilationExplicitDescendantLeaf77,
+        name="compilation_explicit_descendant_leaf_77",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    @versioned_schema(
+        name="compilation_explicit_descendant_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationExplicitDescendantChild77(BaseModel):
+        leaf: CompilationExplicitDescendantLeaf77
+
+    @versioned_schema(
+        name="compilation_explicit_descendant_parent_77",
+        versions=("1", "2"),
+        current="2",
+        nested=(
+            NestedFamily(
+                ("child", "leaf"),
+                leaf_family,
+                matching_labels(),
+            ),
+        ),
+    )
+    class CompilationExplicitDescendantParent77(BaseModel):
+        child: CompilationExplicitDescendantChild77
+
+    with pytest.raises(
+        SchemaCompilationError,
+        match="descends beneath decorator child boundary",
+    ) as error:
+        model_for_version(CompilationExplicitDescendantParent77, "1")
+
+    assert "compilation_explicit_descendant_parent_77" in str(error.value)
+    assert "('child', 'leaf')" in str(error.value)
+
+
+def test_unavailable_decorator_child_downgrade_names_the_child_family() -> None:
+    @versioned_schema(
+        name="compilation_unavailable_child_77",
+        versions=("1", "2"),
+        current="2",
+        transitions=(VersionTransition("1", "2", upgrade=lambda data: data),),
+    )
+    class CompilationUnavailableChild77(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="compilation_unavailable_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class CompilationUnavailableParent77(BaseModel):
+        child: CompilationUnavailableChild77
+
+    with pytest.raises(IrreversibleTransitionError) as error:
+        dump_versioned(CompilationUnavailableParent77, version="1")
+
+    message = str(error.value)
+    assert "compilation_unavailable_child_77" in message
+    assert "$.child" in message
+    assert "has no complete route '2' -> '1'" in message
+
+
+def test_runtime_indistinguishable_container_union_arms_fail_compilation() -> None:
+    @versioned_schema(
+        name="ambiguous_container_union_a_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class A(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="ambiguous_container_union_b_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class B(BaseModel):
+        value: str
+
+    @versioned_schema(
+        name="ambiguous_container_union_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        items: list[A] | list[B]
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="runtime-indistinguishable container arms",
+    ):
+        model_for_version(Parent, "1")
+
+
+def test_abstract_and_concrete_container_union_arms_fail_compilation() -> None:
+    @versioned_schema(
+        name="overlapping_abstract_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Child(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="overlapping_mapping_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class MappingParent(BaseModel):
+        payload: Mapping[str, int] | dict[str, Child]
+
+    @versioned_schema(
+        name="overlapping_sequence_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class SequenceParent(BaseModel):
+        payload: Sequence[int] | list[Child]
+
+    @versioned_schema(
+        name="overlapping_raw_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class RawParent(BaseModel):
+        payload: list | list[Child]
+
+    @versioned_schema(
+        name="overlapping_object_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class ObjectParent(BaseModel):
+        payload: object | list[Child]
+
+    for parent in (MappingParent, SequenceParent, RawParent, ObjectParent):
+        with pytest.raises(
+            UnsupportedWireModelError,
+            match="runtime-indistinguishable container arms",
+        ):
+            model_for_version(parent, "1")
+
+
+def test_typed_dict_union_arm_fails_closed_without_builtin_type_error() -> None:
+    @versioned_schema(name="typed_dict_union_child_77", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        value: int
+
+    class Payload(TypedDict):
+        other: int
+
+    @versioned_schema(name="typed_dict_union_parent_77", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        payload: Child | Payload
+
+    with pytest.raises(UnsupportedWireModelError, match="TypedDict arm"):
+        model_for_version(Parent, "1")
+
+
+def test_unparameterized_generic_wrapper_with_decorator_bound_fails_closed() -> None:
+    @versioned_schema(
+        name="generic_bound_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Child(BaseModel):
+        value: int
+
+    child_type = TypeVar("child_type", bound=Child)
+
+    class Box(BaseModel, Generic[child_type]):
+        item: child_type
+
+    @versioned_schema(
+        name="generic_bound_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        box: Box
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="unresolved generic parameters",
+    ):
+        model_for_version(Parent, "1")
+
+
+def test_specialized_generic_wrapper_discovers_decorator_child() -> None:
+    @versioned_schema(
+        name="specialized_generic_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        value: int
+
+    child_type = TypeVar("child_type")
+
+    class Box(BaseModel, Generic[child_type]):
+        item: child_type
+
+    @versioned_schema(
+        name="specialized_generic_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        box: Box[Child]
+
+    assert dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(box=Box[Child](item=Child(value=4))),
+    ) == {
+        "box": {"item": {"legacy_value": 4, "schema_version": "1"}},
+        "schema_version": "1",
+    }
+
+
+def test_explicit_parent_rejects_child_with_remaining_decorator_routes() -> None:
+    @versioned_schema(name="explicit_auto_grand_77", versions=("1", "2"), current="2")
+    class Grand(BaseModel):
+        value: int
+
+    @versioned_schema(name="explicit_auto_child_77", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        grand: Grand
+
+    @versioned_schema(
+        name="explicit_auto_parent_77",
+        versions=("1", "2"),
+        current="2",
+        nested=(NestedFamily("child", _decorated_family(Child), matching_labels()),),
+    )
+    class Parent(BaseModel):
+        child: Child
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="still contains decorator-discovered nested routes",
+    ):
+        model_for_version(Parent, "1")
+
+
+def test_incomplete_ordinary_wrapper_fails_closed() -> None:
+    class Wrapper(BaseModel):
+        child: "Later"  # noqa: UP037
+
+    @versioned_schema(name="late_wrapper_child_77", versions=("1", "2"), current="2")
+    class Later(BaseModel):
+        value: int
+
+    @versioned_schema(name="late_wrapper_parent_77", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        wrapper: Wrapper
+
+    with pytest.raises(UnsupportedWireModelError, match=r"model_rebuild\(\)"):
+        model_for_version(Parent, "1")
+
+
+def test_unsafe_ordinary_wrapper_models_fail_closed() -> None:
+    @versioned_schema(name="unsafe_wrapper_child_77", versions=("1", "2"), current="2")
+    class Child(BaseModel):
+        value: int
+
+    class TypedExtraWrapper(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        __pydantic_extra__: dict[str, int] = Field(init=False)
+        child: Child
+
+    class RootWrapper(RootModel[Child]):
+        pass
+
+    class SerializedWrapper(BaseModel):
+        child: Child
+
+        @model_serializer
+        def serialize(self) -> dict[str, Any]:
+            return {"child": self.child}
+
+    wrappers = (TypedExtraWrapper, RootWrapper, SerializedWrapper)
+    matches = ("typed extra", "RootModel", "model-level serializer")
+    for ordinal, (wrapper, match) in enumerate(zip(wrappers, matches, strict=True)):
+        parent = create_model(
+            f"UnsafeWrapperParent{ordinal}",
+            __module__=__name__,
+            wrapper=(wrapper, ...),
+        )
+        decorated = versioned_schema(
+            name=f"unsafe_wrapper_parent_{ordinal}_77",
+            versions=("1", "2"),
+            current="2",
+        )(parent)
+        with pytest.raises(UnsupportedWireModelError, match=match):
+            model_for_version(decorated, "1")
+
+
+def test_unrelated_unsafe_wrappers_remain_supported_without_projection() -> None:
+    class RootPayload(RootModel[int]):
+        pass
+
+    class SerializedPayload(BaseModel):
+        value: int
+
+        @model_serializer
+        def serialize(self) -> dict[str, int]:
+            return {"serialized": self.value}
+
+    @versioned_schema(
+        name="unrelated_unsafe_wrapper_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        rooted: RootPayload
+        serialized: SerializedPayload
+
+    historical = model_for_version(Parent, "1")
+
+    assert historical.model_fields["rooted"].annotation is RootPayload
+    assert historical.model_fields["serialized"].annotation is SerializedPayload
+
+
+def test_optional_wrapper_siblings_compare_metadata_contracts_per_site() -> None:
+    @versioned_schema(name="mixed_metadata_family_child_77", versions=("1", "2"), current="2")
+    class FamilyChild(BaseModel):
+        value: int
+
+    @versioned_schema(name="mixed_metadata_model_child_77", versions=("1", "2"), current="2")
+    class ModelChild(BaseModel):
+        schema_version: str = "2"
+        value: int
+
+    class Wrapper(BaseModel):
+        family_child: FamilyChild
+        model_child: ModelChild
+
+    @versioned_schema(name="mixed_metadata_parent_77", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        wrapper: Wrapper | None
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(
+            wrapper=Wrapper(
+                family_child=FamilyChild(value=1),
+                model_child=ModelChild(value=2),
+            )
+        ),
+    )
+    assert rendered["wrapper"] == {
+        "family_child": {"value": 1, "schema_version": "1"},
+        "model_child": {"schema_version": "1", "value": 2},
+    }
+
+
+def _deterministic_decorator_family() -> SchemaFamily[Any]:
+    @versioned_schema(
+        name="deterministic_decorator_child_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class DeterministicDecoratorChild77(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="deterministic_decorator_parent_77",
+        versions=("1", "2"),
+        current="2",
+    )
+    class DeterministicDecoratorParent77(BaseModel):
+        children: list[dict[str, DeterministicDecoratorChild77]]
+
+    return _decorated_family(DeterministicDecoratorParent77)
+
+
+def test_decorator_plan_json_is_deterministic_across_processes() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    family = _deterministic_decorator_family()
+    local = json.dumps(
+        {
+            "validation": family.plan_validation("1").to_dict(),
+            "render": family.plan_render("1").to_dict(),
+        },
+        separators=(",", ":"),
+    )
+    script = (
+        "import json\n"
+        "from tests.unit.test_decorator_nested_compilation import "
+        "_deterministic_decorator_family\n"
+        "family = _deterministic_decorator_family()\n"
+        "print(json.dumps({"
+        "'validation': family.plan_validation('1').to_dict(),"
+        "'render': family.plan_render('1').to_dict(),"
+        "}, separators=(',', ':')))\n"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == local

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -1206,7 +1206,10 @@ def test_wire_decorator_child_label_mismatch() -> None:
 
     fam = _default_family_for_model(MismatchParent)
     assert fam is not None
-    with pytest.raises(UnsupportedWireModelError, match="could not be built safely"):
+    with pytest.raises(
+        SchemaCompilationError,
+        match="must use the exact labels.*declare an explicit nested mapping",
+    ):
         fam.model_for("v1")
 
 


### PR DESCRIPTION
## Summary

- Carry decorator-discovered child families through built-in containers, ordinary wrappers, recursive families, and recoverable union branches.
- Preserve authoritative branch and occurrence identity across child-before-parent migration, final materialization, metadata preflight, and target-wire projection.
- Add deterministic conditional planning steps without adding implicit routes to the explicit public nested inventory.
- Project defaults from declared fields only and reject opaque factories, unsafe wrappers, ambiguous unions, invalid runtime keys, and unprovable callback mutations.
- Fail compilation for explicit-to-implicit nesting composition, with guidance to make the child routes explicit.

## Safety and compatibility

- Wrong-family, cross-site, duplicated, reused, stale-metadata, and set-cardinality cases now fail closed with package exceptions.
- Validators remain on the authoritative boundary and run once under configured instance-revalidation policies.
- Decorator-to-explicit composition round-trips historical names; the inverse unsupported composition fails before validation or callbacks.
- The immutable 0.3.0 compatibility artifact remains unchanged.

## Validation

- uv run make ci: 414 passed; 90.80% coverage.
- uv run make docs-build-strict: passed with no issues.
- uv build: wheel and sdist built successfully.
- uv run python tests/compatibility/v0_3_0_contract.py --check: passed.
- Conventional Commit and diff checks passed.
- Two independent adversarial reviews replayed the saved regression set with no remaining blocker.

Closes #77