### PR TITLE
fix(rendering): enforce target wire contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,13 @@ APP_CONFIG_SCHEMA = SchemaFamily(
 result = APP_CONFIG_SCHEMA.validate({"schema_version": "1", "retries": 2})
 assert result.current_model == AppConfig(timeout=5.0, retries=2, new_feature=False)
 
-v1_config = APP_CONFIG_SCHEMA.dump(version="1")
+v1_config = APP_CONFIG_SCHEMA.defaults_for(version="1")
 assert v1_config == {"timeout": 5.0, "retries": 3, "schema_version": "1"}
 ```
+
+`defaults_for()` constructs the requested wire version directly, so historical
+defaults do not depend on a downgrade route from the current version. Use
+`dump(version=..., data=current_config)` when converting actual current data.
 
 `missing_version` is only for legacy config files that do not contain a schema
 version field. For example, `missing_version="1"` means "if a payload has no

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,11 +15,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   families, and serialized inventories and plans.
 
 ### Changed
+- Corrected the pre-1.0 rendering contract so `defaults_for()` constructs the
+  requested target wire model directly, while `dump(data=None)` delegates to
+  it and an empty mapping remains current data. Complete output now defaults to
+  JSON serialization aliases and rejects omission, polymorphic, round-trip,
+  and unknown options that can weaken the declared target shape.
 - Corrected the API reference to document that user transition exceptions
   propagate unchanged while invalid transition return values raise
   `InvalidMigrationError`.
 
 ### Fixed
+- Made explicit historical wire models with family-owned metadata expose a
+  complete document adapter, including safe metadata composition, nested JSON
+  Schema definitions, ordinary Pydantic construction/copy/assignment behavior,
+  and once-only body validation and serialization. Serializer-controlled
+  metadata collisions and unsafe serializer relocation of managed nested
+  families now fail closed. These generated adapters are final, reserve complete
+  nested metadata envelopes, preflight declared attribute input, and reject
+  output-name collisions from allowed extras.
+- Removed redundant family-owned discriminators from embedded child output
+  across built-in and decorator-discovered nested routes while retaining
+  model-owned child metadata.
 - Replaced the redirecting Read the Docs badge source with a directly rendered
   Shields endpoint so the documentation status appears on PyPI.
 - Rejected nested-family mappings, heterogeneous branches, and child-model

--- a/docs/guide/application-exchange.md
+++ b/docs/guide/application-exchange.md
@@ -104,6 +104,14 @@ CONSUMER_SCHEMA = SchemaFamily(
 The declarations for each shared label must describe the same wire contract,
 even though the applications' current Python field names can differ.
 
+Serialization and validation aliases can also differ in Pydantic. Versioned
+output defaults to `by_alias=True`, so a producer emits each target field's
+serialization alias (or ordinary alias). The consumer must accept that exact
+location as a field name, alias, or `AliasChoices` entry. Do not assume the
+producer's validation-only alias is its output name. Use `by_alias=False` only
+when both sides deliberately share Python field names, and cover that mode with
+an exchange test.
+
 ## Advertise accepted versions
 
 The consumer can publish a small application-owned capability document:
@@ -220,6 +228,10 @@ received = CONSUMER_SCHEMA.validate(payload, version=target)
 When both transport and document metadata are present, they must agree. The
 library validates the selected wire contract rather than silently replacing a
 conflicting embedded label.
+
+Transport-owned metadata requires family-owned version metadata. A
+model-owned discriminator is a declared body field and cannot be removed with
+`include_version=False`.
 
 ## Fail when there is no safe overlap
 

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -1,13 +1,18 @@
 # Rendering Configs
 
-Use `dump_versioned()` to render a config in a requested schema version.
+Use `defaults_for()` to materialize one version's defaults and `dump()` to
+convert current data into a requested schema version. The decorator-compatible
+`dump_versioned()` function supports both operations.
 
 ```python
-dumped = dump_versioned(AppConfig, version="1")
+defaults = APP_CONFIG_SCHEMA.defaults_for(version="1")
+dumped = APP_CONFIG_SCHEMA.dump(version="1", data=current_config)
 ```
 
-The output validates against the generated historical model and includes the
-configured version field by default.
+By default, output uses the target model's JSON serialization schema, applies
+serialization aliases, and includes the configured version field. Pydantic can
+define different validation and serialization aliases, so an intentionally
+asymmetric model may require a separately aligned consumer contract.
 
 ## Render defaults
 
@@ -23,6 +28,17 @@ assert dump_versioned(AppConfig, version="1") == {
     "schema_version": "1",
 }
 ```
+
+`SchemaFamily.defaults_for(version=...)` constructs the selected target wire
+model from `{}` and serializes it directly. It does not plan or execute a
+downgrade from the current version. Historical defaults therefore remain
+available even when a custom upgrade has no reverse operation. Target default
+factories, default validation, validators on an explicit wire model, and its
+serializer retain normal Pydantic behavior and execute once.
+
+For compatibility, `dump(version=..., data=None)` delegates to
+`defaults_for()`. An empty mapping is real current input, not defaults syntax;
+required current fields still fail validation.
 
 ## Render existing data
 
@@ -71,14 +87,81 @@ such as `{"schema_version": "1", ...}` invalid current input when the current
 version is `"2"`, even if the requested output version is `"1"`. Omit the input
 metadata when the application model does not own it.
 
+The converted value is validated by the target wire model before target
+serialization. An explicit historical model keeps its own validators and
+serializer. With family-owned metadata, `model_for(version)` returns a complete
+document adapter around that explicit body model. The adapter invokes the body
+serializer once, requires object-shaped output, and rejects any attempt by the
+body serializer to emit or replace the reserved metadata path. A nested
+family-owned metadata path reserves its complete root envelope; application
+data cannot share sibling keys under that root.
+
+The document adapter is final. If an application needs a specialized historical
+body, subclass the explicit wire body before passing it to `SchemaVersion`
+rather than subclassing `model_for(version)`. The body remains the sole owner of
+its aliases, validators, serializer, and JSON Schema callbacks. Custom model
+core/JSON Schema hooks are rejected because composing them through the adapter
+would not have once-only semantics. Annotation or decorator serializers that
+can relocate a declared nested-family path are rejected for the same reason,
+as are custom model schema hooks and legacy `json_encoders` on that path.
+
+Attribute input is available only when the explicit body sets
+`ConfigDict(from_attributes=True)`. The adapter preflights family-owned metadata
+before executing body validators. Per-call `from_attributes=True` cannot enable
+attribute input for a body that did not declare it; use a mapping or an exact
+body instance instead. Allowed extras remain available, but an extra that
+overwrites an active field or computed-field serialization name fails closed.
+The facade exposes the declared Pydantic state and standard model operations;
+it does not proxy arbitrary body methods. Self-references created inside
+body-owned values retain the explicit body's identity, so applications must not
+use `value is document` as part of the wire contract.
+
+## Serialization options
+
+Rendering defaults to `mode="json"` and `by_alias=True`. The complete-output
+API accepts this bounded set of `model_dump()` options:
+
+- `mode`
+- `by_alias`
+- `context`
+- `fallback`
+- `warnings`
+- `round_trip=False`
+- `serialize_as_any=False`
+- `polymorphic_serialization=False` or `None`
+
+Truthy polymorphic options are rejected because subclass-only fields can escape
+the declared target contract. `round_trip=True` is rejected because Pydantic may
+omit computed target fields in that mode. Unknown options fail closed so a new
+Pydantic keyword cannot silently weaken the versioned contract.
+
+The following omission options are rejected whenever they are present, even if
+their value would currently be false or empty:
+
+- `include`
+- `exclude`
+- `exclude_unset`
+- `exclude_defaults`
+- `exclude_none`
+- `exclude_computed_fields`
+
+Use the returned complete dictionary as the versioned document, then derive a
+partial view outside this API when an application deliberately needs one.
+
 ## Omit version metadata
 
-Set `include_version=False` when version metadata is stored outside the rendered
-payload:
+Set `include_version=False` when family-owned version metadata is stored outside
+the rendered payload:
 
 ```python
 dumped = dump_versioned(AppConfig, version="1", include_version=False)
 ```
+
+This is an explicit body-only mode. Its result is not a complete document for
+the family-owned `model_for(version)` adapter, so the consumer must supply the
+version separately. Model-owned metadata is part of the body contract and
+cannot be omitted; requesting `include_version=False` for that ownership mode
+raises `ValueError` before target construction or serialization.
 
 ## Nested version metadata
 
@@ -100,3 +183,8 @@ assert dump_versioned(MetadataConfig, version="1") == {
     "metadata": {"schema_version": "1"},
 }
 ```
+
+For a declared nested family, the parent version mapping owns child selection.
+Its embedded family-owned discriminator is therefore omitted from the rendered
+child value. A child discriminator declared as model-owned remains a real body
+field and is retained and verified.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -33,8 +33,12 @@ declaration sequence and has no default-selection side effect.
 - `model_for(version)`: return the family-local, object-shaped generated wire
   contract for that declared version.
 - `validate(data, *, version=None)`: validate historical input and upgrade it to the current model.
-- `defaults_for(*, version, include_version=True, **dump_kwargs)`: render target defaults.
-- `dump(*, version, data=None, include_version=True, **dump_kwargs)`: return a target-version dictionary.
+- `defaults_for(*, version, include_version=True, **dump_kwargs)`: construct and
+  serialize the selected target wire model's defaults without planning or
+  executing a downgrade.
+- `dump(*, version, data=None, include_version=True, **dump_kwargs)`: convert
+  current data to a target-version dictionary; `data=None` delegates to
+  `defaults_for()`, while `{}` remains real current input.
 
 Compilation is idempotent and thread-safe. A family owns its generated-model
 identities and cache, so two families can reuse one current model without
@@ -111,6 +115,25 @@ default `label`. Output-only or disabled validation locations are rejected.
 That location must remain invariant; nested model-owned paths are rejected
 until the top-level conversion compiler can resolve them safely. No
 discriminator is added when `version_metadata=None`.
+
+For an explicit historical wire body, that family-owned document adapter is a
+final facade: subclass the explicit body before registering the version, not the
+class returned by `model_for()`. The explicit body owns its materialized aliases,
+validators, serializer, and JSON Schema callbacks exactly once. Custom model
+core/JSON Schema hooks and serializer behavior that can relocate a managed
+nested-family path are unsupported; this includes annotation/decorator
+serializers, custom schema hooks, and legacy `json_encoders` along that path.
+Nested family-owned metadata reserves its
+entire root envelope, and allowed extras cannot overwrite an active declared
+serialization name.
+
+Attribute validation through this facade follows the explicit body's declared
+`ConfigDict(from_attributes=True)` policy. Family metadata is checked before
+body validators execute. A per-call flag cannot enable attribute input when the
+body configuration disables it; callers must instead provide a mapping or an
+instance of the explicit body. The facade does not proxy arbitrary body methods,
+and self-references stored inside body-owned values keep body identity rather
+than being rewritten as facade identity.
 
 Automatic projection raises `UnsupportedWireModelError` for a `RootModel`,
 unresolved generic, model-level serializer, overridden model core/JSON Schema
@@ -356,16 +379,33 @@ forward upgrades, and validates the current model.
 
 `dump_versioned(subject, *, version, data=None, include_version=True, **dump_kwargs)`
 
-Renders defaults, model data, or mapping data using a requested version and
-returns a dictionary. Mapping and unrelated model data is validated as the
-authoritative current model before reverse transitions run; authoritative model
-instances follow their Pydantic `revalidate_instances` policy. Embedded version
-metadata at any accepted input name must match the current version. Rendering
-extracts authoritative declared fields into detached canonical data, excluding
-allowed extras, subclass-only fields, and serializers, so transition mutation
-cannot affect caller-owned containers. Invalid unrelated models raise the
-current model's `ValidationError`. Extra keyword arguments are passed to the
-final target model's Pydantic `model_dump()`.
+With `data=None`, delegates to target-direct `defaults_for()` and does not
+require a render route. With model or mapping data, converts current data using
+the requested render plan and returns the target serialization dictionary. An
+empty mapping is data, not defaults syntax.
+
+Mapping and unrelated model data is validated as the authoritative current
+model before reverse transitions run; authoritative model instances follow
+their Pydantic `revalidate_instances` policy. Embedded version metadata at any
+accepted input name must match the current version. Rendering extracts
+authoritative declared fields into detached canonical data, excluding allowed
+extras, subclass-only fields, and serializers, so transition mutation cannot
+affect caller-owned containers. Invalid unrelated models raise the current
+model's `ValidationError`.
+
+Target serialization defaults to `mode="json"` and `by_alias=True`. Supported
+keyword arguments are `mode`, `by_alias`, `context`, `fallback`, `warnings`,
+false `round_trip`, false `serialize_as_any`, and false or `None`
+`polymorphic_serialization`. Truthy polymorphic modes, `round_trip=True`, unknown
+options, and the omission options `include`, `exclude`, `exclude_unset`,
+`exclude_defaults`, `exclude_none`, and `exclude_computed_fields` raise
+`ValueError`. Omission options are rejected by presence.
+
+Family-owned `include_version=False` returns a body-only dictionary for a
+transport that carries the label separately. Model-owned metadata is part of
+the body contract, so that option is unavailable. Family-owned metadata on
+embedded child families is omitted because the parent mapping owns child
+selection; model-owned child metadata remains.
 
 ## Result
 

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -48,6 +48,31 @@ class _DecoratorRouteSelection:
     value_identity: int | None = None
 
 
+_CONTRACT_FIELD_OMISSION_OPTIONS = frozenset(
+    {
+        "exclude",
+        "exclude_computed_fields",
+        "exclude_defaults",
+        "exclude_none",
+        "exclude_unset",
+        "include",
+    }
+)
+_SUPPORTED_MODEL_DUMP_OPTIONS = frozenset(
+    {
+        "by_alias",
+        "context",
+        "fallback",
+        "mode",
+        "polymorphic_serialization",
+        "round_trip",
+        "serialize_as_any",
+        "warnings",
+    }
+)
+_MISSING = object()
+
+
 def _runtime_label(value: object, *, family_name: str) -> str:
     if not isinstance(value, str) or not value:
         msg = f"Schema version for {family_name!r} must be a non-empty string"
@@ -581,7 +606,17 @@ def _dump_family[T: BaseModel](
     include_version: bool,
     dump_kwargs: Mapping[str, Any],
 ) -> dict[str, Any]:
+    _validate_model_dump_options(dump_kwargs)
+    if data is None:
+        return _defaults_family(
+            family,
+            version=version,
+            include_version=include_version,
+            dump_kwargs=dump_kwargs,
+        )
+
     compiled = family._compiled_family()
+    _validate_include_version_mode(compiled, include_version)
     requested = _runtime_label(version, family_name=family.name)
     target = compiled.version(requested)
     target_index = compiled.index(requested)
@@ -595,15 +630,11 @@ def _dump_family[T: BaseModel](
         parent_label=compiled.current_version,
     )
 
-    if data is None:
-        payload = {}
-        decorator_selections: tuple[_DecoratorRouteSelection, ...] = ()
-    else:
-        payload, decorator_selections = _validated_current_render_payload(
-            family=family,
-            compiled=compiled,
-            data=data,
-        )
+    payload, decorator_selections = _validated_current_render_payload(
+        family=family,
+        compiled=compiled,
+        data=data,
+    )
 
     # Authoritative current-model validation already returns canonical field
     # names for the complete declared subtree. Nested conversion must not
@@ -672,7 +703,8 @@ def _dump_family[T: BaseModel](
         wire_boundary=True,
     )
     if compiled.version_metadata is not None and (
-        requested != compiled.current_version or compiled.version_metadata.owner == "model"
+        compiled.version_metadata.owner == "model"
+        or (requested != compiled.current_version and target.wire_model_kind != "explicit")
     ):
         payload = dict(payload)
         if compiled.version_metadata.owner == "family":
@@ -689,33 +721,484 @@ def _dump_family[T: BaseModel](
         parent_label=requested,
         selections=decorator_selections,
     )
-    if "mode" in dump_kwargs:
-        dumped = target_model.model_dump(**dump_kwargs)
-    else:
-        dumped = target_model.model_dump(mode="json", **dump_kwargs)
-    if compiled.nested:
-        for nested in compiled.nested:
-            collection_kind = _nested_family_collection_kind(
-                model=compiled.model,
-                path=nested.path,
-            )
-            if collection_kind != "list":
-                continue
-            _prune_nested_family_metadata_at_path(
-                payload=dumped,
-                model=target.model,
-                path=_target_nested_path(target, nested.path),
-                family=nested.family._compiled_family(),
-                target_label=nested.child_label(requested),
-            )
-    if compiled.version_metadata is not None:
-        if compiled.version_metadata.owner == "model":
-            _remove_model_metadata_output_aliases(compiled, dumped)
-        if include_version:
-            _set_version_field(dumped, compiled.version_metadata.path, requested)
-        else:
-            _remove_version_field(dumped, compiled.version_metadata.path)
+    return _serialize_target_model(
+        compiled=compiled,
+        requested=requested,
+        target_model=target_model,
+        include_version=include_version,
+        dump_kwargs=dump_kwargs,
+    )
+
+
+def _defaults_family[T: BaseModel](
+    family: SchemaFamily[T],
+    *,
+    version: str,
+    include_version: bool,
+    dump_kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    _validate_model_dump_options(dump_kwargs)
+    compiled = family._compiled_family()
+    _validate_include_version_mode(compiled, include_version)
+    requested = _runtime_label(version, family_name=family.name)
+    target_model = compiled.version(requested).model.model_validate({})
+    return _serialize_target_model(
+        compiled=compiled,
+        requested=requested,
+        target_model=target_model,
+        include_version=include_version,
+        dump_kwargs=dump_kwargs,
+    )
+
+
+def _serialize_target_model(
+    *,
+    compiled: _CompiledFamily,
+    requested: str,
+    target_model: BaseModel,
+    include_version: bool,
+    dump_kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    serialization_options = dict(dump_kwargs)
+    serialization_options.pop("polymorphic_serialization", None)
+    serialization_options.setdefault("by_alias", True)
+    serialization_options.setdefault("mode", "json")
+    serialized = target_model.model_dump(**serialization_options)
+    if not isinstance(serialized, Mapping):
+        msg = (
+            f"Target wire model for family {compiled.name!r} and version "
+            f"{requested!r} must serialize to an object"
+        )
+        raise ValueError(msg)
+    dumped = dict(serialized)
+
+    target = compiled.version(requested)
+    for nested in compiled.nested:
+        _prune_nested_family_metadata_at_path(
+            payload=dumped,
+            source_payload=target_model,
+            model=target.model,
+            path=_target_nested_path(target, nested.path),
+            family=nested.family._compiled_family(),
+            target_label=nested.child_label(requested),
+            by_alias=serialization_options["by_alias"],
+        )
+
+    selections = _select_decorator_routes(
+        target_model,
+        compiled=compiled,
+        parent_label=requested,
+        source_version=target,
+    )
+    _prune_serialized_decorator_metadata(
+        dumped=dumped,
+        source_model=target_model,
+        compiled=compiled,
+        parent_label=requested,
+        selections=selections,
+        by_alias=serialization_options["by_alias"],
+    )
+    _validate_target_extra_output_collisions(
+        target_model,
+        by_alias=serialization_options["by_alias"],
+    )
+    _apply_serialized_version_metadata(
+        dumped=dumped,
+        compiled=compiled,
+        requested=requested,
+        target_model=type(target_model),
+        include_version=include_version,
+        by_alias=serialization_options["by_alias"],
+    )
     return dumped
+
+
+def _validate_target_extra_output_collisions(
+    target_model: BaseModel,
+    *,
+    by_alias: Any,
+) -> None:
+    seen: set[int] = set()
+
+    def visit(value: Any) -> None:
+        if id(value) in seen:
+            return
+        seen.add(id(value))
+        if isinstance(value, BaseModel):
+            model = type(value)
+            extras = value.__pydantic_extra__
+            if isinstance(extras, Mapping) and extras:
+                output_names = {
+                    _serialized_field_name(model, field_name, by_alias=by_alias)
+                    for field_name in model.model_fields
+                }
+                use_alias = (
+                    model.model_config.get("serialize_by_alias", False) is True
+                    if by_alias is None
+                    else by_alias is True
+                )
+                output_names.update(
+                    field_info.alias
+                    if use_alias and isinstance(field_info.alias, str)
+                    else field_name
+                    for field_name, field_info in model.model_computed_fields.items()
+                )
+                collisions = sorted(name for name in extras if name in output_names)
+                if collisions:
+                    formatted = ", ".join(repr(name) for name in collisions)
+                    msg = (
+                        f"Target wire model {model.__name__!r} extras overwrite "
+                        f"declared serialization location(s): {formatted}"
+                    )
+                    raise ValueError(msg)
+                for item in extras.values():
+                    visit(item)
+            for field_name in model.model_fields:
+                if field_name in value.__dict__:
+                    visit(value.__dict__[field_name])
+            return
+        if isinstance(value, Mapping):
+            for item in value.values():
+                visit(item)
+            return
+        if isinstance(value, list | tuple | set | frozenset):
+            for item in value:
+                visit(item)
+
+    visit(target_model)
+
+
+def _validate_model_dump_options(dump_kwargs: Mapping[str, Any]) -> None:
+    omission_options = sorted(_CONTRACT_FIELD_OMISSION_OPTIONS.intersection(dump_kwargs))
+    if omission_options:
+        formatted = ", ".join(repr(option) for option in omission_options)
+        msg = (
+            "Versioned rendering cannot omit target contract fields; unsupported "
+            f"model_dump option(s): {formatted}"
+        )
+        raise ValueError(msg)
+
+    unsupported = sorted(set(dump_kwargs).difference(_SUPPORTED_MODEL_DUMP_OPTIONS))
+    if unsupported:
+        formatted = ", ".join(repr(option) for option in unsupported)
+        msg = f"Versioned rendering received unsupported model_dump option(s): {formatted}"
+        raise ValueError(msg)
+
+    polymorphic = tuple(
+        option
+        for option in ("serialize_as_any", "polymorphic_serialization")
+        if dump_kwargs.get(option)
+    )
+    if polymorphic:
+        formatted = ", ".join(repr(option) for option in polymorphic)
+        msg = (
+            "Versioned rendering cannot use polymorphic serialization because it may "
+            f"expose fields outside the target wire contract: {formatted}"
+        )
+        raise ValueError(msg)
+    if dump_kwargs.get("round_trip"):
+        msg = (
+            "Versioned rendering cannot use round_trip=True because Pydantic may "
+            "omit computed target contract fields"
+        )
+        raise ValueError(msg)
+
+
+def _validate_include_version_mode(
+    compiled: _CompiledFamily,
+    include_version: bool,
+) -> None:
+    metadata = compiled.version_metadata
+    if include_version or metadata is None or metadata.owner != "model":
+        return
+    msg = (
+        f"Schema family {compiled.name!r} uses model-owned version metadata; "
+        "include_version=False is unavailable because that field is part of the body contract"
+    )
+    raise ValueError(msg)
+
+
+def _apply_serialized_version_metadata(
+    *,
+    dumped: dict[str, Any],
+    compiled: _CompiledFamily,
+    requested: str,
+    target_model: type[BaseModel],
+    include_version: bool,
+    by_alias: Any,
+) -> None:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        return
+    if metadata.owner == "family":
+        if include_version:
+            _ensure_serialized_version_field(
+                dumped,
+                metadata.path,
+                requested,
+                family_name=compiled.name,
+            )
+        else:
+            _remove_version_field(dumped, metadata.path)
+        return
+
+    if not include_version:
+        _validate_include_version_mode(compiled, include_version)
+    _verify_serialized_model_metadata(
+        dumped,
+        compiled=compiled,
+        requested=requested,
+        target_model=target_model,
+        by_alias=by_alias,
+    )
+
+
+def _verify_serialized_model_metadata(
+    dumped: Mapping[str, Any],
+    *,
+    compiled: _CompiledFamily,
+    requested: str,
+    target_model: type[BaseModel],
+    by_alias: Any,
+) -> None:
+    field_name = _model_metadata_field_name(compiled)
+    output_key = _serialized_field_name(target_model, field_name, by_alias=by_alias)
+    candidate_keys = _model_metadata_serialization_keys(
+        compiled,
+        target_model=target_model,
+        field_name=field_name,
+    )
+    value = dumped.get(output_key, _MISSING)
+    if value is _MISSING:
+        msg = (
+            f"Target wire model for family {compiled.name!r} and version "
+            f"{requested!r} omitted model-owned version metadata {output_key!r}"
+        )
+        raise ValueError(msg)
+    if value != requested:
+        msg = (
+            f"Target wire model for family {compiled.name!r} serialized version "
+            f"metadata {output_key!r} as {value!r}, expected {requested!r}"
+        )
+        raise ValueError(msg)
+    duplicate_keys = tuple(key for key in candidate_keys if key != output_key and key in dumped)
+    if duplicate_keys:
+        formatted = ", ".join(repr(key) for key in duplicate_keys)
+        msg = (
+            f"Target wire model for family {compiled.name!r} serialized duplicate "
+            f"version metadata at {formatted}"
+        )
+        raise ValueError(msg)
+
+
+def _ensure_serialized_version_field(
+    data: dict[str, Any],
+    version_field: VersionPath,
+    value: str,
+    *,
+    family_name: str,
+) -> None:
+    existing = _serialized_version_field(data, version_field)
+    if existing is not _MISSING:
+        if existing != value:
+            msg = (
+                f"Target wire model for family {family_name!r} serialized version "
+                f"metadata {_version_field_display(version_field)!r} as "
+                f"{existing!r}, expected {value!r}"
+            )
+            raise ValueError(msg)
+        return
+    _set_version_field(data, version_field, value)
+
+
+def _serialized_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
+    if isinstance(version_field, str):
+        return data[version_field] if version_field in data else _MISSING
+    current: Any = data
+    for part in version_field:
+        if not isinstance(current, Mapping) or part not in current:
+            return _MISSING
+        current = current[part]
+    return current
+
+
+def _model_metadata_serialization_keys(
+    compiled: _CompiledFamily,
+    *,
+    target_model: type[BaseModel],
+    field_name: str,
+) -> tuple[str, ...]:
+    metadata = compiled.version_metadata
+    keys: list[str] = [field_name]
+    if metadata is not None and isinstance(metadata.path, str):
+        keys.append(metadata.path)
+    for model in (compiled.model, target_model):
+        field_info = model.model_fields[field_name]
+        for candidate in (
+            field_info.alias,
+            field_info.validation_alias,
+            field_info.serialization_alias,
+        ):
+            if isinstance(candidate, str):
+                keys.append(candidate)
+    return tuple(dict.fromkeys(keys))
+
+
+def _serialized_field_name(
+    model: type[BaseModel],
+    field_name: str,
+    *,
+    by_alias: Any,
+) -> str:
+    use_alias = (
+        model.model_config.get("serialize_by_alias", False) is True
+        if by_alias is None
+        else by_alias is True
+    )
+    field_info = model.model_fields[field_name]
+    if use_alias:
+        output_alias = field_info.serialization_alias
+        if output_alias is None:
+            output_alias = field_info.alias
+        if isinstance(output_alias, str):
+            return output_alias
+    return field_name
+
+
+def _prune_serialized_decorator_metadata(
+    *,
+    dumped: dict[str, Any],
+    source_model: BaseModel,
+    compiled: _CompiledFamily,
+    parent_label: str,
+    selections: tuple[_DecoratorRouteSelection, ...],
+    by_alias: Any,
+) -> None:
+    source_payload = _extract_declared_fields(source_model)
+    for selection in _decorator_selections_child_first(selections):
+        location = _serialized_decorator_selection_location(
+            compiled=compiled,
+            parent_label=parent_label,
+            selection=selection,
+            by_alias=by_alias,
+        )
+        if location is None:
+            continue
+        found, payload = _payload_at_location(dumped, location)
+        if not found:
+            continue
+        source_found, source_value = _payload_at_location(
+            source_payload,
+            selection.location,
+        )
+        if not source_found:
+            source_value = selection
+        _prune_nested_family_metadata_payload(
+            payload,
+            selection.route.family._compiled_family(),
+            selection.label,
+            by_alias=by_alias,
+            source_value=source_value,
+        )
+
+
+def _serialized_decorator_selection_location(
+    *,
+    compiled: _CompiledFamily,
+    parent_label: str,
+    selection: _DecoratorRouteSelection,
+    by_alias: Any,
+) -> tuple[str | int, ...] | None:
+    if selection.parent is None:
+        prefix: tuple[str | int, ...] = ()
+        owner_compiled = compiled
+        owner_label = parent_label
+    else:
+        parent_location = _serialized_decorator_selection_location(
+            compiled=compiled,
+            parent_label=parent_label,
+            selection=selection.parent,
+            by_alias=by_alias,
+        )
+        if parent_location is None:
+            return None
+        prefix = parent_location
+        owner_compiled = selection.parent.route.family._compiled_family()
+        owner_label = selection.parent.label
+
+    owner_target = owner_compiled.version(owner_label)
+    annotation: Any = owner_target.model
+    relative = iter(selection.relative_location)
+    serialized: list[str | int] = list(prefix)
+    for step_index, step in enumerate(selection.route.traversal):
+        normalized = _strip_annotated(annotation)
+        if step.kind == "field":
+            try:
+                location_part = next(relative)
+            except StopIteration:
+                return None
+            if location_part != step.value:
+                return None
+            if not isinstance(normalized, type) or not issubclass(normalized, BaseModel):
+                return None
+            field_name = step.value
+            if step_index == 0:
+                projected_name = owner_target.projection.field(field_name).version_name
+                if projected_name is None:
+                    return None
+                field_name = projected_name
+            field_info = normalized.model_fields.get(field_name)
+            if field_info is None:
+                return None
+            serialized.append(_serialized_field_name(normalized, field_name, by_alias=by_alias))
+            annotation = field_info.annotation
+            continue
+        if step.kind == "union_arm":
+            arguments = get_args(normalized)
+            ordinal = int(step.value)
+            if ordinal >= len(arguments):
+                return None
+            annotation = arguments[ordinal]
+            continue
+        if step.kind == "each":
+            try:
+                occurrence = next(relative)
+            except StopIteration:
+                return None
+            arguments = get_args(normalized)
+            if not arguments:
+                return None
+            serialized.append(occurrence)
+            annotation = arguments[0]
+            continue
+        if step.kind == "tuple_index":
+            try:
+                occurrence = next(relative)
+            except StopIteration:
+                return None
+            ordinal = int(step.value)
+            arguments = get_args(normalized)
+            if occurrence != ordinal or ordinal >= len(arguments):
+                return None
+            serialized.append(occurrence)
+            annotation = arguments[ordinal]
+            continue
+        if step.kind == "mapping_values":
+            try:
+                occurrence = next(relative)
+            except StopIteration:
+                return None
+            arguments = get_args(normalized)
+            if len(arguments) != 2:
+                return None
+            serialized.append(occurrence)
+            annotation = arguments[1]
+            continue
+    try:
+        next(relative)
+    except StopIteration:
+        return tuple(serialized)
+    return None
 
 
 def _validated_current_render_payload[T: BaseModel](
@@ -2462,11 +2945,29 @@ def _prune_nested_family_metadata_payload(
     payload: Any,
     family: _CompiledFamily,
     target_label: str | None = None,
+    *,
+    by_alias: Any = False,
+    source_value: Any = _MISSING,
 ) -> None:
     resolved_target = family.current_version if target_label is None else target_label
+    if not isinstance(payload, Mapping):
+        msg = (
+            f"Nested target wire model for family {family.name!r} and version "
+            f"{resolved_target!r} must serialize to an object"
+        )
+        raise ValueError(msg)
     metadata = family.version_metadata
-    if metadata is not None and metadata.owner == "family" and isinstance(payload, Mapping):
-        _remove_version_field(payload, metadata.path)
+    if metadata is not None:
+        if metadata.owner == "family":
+            _remove_version_field(payload, metadata.path)
+        else:
+            _verify_serialized_model_metadata(
+                payload,
+                compiled=family,
+                requested=resolved_target,
+                target_model=family.version(resolved_target).model,
+                by_alias=by_alias,
+            )
 
     if not family.nested:
         return
@@ -2478,46 +2979,381 @@ def _prune_nested_family_metadata_payload(
             continue
         _prune_nested_family_metadata_at_path(
             payload=payload,
+            source_payload=source_value,
             model=target.model,
             path=target_path,
             family=child.family._compiled_family(),
             target_label=child.child_label(resolved_target),
+            by_alias=by_alias,
         )
 
 
 def _prune_nested_family_metadata_at_path(
     *,
     payload: Any,
+    source_payload: Any = _MISSING,
     path: tuple[str, ...] | None,
     family: SchemaFamily[Any] | _CompiledFamily,
     model: type[BaseModel] | None = None,
     target_label: str | None = None,
+    by_alias: Any = False,
 ) -> None:
     if path is None:
         return
     compiled_family = family if isinstance(family, _CompiledFamily) else family._compiled_family()
     resolved_target = compiled_family.current_version if target_label is None else target_label
     if not path:
-        nested_payloads = (payload,)
+        _prune_serialized_nested_value(
+            payload,
+            source_payload=source_payload,
+            annotation=compiled_family.version(resolved_target).model,
+            family=compiled_family,
+            target_label=resolved_target,
+            by_alias=by_alias,
+        )
+        return
     elif model is None:
         # A path without its declaring model cannot be traversed safely: searching
         # arbitrary mapping values would let unrelated payload data impersonate a
         # declared nested field.
         return
-    else:
-        nested_payloads = _declared_payload_values_at_path(
-            payload,
-            model=model,
-            path=path,
-            include_serialization_aliases=True,
+    _prune_serialized_nested_path(
+        payload,
+        source_payload=source_payload,
+        model=model,
+        path=path,
+        family=compiled_family,
+        target_label=resolved_target,
+        by_alias=by_alias,
+    )
+
+
+def _prune_serialized_nested_path(
+    payload: Any,
+    *,
+    source_payload: Any,
+    model: type[BaseModel],
+    path: tuple[str, ...],
+    family: _CompiledFamily,
+    target_label: str,
+    by_alias: Any,
+) -> None:
+    if not isinstance(payload, Mapping):
+        msg = (
+            f"Target wire model containing nested family {family.name!r} must "
+            f"serialize declared path {path!r} through objects"
         )
-    for nested_payload in nested_payloads:
-        for item in _nested_payload_items(nested_payload):
-            _prune_nested_family_metadata_payload(
-                item,
-                compiled_family,
-                resolved_target,
+        raise ValueError(msg)
+    field_name, *remaining = path
+    field_info = model.model_fields.get(field_name)
+    if field_info is None:
+        return
+    found, field_payload = _serialized_nested_field_payload(
+        payload,
+        source_payload=source_payload,
+        model=model,
+        field_name=field_name,
+        field_info=field_info,
+        family_name=family.name,
+        by_alias=by_alias,
+    )
+    if not found:
+        msg = f"Target wire model omitted declared nested family {family.name!r} at path {path!r}"
+        raise ValueError(msg)
+    source_field_payload = _declared_source_field_payload(
+        source_payload,
+        field_name=field_name,
+    )
+    if remaining:
+        _prune_serialized_nested_path_through_annotation(
+            field_payload,
+            source_payload=source_field_payload,
+            annotation=field_info.annotation,
+            path=tuple(remaining),
+            family=family,
+            target_label=target_label,
+            by_alias=by_alias,
+        )
+        return
+    _prune_serialized_nested_value(
+        field_payload,
+        source_payload=source_field_payload,
+        annotation=field_info.annotation,
+        family=family,
+        target_label=target_label,
+        by_alias=by_alias,
+    )
+
+
+def _serialized_nested_field_payload(
+    payload: Mapping[Any, Any],
+    *,
+    source_payload: Any,
+    model: type[BaseModel],
+    field_name: str,
+    field_info: Any,
+    family_name: str,
+    by_alias: Any,
+) -> tuple[bool, Any]:
+    output_name = _serialized_field_name(model, field_name, by_alias=by_alias)
+    if isinstance(source_payload, BaseModel):
+        extras = source_payload.__pydantic_extra__
+        if isinstance(extras, Mapping) and output_name in extras:
+            msg = (
+                f"Target wire model extra {output_name!r} overwrites the declared "
+                f"location for nested family {family_name!r}"
             )
+            raise ValueError(msg)
+    candidates = [field_name]
+    for candidate in (field_info.alias, field_info.serialization_alias):
+        if isinstance(candidate, str) and candidate not in candidates:
+            candidates.append(candidate)
+    present = tuple(candidate for candidate in candidates if candidate in payload)
+    if len(present) > 1:
+        formatted = ", ".join(repr(candidate) for candidate in present)
+        msg = (
+            f"Target wire model serialized duplicate locations for nested family "
+            f"{family_name!r}: {formatted}"
+        )
+        raise ValueError(msg)
+    if output_name not in payload:
+        return False, None
+    return True, payload[output_name]
+
+
+def _prune_serialized_nested_path_through_annotation(
+    payload: Any,
+    *,
+    source_payload: Any,
+    annotation: Any,
+    path: tuple[str, ...],
+    family: _CompiledFamily,
+    target_label: str,
+    by_alias: Any,
+) -> None:
+    annotation = _strip_annotated(annotation)
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        if (
+            payload is None
+            and NoneType in get_args(annotation)
+            and (source_payload is None or source_payload is _MISSING)
+        ):
+            return
+        candidates = tuple(
+            argument
+            for argument in get_args(annotation)
+            if argument is not NoneType and _annotation_declares_path(argument, path)
+        )
+        if candidates:
+            _prune_serialized_nested_path_through_annotation(
+                payload,
+                source_payload=source_payload,
+                annotation=candidates[0],
+                path=path,
+                family=family,
+                target_label=target_label,
+                by_alias=by_alias,
+            )
+        return
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        _prune_serialized_nested_path(
+            payload,
+            source_payload=source_payload,
+            model=annotation,
+            path=path,
+            family=family,
+            target_label=target_label,
+            by_alias=by_alias,
+        )
+        return
+    kind = _collection_kind(annotation)
+    if kind is None:
+        return
+    items = _serialized_collection_items(
+        payload,
+        annotation,
+        source_payload=source_payload,
+        family_name=family.name,
+    )
+    for item, item_annotation, source_item in items:
+        _prune_serialized_nested_path_through_annotation(
+            item,
+            source_payload=source_item,
+            annotation=item_annotation,
+            path=path,
+            family=family,
+            target_label=target_label,
+            by_alias=by_alias,
+        )
+    _validate_serialized_set_cardinality(
+        payload,
+        kind=kind,
+        family_name=family.name,
+    )
+
+
+def _prune_serialized_nested_value(
+    payload: Any,
+    *,
+    source_payload: Any,
+    annotation: Any,
+    family: _CompiledFamily,
+    target_label: str,
+    by_alias: Any,
+) -> None:
+    annotation = _strip_annotated(annotation)
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        arguments = get_args(annotation)
+        if (
+            payload is None
+            and NoneType in arguments
+            and (source_payload is None or source_payload is _MISSING)
+        ):
+            return
+        concrete = tuple(argument for argument in arguments if argument is not NoneType)
+        child_model = family.version(target_label).model
+        selected = next(
+            (
+                argument
+                for argument in concrete
+                if _annotation_contains_model(argument, child_model)
+            ),
+            concrete[0] if concrete else annotation,
+        )
+        _prune_serialized_nested_value(
+            payload,
+            source_payload=source_payload,
+            annotation=selected,
+            family=family,
+            target_label=target_label,
+            by_alias=by_alias,
+        )
+        return
+    kind = _collection_kind(annotation)
+    if kind is not None:
+        items = _serialized_collection_items(
+            payload,
+            annotation,
+            source_payload=source_payload,
+            family_name=family.name,
+        )
+        for item, item_annotation, source_item in items:
+            _prune_serialized_nested_value(
+                item,
+                source_payload=source_item,
+                annotation=item_annotation,
+                family=family,
+                target_label=target_label,
+                by_alias=by_alias,
+            )
+        _validate_serialized_set_cardinality(
+            payload,
+            kind=kind,
+            family_name=family.name,
+        )
+        return
+    _prune_nested_family_metadata_payload(
+        payload,
+        family,
+        target_label,
+        by_alias=by_alias,
+        source_value=source_payload,
+    )
+
+
+def _serialized_collection_items(
+    payload: Any,
+    annotation: Any,
+    *,
+    source_payload: Any,
+    family_name: str,
+) -> tuple[tuple[Any, Any, Any], ...]:
+    if not isinstance(payload, list | tuple | set | frozenset):
+        msg = (
+            f"Nested target wire collection for family {family_name!r} changed "
+            "its declared container shape during serialization"
+        )
+        raise ValueError(msg)
+    values = tuple(payload)
+    source_values = (
+        tuple(source_payload)
+        if isinstance(source_payload, list | tuple | set | frozenset)
+        else (_MISSING,) * len(values)
+    )
+    if source_payload is not _MISSING and len(source_values) != len(values):
+        msg = (
+            f"Nested rendering for family {family_name!r} cannot preserve "
+            "collection cardinality after target serialization"
+        )
+        raise InvalidMigrationError(msg)
+    arguments = get_args(annotation)
+    if get_origin(annotation) is tuple and arguments and arguments[-1] is not Ellipsis:
+        return tuple(zip(values, arguments, source_values, strict=False))
+    item_annotation = arguments[0] if arguments else Any
+    return tuple(
+        (item, item_annotation, source_item)
+        for item, source_item in zip(values, source_values, strict=False)
+    )
+
+
+def _declared_source_field_payload(source: Any, *, field_name: str) -> Any:
+    if isinstance(source, BaseModel):
+        return source.__dict__.get(field_name, _MISSING)
+    if isinstance(source, Mapping):
+        return source.get(field_name, _MISSING)
+    return _MISSING
+
+
+def _validate_serialized_set_cardinality(
+    payload: Any,
+    *,
+    kind: Literal["list", "tuple", "set", "frozenset"],
+    family_name: str,
+) -> None:
+    if kind not in ("set", "frozenset"):
+        return
+    items = list(payload)
+    if _has_duplicate_payload(items):
+        msg = (
+            f"Nested rendering for family {family_name!r} cannot preserve set "
+            "cardinality after target serialization"
+        )
+        raise InvalidMigrationError(msg)
+
+
+def _annotation_declares_path(annotation: Any, path: tuple[str, ...]) -> bool:
+    annotation = _strip_annotated(annotation)
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        return any(
+            argument is not NoneType and _annotation_declares_path(argument, path)
+            for argument in get_args(annotation)
+        )
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        field_info = annotation.model_fields.get(path[0])
+        if field_info is None:
+            return False
+        if len(path) == 1:
+            return True
+        return _annotation_declares_path(field_info.annotation, path[1:])
+    if _collection_kind(annotation) is None:
+        return False
+    return any(
+        argument is not Ellipsis and _annotation_declares_path(argument, path)
+        for argument in get_args(annotation)
+    )
+
+
+def _annotation_contains_model(annotation: Any, model: type[BaseModel]) -> bool:
+    annotation = _strip_annotated(annotation)
+    if annotation is model:
+        return True
+    return any(
+        argument is not Ellipsis and _annotation_contains_model(argument, model)
+        for argument in get_args(annotation)
+    )
 
 
 def _convert_nested_child_family(

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import json
 import sys
 from collections.abc import Iterable, Mapping, Sequence
-from copy import deepcopy
+from copy import copy, deepcopy
 from dataclasses import is_dataclass
 from functools import reduce
 from operator import or_
-from types import GenericAlias, UnionType
+from types import GenericAlias, MemberDescriptorType, UnionType
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     ForwardRef,
     Literal,
     TypeVar,
@@ -33,18 +34,20 @@ from pydantic import (
     ConfigDict,
     Discriminator,
     Field,
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
     GetPydanticSchema,
     WithJsonSchema,
     create_model,
 )
-from pydantic.functional_serializers import PlainSerializer, WrapSerializer
+from pydantic.functional_serializers import PlainSerializer, SerializeAsAny, WrapSerializer
 from pydantic.functional_validators import (
     AfterValidator,
     BeforeValidator,
     PlainValidator,
     WrapValidator,
 )
-from pydantic_core import PydanticUndefined
+from pydantic_core import CoreSchema, PydanticUndefined, core_schema
 from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
 
 from pydantic_versions._compiler import (
@@ -71,6 +74,8 @@ _SCHEMA_HOOK_NAMES = (
     "__modify_schema__",
 )
 _MISSING = object()
+_DOCUMENT_BODY_SLOT = "_FamilyDocumentAdapterBase__document_body"
+_SERIALIZE_AS_ANY_METADATA_TYPE = type(cast(Any, SerializeAsAny)())
 
 _MODEL_SCHEMA_STRUCTURE_KEYS = frozenset(
     {
@@ -206,6 +211,7 @@ _FUNCTIONAL_FIELD_BEHAVIOR = (
     BeforeValidator,
     PlainSerializer,
     PlainValidator,
+    _SERIALIZE_AS_ANY_METADATA_TYPE,
     WrapSerializer,
     WrapValidator,
 )
@@ -261,7 +267,32 @@ def _build_model_for_projection(
                 "explicit wire models cannot contain decorator-discovered child families; "
                 "declare explicit NestedFamily boundaries instead",
             )
-        return _validate_explicit_wire_model(family, projection, wire_model)
+        _validate_explicit_nested_serializer_boundaries(
+            family,
+            projection,
+            wire_model,
+            nested=nested,
+        )
+        metadata = family.version_metadata
+        if metadata is not None and metadata.owner == "family":
+            _validate_family_document_adapter_schema_hooks(
+                family,
+                projection,
+                wire_model,
+            )
+            _validate_family_document_adapter_member_collisions(
+                family,
+                projection,
+                wire_model,
+            )
+        validated = _validate_explicit_wire_model(family, projection, wire_model)
+        if metadata is not None and metadata.owner == "family":
+            return _build_family_document_adapter(
+                family,
+                projection,
+                validated,
+            )
+        return validated
     try:
         return _build_model_for_projection_unchecked(
             family,
@@ -286,6 +317,15 @@ def _validate_explicit_wire_model(
     wire_model: type[BaseModel],
 ) -> type[BaseModel]:
     _validate_explicit_wire_model_metadata(family, projection, wire_model)
+    _validate_explicit_family_metadata_collision(family, projection, wire_model)
+    if family.version_metadata is not None and family.version_metadata.owner == "model":
+        _validate_generated_metadata_aliases(
+            family,
+            projection,
+            wire_model,
+            model_metadata_field=_model_metadata_field(family),
+        )
+    _validate_unique_serialization_names(family, projection, wire_model)
     _validate_object_schema(
         family,
         projection,
@@ -299,6 +339,780 @@ def _validate_explicit_wire_model(
         mode="serialization",
     )
     return wire_model
+
+
+def _build_family_document_adapter(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    body_model: type[BaseModel],
+) -> type[BaseModel]:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "family":
+        msg = f"Schema family {family.name!r} lost family-owned version metadata"
+        raise SchemaCompilationError(msg)
+    label = projection.label
+    metadata_path = metadata.path
+    _validate_family_document_adapter_schema_hooks(family, projection, body_model)
+    adapter_config = dict(body_model.model_config)
+    # The exact body schema remains the sole owner of materialized aliases and
+    # JSON Schema callbacks. Replaying these while create_model builds the
+    # document facade can change stateful aliases or execute callbacks twice.
+    for key in (
+        "alias_generator",
+        "field_title_generator",
+        "json_schema_extra",
+        "model_title_generator",
+        "schema_generator",
+    ):
+        adapter_config.pop(key, None)
+    body_config = ConfigDict(**adapter_config)
+    body_fields = tuple(body_model.model_fields)
+
+    def synchronize_adapter(instance: BaseModel) -> BaseModel:
+        body = object.__getattribute__(
+            instance,
+            "_FamilyDocumentAdapterBase__document_body",
+        )
+        if not isinstance(body, body_model):
+            msg = (
+                f"Family-owned document adapter for {family.name!r} lost its "
+                "validated explicit wire body"
+            )
+            raise ValueError(msg)
+        adapter_instance = cast(Any, instance)
+        synchronized = type(adapter_instance)._from_document_body(body)
+        _FamilyDocumentAdapterBase._replace_document_adapter_state(
+            adapter_instance,
+            synchronized,
+        )
+        return body
+
+    class _FamilyDocumentAdapterBase(BaseModel):
+        __slots__ = ("__document_body",)
+
+        model_config = body_config
+        _document_body_model: ClassVar[type[BaseModel]] = body_model
+
+        @classmethod
+        def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+            super().__pydantic_init_subclass__(**kwargs)
+            if _FamilyDocumentAdapterBase in cls.__bases__:
+                return
+            msg = (
+                f"Generated family-owned document model for {family.name!r} is final; "
+                "subclass the explicit wire body before declaring the schema version"
+            )
+            raise TypeError(msg)
+
+        def __init__(self, /, **data: Any) -> None:
+            validated = type(self).model_validate(data)
+            _FamilyDocumentAdapterBase._replace_document_adapter_state(self, validated)
+
+        def __getattribute__(self, name: str) -> Any:
+            if name in body_fields:
+                try:
+                    body = object.__getattribute__(
+                        self,
+                        "_FamilyDocumentAdapterBase__document_body",
+                    )
+                except AttributeError:
+                    body = None
+                if isinstance(body, body_model):
+                    value = getattr(body, name)
+                    return self if value is body else value
+            # Explicit bodies with extra="allow" may legitimately receive names
+            # used only by the generated facade. Keep those values observable in
+            # exactly the same way as on the body while internal calls use the
+            # unbound helper methods and the slot descriptor directly.
+            if name in {
+                _DOCUMENT_BODY_SLOT,
+                "_document_body_model",
+                "_from_document_body",
+                "_replace_document_adapter_state",
+            }:
+                extras = object.__getattribute__(self, "__pydantic_extra__")
+                if isinstance(extras, Mapping) and name in extras:
+                    return extras[name]
+            return super().__getattribute__(name)
+
+        def _replace_document_adapter_state(self, adapter: BaseModel) -> None:
+            metadata_root = metadata_path if isinstance(metadata_path, str) else metadata_path[0]
+            existing_metadata = self.__dict__.get(metadata_root, _MISSING)
+            if existing_metadata is not _MISSING:
+                adapter.__dict__[metadata_root] = existing_metadata
+            object.__setattr__(self, "__dict__", adapter.__dict__)
+            object.__setattr__(
+                self,
+                "__pydantic_fields_set__",
+                adapter.__pydantic_fields_set__,
+            )
+            object.__setattr__(self, "__pydantic_extra__", adapter.__pydantic_extra__)
+            object.__setattr__(self, "__pydantic_private__", adapter.__pydantic_private__)
+            body = object.__getattribute__(
+                adapter,
+                "_FamilyDocumentAdapterBase__document_body",
+            )
+            object.__setattr__(
+                self,
+                "_FamilyDocumentAdapterBase__document_body",
+                body,
+            )
+
+        @classmethod
+        def _from_document_body(cls, body: BaseModel) -> BaseModel:
+            values = {name: body.__dict__.get(name, PydanticUndefined) for name in body_fields}
+            extras = body.__pydantic_extra__
+            if isinstance(extras, Mapping):
+                values.update(
+                    (name, value)
+                    for name, value in extras.items()
+                    if name not in body_model.model_fields
+                )
+            adapter = super().model_construct(
+                _fields_set=set(body.model_fields_set),
+                **values,
+            )
+            # model_construct fills facade defaults. Preserve the exact body
+            # state after supported deletion rather than resurrecting fields.
+            for name in body_fields:
+                if name not in body.__dict__:
+                    adapter.__dict__.pop(name, None)
+            object.__setattr__(adapter, "__pydantic_fields_set__", body.__pydantic_fields_set__)
+            object.__setattr__(adapter, "__pydantic_extra__", body.__pydantic_extra__)
+            object.__setattr__(adapter, "__pydantic_private__", body.__pydantic_private__)
+            object.__setattr__(
+                adapter,
+                "_FamilyDocumentAdapterBase__document_body",
+                body,
+            )
+            return adapter
+
+        @classmethod
+        def model_construct(
+            cls,
+            _fields_set: set[str] | None = None,
+            **values: Any,
+        ) -> BaseModel:
+            body_values = _copy_without_document_metadata(
+                values,
+                metadata_path=metadata_path,
+                expected=label,
+                family_name=family.name,
+            )
+            body_fields_set = None if _fields_set is None else set(_fields_set)
+            if body_fields_set is not None:
+                metadata_root = (
+                    metadata_path if isinstance(metadata_path, str) else metadata_path[0]
+                )
+                body_fields_set.discard(metadata_root)
+            body = body_model.model_construct(
+                _fields_set=body_fields_set,
+                **body_values,
+            )
+            return cls._from_document_body(body)
+
+        @classmethod
+        def __get_pydantic_core_schema__(
+            cls,
+            _source_type: Any,
+            handler: GetCoreSchemaHandler,
+        ) -> CoreSchema:
+            body_schema = handler.generate_schema(body_model)
+
+            def strip_metadata(value: Any) -> Any:
+                if isinstance(value, cls):
+                    body = object.__getattribute__(
+                        value,
+                        "_FamilyDocumentAdapterBase__document_body",
+                    )
+                    if isinstance(body, body_model):
+                        return body
+                if isinstance(value, body_model):
+                    _reject_explicit_body_document_metadata(
+                        value,
+                        metadata_path=metadata_path,
+                        family_name=family.name,
+                    )
+                    return value
+                if not isinstance(value, Mapping):
+                    return value
+                copied = _copy_without_document_metadata(
+                    value,
+                    metadata_path=metadata_path,
+                    expected=label,
+                    family_name=family.name,
+                )
+                return copied
+
+            def validate_document(value: Any, inner_handler: Any) -> BaseModel:
+                revalidation = body_model.model_config.get("revalidate_instances", "never")
+                foreign_body = isinstance(value, body_model) and not isinstance(value, cls)
+                attribute_source = not isinstance(value, (cls, body_model, Mapping))
+                if attribute_source:
+                    if body_model.model_config.get("from_attributes") is not True:
+                        msg = (
+                            f"Explicit wire body for family {family.name!r} does not "
+                            "enable attribute validation; use a mapping or body instance"
+                        )
+                        raise ValueError(msg)
+                    _validate_document_metadata_attributes(
+                        value,
+                        metadata_path=metadata_path,
+                        expected=label,
+                        family_name=family.name,
+                    )
+                if isinstance(value, cls):
+                    if revalidation != "always":
+                        synchronize_adapter(value)
+                        return value
+                    body = strip_metadata(value)
+                    body = inner_handler(body)
+                else:
+                    body = inner_handler(strip_metadata(value))
+                if foreign_body and body is value:
+                    body = _model_revalidation_proxy(body, type(body))
+                return cls._from_document_body(body)
+
+            def serialize_document(instance: BaseModel, handler: Any, info: Any) -> Any:
+                body = synchronize_adapter(instance)
+                try:
+                    serialized = handler(body)
+                finally:
+                    synchronize_adapter(instance)
+                if not isinstance(serialized, Mapping):
+                    msg = (
+                        f"Explicit wire body for family {family.name!r} and version "
+                        f"{label!r} must serialize to an object"
+                    )
+                    raise ValueError(msg)
+                return _copy_with_document_metadata(
+                    serialized,
+                    metadata_path=metadata_path,
+                    metadata_value=label,
+                    family_name=family.name,
+                )
+
+            return core_schema.no_info_wrap_validator_function(
+                validate_document,
+                body_schema,
+                serialization=core_schema.wrap_serializer_function_ser_schema(
+                    serialize_document,
+                    info_arg=True,
+                    schema=body_schema,
+                    return_schema=core_schema.dict_schema(),
+                ),
+            )
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls,
+            _core_schema: CoreSchema,
+            handler: GetJsonSchemaHandler,
+        ) -> dict[str, Any]:
+            body_core_schema: Any = _core_schema.get("schema")
+            if handler.mode == "serialization":
+                serialization = _core_schema.get("serialization")
+                if isinstance(serialization, Mapping):
+                    body_core_schema = serialization.get("schema", body_core_schema)
+            schema = deepcopy(handler(body_core_schema))
+            schema = deepcopy(handler.resolve_ref_schema(schema))
+            _add_document_metadata_json_schema(
+                schema,
+                metadata_path=metadata_path,
+                label=label,
+            )
+            return schema
+
+        def __getattr__(self, name: str) -> Any:
+            body = object.__getattribute__(
+                self,
+                "_FamilyDocumentAdapterBase__document_body",
+            )
+            if isinstance(body, body_model) and (
+                name in body_model.__private_attributes__
+                or name in body_model.model_computed_fields
+            ):
+                try:
+                    value = getattr(body, name)
+                    return self if value is body else value
+                finally:
+                    synchronize_adapter(self)
+            try:
+                base_getattr = vars(BaseModel)["__getattr__"]
+                value = base_getattr(self, name)
+                return self if value is body else value
+            except AttributeError:
+                raise
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            if name == _DOCUMENT_BODY_SLOT:
+                msg = f"Internal document state for family {family.name!r} is reserved"
+                raise AttributeError(msg)
+            body = object.__getattribute__(
+                self,
+                "_FamilyDocumentAdapterBase__document_body",
+            )
+            body_private = name in body_model.__private_attributes__
+            if isinstance(body, body_model) and (not name.startswith("_") or body_private):
+                metadata_root = (
+                    metadata_path if isinstance(metadata_path, str) else metadata_path[0]
+                )
+                if name == metadata_root:
+                    _copy_without_document_metadata(
+                        {name: value},
+                        metadata_path=metadata_path,
+                        expected=label,
+                        family_name=family.name,
+                    )
+                    return
+                try:
+                    setattr(body, name, value)
+                finally:
+                    synchronize_adapter(self)
+                return
+            super().__setattr__(name, value)
+
+        def __delattr__(self, name: str) -> None:
+            if name == _DOCUMENT_BODY_SLOT:
+                msg = f"Internal document state for family {family.name!r} is reserved"
+                raise AttributeError(msg)
+            body = object.__getattribute__(
+                self,
+                "_FamilyDocumentAdapterBase__document_body",
+            )
+            if isinstance(body, body_model):
+                metadata_root = (
+                    metadata_path if isinstance(metadata_path, str) else metadata_path[0]
+                )
+                if name == metadata_root:
+                    msg = f"Family-owned version metadata for {family.name!r} cannot be deleted"
+                    raise AttributeError(msg)
+                extras = body.__pydantic_extra__
+                body_extra = isinstance(extras, Mapping) and name in extras
+                if (
+                    name in body_model.model_fields
+                    or name in body_model.__private_attributes__
+                    or name in body_model.model_computed_fields
+                    or body_extra
+                ):
+                    try:
+                        delattr(body, name)
+                    finally:
+                        synchronize_adapter(self)
+                    return
+            super().__delattr__(name)
+
+        def model_copy(
+            self,
+            *,
+            update: Mapping[str, Any] | None = None,
+            deep: bool = False,
+        ) -> BaseModel:
+            body = object.__getattribute__(
+                self,
+                "_FamilyDocumentAdapterBase__document_body",
+            )
+            if not isinstance(body, body_model):
+                msg = (
+                    f"Family-owned document adapter for {family.name!r} lost its "
+                    "validated explicit wire body"
+                )
+                raise ValueError(msg)
+            body_update = None
+            if update is not None:
+                body_update = _copy_without_document_metadata(
+                    update,
+                    metadata_path=metadata_path,
+                    expected=label,
+                    family_name=family.name,
+                )
+            copied = body.model_copy(update=body_update, deep=deep)
+            adapter = type(self)._from_document_body(copied)
+            if not deep:
+                metadata_root = (
+                    metadata_path if isinstance(metadata_path, str) else metadata_path[0]
+                )
+                if metadata_root in self.__dict__:
+                    adapter.__dict__[metadata_root] = self.__dict__[metadata_root]
+            return adapter
+
+        def __copy__(self) -> BaseModel:
+            return self.model_copy()
+
+        def __iter__(self) -> Any:
+            synchronize_adapter(self)
+            return super().__iter__()
+
+        def __repr_args__(self) -> Any:
+            synchronize_adapter(self)
+            return super().__repr_args__()
+
+        def __eq__(self, other: Any) -> bool:
+            for value in (self, other):
+                if isinstance(value, _FamilyDocumentAdapterBase):
+                    synchronize_adapter(value)
+            return super().__eq__(other)
+
+        def __deepcopy__(self, memo: dict[int, Any] | None = None) -> BaseModel:
+            if memo is None:
+                memo = {}
+            existing = memo.get(id(self))
+            if isinstance(existing, type(self)):
+                return existing
+            placeholder = object.__new__(type(self))
+            memo[id(self)] = placeholder
+            body = object.__getattribute__(
+                self,
+                "_FamilyDocumentAdapterBase__document_body",
+            )
+            if not isinstance(body, body_model):
+                msg = (
+                    f"Family-owned document adapter for {family.name!r} lost its "
+                    "validated explicit wire body"
+                )
+                raise ValueError(msg)
+            copied = type(self)._from_document_body(deepcopy(body, memo))
+            metadata_root = metadata_path if isinstance(metadata_path, str) else metadata_path[0]
+            if metadata_root in self.__dict__:
+                copied.__dict__[metadata_root] = deepcopy(
+                    self.__dict__[metadata_root],
+                    memo,
+                )
+            _FamilyDocumentAdapterBase._replace_document_adapter_state(
+                placeholder,
+                copied,
+            )
+            return placeholder
+
+    fields: dict[str, Any] = {
+        name: (field_info.annotation, _copy_document_field_info(field_info))
+        for name, field_info in body_model.model_fields.items()
+    }
+    _add_family_metadata_field(family, label, fields)
+    adapter = create_model(
+        _generated_model_name(family.model, family.name, label),
+        __base__=_FamilyDocumentAdapterBase,
+        __module__=family.model.__module__,
+        **fields,
+    )
+    adapter.__pydantic_computed_fields__ = dict(body_model.model_computed_fields)
+    _validate_object_schema(family, projection, adapter, mode="validation")
+    _validate_object_schema(family, projection, adapter, mode="serialization")
+    return adapter
+
+
+def _model_revalidation_proxy(
+    instance: BaseModel,
+    target_type: type[BaseModel],
+) -> BaseModel:
+    proxy = object.__new__(target_type)
+    object.__setattr__(proxy, "__dict__", dict(instance.__dict__))
+    extras = instance.__pydantic_extra__
+    object.__setattr__(
+        proxy,
+        "__pydantic_extra__",
+        None if extras is None else dict(extras),
+    )
+    object.__setattr__(
+        proxy,
+        "__pydantic_fields_set__",
+        set(instance.__pydantic_fields_set__),
+    )
+    private = instance.__pydantic_private__
+    object.__setattr__(
+        proxy,
+        "__pydantic_private__",
+        None if private is None else dict(private),
+    )
+    standard_slots = {
+        "__dict__",
+        "__pydantic_extra__",
+        "__pydantic_fields_set__",
+        "__pydantic_private__",
+    }
+    for owner in type(instance).__mro__:
+        for name, descriptor in vars(owner).items():
+            if name in standard_slots or not isinstance(descriptor, MemberDescriptorType):
+                continue
+            try:
+                slot_value = descriptor.__get__(instance, type(instance))
+            except AttributeError:
+                continue
+            descriptor.__set__(proxy, slot_value)
+    return proxy
+
+
+def _copy_document_field_info(field_info: Any) -> Any:
+    copied = copy(field_info)
+    if any(
+        alias is not None
+        for alias in (
+            field_info.alias,
+            field_info.validation_alias,
+            field_info.serialization_alias,
+        )
+    ):
+        copied.alias_priority = 2
+    return copied
+
+
+def _validate_family_document_adapter_schema_hooks(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    body_model: type[BaseModel],
+) -> None:
+    for hook in _CUSTOM_MODEL_HOOKS:
+        owner = _first_defining_class(body_model, hook)
+        if owner is not None and owner is not BaseModel:
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"family-owned metadata cannot safely compose custom model hook {hook} "
+                "from an explicit wire body",
+            )
+
+
+def _validate_family_document_adapter_member_collisions(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    body_model: type[BaseModel],
+) -> None:
+    reserved = set(vars(BaseModel)) | {
+        _DOCUMENT_BODY_SLOT,
+        "_document_body_model",
+        "_from_document_body",
+        "_replace_document_adapter_state",
+    }
+    for kind, names in (
+        ("private attribute", body_model.__private_attributes__),
+        ("computed field", body_model.model_computed_fields),
+    ):
+        collision = next((name for name in names if name in reserved), None)
+        if collision is None:
+            continue
+        _raise_projection_unsupported(
+            family,
+            projection,
+            f"explicit wire body {kind} {collision!r} conflicts with the "
+            "family-owned document adapter API",
+        )
+
+
+def _reject_explicit_body_document_metadata(
+    body: BaseModel,
+    *,
+    metadata_path: str | tuple[str, ...],
+    family_name: str,
+) -> None:
+    extras = body.__pydantic_extra__
+    if not isinstance(extras, Mapping):
+        return
+    path = (metadata_path,) if isinstance(metadata_path, str) else metadata_path
+    if path[0] not in extras:
+        return
+    msg = (
+        f"Explicit wire body for family {family_name!r} contains the reserved "
+        f"family-owned metadata root {path[0]!r}"
+    )
+    raise ValueError(msg)
+
+
+def _validate_document_metadata_attributes(
+    value: Any,
+    *,
+    metadata_path: str | tuple[str, ...],
+    expected: str,
+    family_name: str,
+) -> None:
+    path = (metadata_path,) if isinstance(metadata_path, str) else metadata_path
+    current = value
+    for index, part in enumerate(path):
+        if index > 0:
+            current_mapping = _document_metadata_mapping(current)
+            if current_mapping is None:
+                try:
+                    namespace = object.__getattribute__(current, "__dict__")
+                except (AttributeError, TypeError):
+                    namespace = None
+                if isinstance(namespace, Mapping):
+                    current_mapping = namespace
+            if current_mapping is None or set(current_mapping) != {part}:
+                msg = (
+                    f"Version metadata for family {family_name!r} reserves the entire "
+                    f"root {path[0]!r}; the complete metadata path is required "
+                    "without siblings"
+                )
+                raise ValueError(msg)
+            current = current_mapping[part]
+            continue
+        if isinstance(current, Mapping):
+            if part not in current:
+                if index == 0:
+                    return
+                msg = (
+                    f"Version metadata for family {family_name!r} is incomplete at "
+                    f"reserved path component {part!r}"
+                )
+                raise ValueError(msg)
+            current = current[part]
+            continue
+        try:
+            current = getattr(current, part)
+        except AttributeError:
+            if index == 0:
+                return
+            msg = (
+                f"Version metadata for family {family_name!r} is incomplete at "
+                f"reserved path component {part!r}"
+            )
+            raise ValueError(msg) from None
+        except Exception as exc:
+            msg = (
+                f"Version metadata for family {family_name!r} could not be read "
+                f"from attribute path component {part!r}"
+            )
+            raise ValueError(msg) from exc
+    if current != expected:
+        msg = f"Version metadata for family {family_name!r} is {current!r}; expected {expected!r}"
+        raise ValueError(msg)
+
+
+def _copy_without_document_metadata(
+    value: Mapping[Any, Any],
+    *,
+    metadata_path: str | tuple[str, ...],
+    expected: str,
+    family_name: str,
+) -> dict[Any, Any]:
+    path = (metadata_path,) if isinstance(metadata_path, str) else metadata_path
+    copied: dict[Any, Any] = dict(value)
+    root = path[0]
+    if root not in copied:
+        return copied
+    if len(path) == 1:
+        declared = copied.pop(root)
+        if declared != expected:
+            msg = (
+                f"Version metadata for family {family_name!r} is {declared!r}; "
+                f"expected {expected!r}"
+            )
+            raise ValueError(msg)
+        return copied
+
+    current: Any = copied[root]
+    for part in path[1:-1]:
+        current_mapping = _document_metadata_mapping(current)
+        if current_mapping is None:
+            msg = (
+                f"Version metadata for family {family_name!r} has a non-object "
+                f"component at {part!r}"
+            )
+            raise ValueError(msg)
+        if set(current_mapping) != {part}:
+            msg = (
+                f"Version metadata for family {family_name!r} reserves the entire "
+                f"root {root!r}; sibling data cannot share that envelope"
+            )
+            raise ValueError(msg)
+        current = current_mapping[part]
+    final = path[-1]
+    current_mapping = _document_metadata_mapping(current)
+    if current_mapping is None:
+        msg = f"Version metadata for family {family_name!r} has a non-object component at {final!r}"
+        raise ValueError(msg)
+    if set(current_mapping) != {final}:
+        msg = (
+            f"Version metadata for family {family_name!r} reserves the entire "
+            f"root {root!r}; the complete metadata path is required without siblings"
+        )
+        raise ValueError(msg)
+    declared = current_mapping[final]
+    if declared != expected:
+        msg = f"Version metadata for family {family_name!r} is {declared!r}; expected {expected!r}"
+        raise ValueError(msg)
+    copied.pop(root)
+    return copied
+
+
+def _copy_with_document_metadata(
+    payload: Mapping[Any, Any],
+    *,
+    metadata_path: str | tuple[str, ...],
+    metadata_value: str,
+    family_name: str,
+) -> dict[Any, Any]:
+    path = (metadata_path,) if isinstance(metadata_path, str) else metadata_path
+    copied: dict[Any, Any] = dict(payload)
+    current = copied
+    for part in path[:-1]:
+        existing = current.get(part, _MISSING)
+        if existing is _MISSING:
+            child: dict[Any, Any] = {}
+        else:
+            msg = (
+                f"Explicit wire serializer for family {family_name!r} conflicts with "
+                f"version metadata at reserved path component {part!r}"
+            )
+            raise ValueError(msg)
+        current[part] = child
+        current = child
+    final = path[-1]
+    existing = current.get(final, _MISSING)
+    if existing is not _MISSING:
+        msg = (
+            f"Explicit wire serializer for family {family_name!r} emitted conflicting "
+            f"version metadata {existing!r}; the family-owned path is reserved"
+        )
+        raise ValueError(msg)
+    current[final] = metadata_value
+    return copied
+
+
+def _document_metadata_mapping(value: Any) -> Mapping[Any, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    if not isinstance(value, BaseModel):
+        return None
+    mapped = {
+        name: value.__dict__[name] for name in type(value).model_fields if name in value.__dict__
+    }
+    extras = value.__pydantic_extra__
+    if isinstance(extras, Mapping):
+        mapped.update(extras)
+    return mapped
+
+
+def _add_document_metadata_json_schema(
+    schema: dict[str, Any],
+    *,
+    metadata_path: str | tuple[str, ...],
+    label: str,
+) -> None:
+    path = (metadata_path,) if isinstance(metadata_path, str) else metadata_path
+    current = schema
+    for index, part in enumerate(path):
+        current.setdefault("type", "object")
+        properties = current.setdefault("properties", {})
+        if not isinstance(properties, dict):
+            return
+        if index == len(path) - 1:
+            properties[part] = {
+                "const": label,
+                "default": label,
+                "title": part.replace("_", " ").title(),
+                "type": "string",
+            }
+            return
+        existing_child = properties.get(part)
+        child: dict[str, Any]
+        if isinstance(existing_child, dict):
+            child = cast(dict[str, Any], existing_child)
+        else:
+            child = {"type": "object", "properties": {}}
+            properties[part] = child
+        child["additionalProperties"] = False
+        child["required"] = [path[index + 1]]
+        current = child
 
 
 def _validate_explicit_wire_model_metadata(
@@ -493,6 +1307,7 @@ def _build_model_for_projection_unchecked(
         generated,
         model_metadata_field=model_metadata_field,
     )
+    _validate_unique_serialization_names(family, projection, generated)
     _validate_object_schema(family, projection, generated, mode="validation")
     _validate_object_schema(family, projection, generated, mode="serialization")
     return generated
@@ -1114,15 +1929,48 @@ def _validate_family_metadata_collision(family: SchemaFamily[Any]) -> None:
         return
     root_name = metadata.path if isinstance(metadata.path, str) else metadata.path[0]
     for field_name, field_info in family.model.model_fields.items():
-        if (
-            root_name == field_name
-            or root_name == field_info.alias
-            or root_name == field_info.validation_alias
-            or root_name == field_info.serialization_alias
+        attributes = field_info.asdict()["attributes"]
+        if any(
+            key in attributes and _has_effect(attributes[key]) for key in _OMITTED_FIELD_ATTRIBUTES
+        ):
+            continue
+        if any(
+            path and path[0] == root_name for path in _field_contract_paths(field_name, field_info)
         ):
             _raise_unsupported(
                 family,
                 f"family-owned version metadata collides with body field {field_name!r}",
+            )
+
+
+def _validate_explicit_family_metadata_collision(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    model: type[BaseModel],
+) -> None:
+    metadata = family.version_metadata
+    if metadata is None or metadata.owner != "family":
+        return
+    root_name = metadata.path if isinstance(metadata.path, str) else metadata.path[0]
+    for field_name, field_info in model.model_fields.items():
+        if any(
+            path and path[0] == root_name for path in _field_contract_paths(field_name, field_info)
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"family-owned version metadata collides with explicit wire field {field_name!r}",
+            )
+    for field_name, field_info in model.model_computed_fields.items():
+        if any(
+            path and path[0] == root_name
+            for path in _computed_field_output_paths(field_name, field_info)
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                "family-owned version metadata collides with explicit wire computed "
+                f"field {field_name!r}",
             )
 
 
@@ -1181,6 +2029,438 @@ def _validate_generated_metadata_aliases(
                 projection,
                 f"version metadata overlaps projected field or alias {field_name!r}",
             )
+    for field_name, field_info in model.model_computed_fields.items():
+        if any(
+            path and path[0] in reserved_roots
+            for path in _computed_field_output_paths(field_name, field_info)
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"version metadata overlaps computed field or alias {field_name!r}",
+            )
+
+
+def _field_contract_paths(field_name: str, field_info: Any) -> tuple[tuple[str | int, ...], ...]:
+    return (
+        (field_name,),
+        *_alias_paths(field_info.alias),
+        *_alias_paths(field_info.validation_alias),
+        *_alias_paths(field_info.serialization_alias),
+    )
+
+
+def _computed_field_output_paths(
+    field_name: str,
+    field_info: Any,
+) -> tuple[tuple[str | int, ...], ...]:
+    return ((field_name,), *_alias_paths(field_info.alias))
+
+
+def _validate_unique_serialization_names(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    model: type[BaseModel],
+) -> None:
+    schema = model.__pydantic_core_schema__
+    definitions = _core_schema_definitions(schema)
+    root = schema.get("schema") if schema.get("type") == "definitions" else schema
+    _validate_core_schema_serialization_names(
+        family,
+        projection,
+        root,
+        definitions=definitions,
+        seen=set(),
+    )
+
+
+def _raise_duplicate_serialization_name(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    model: type[Any],
+    output_name: str,
+    first: str,
+    second: str,
+) -> None:
+    _raise_projection_unsupported(
+        family,
+        projection,
+        f"wire model {_model_display(model)!r} serializes {first} and {second} "
+        f"to duplicate output name {output_name!r}",
+    )
+
+
+def _core_schema_definitions(schema: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    definitions = schema.get("definitions")
+    if not isinstance(definitions, list):
+        return {}
+    return {
+        reference: definition
+        for definition in definitions
+        if isinstance(definition, Mapping) and isinstance(reference := definition.get("ref"), str)
+    }
+
+
+def _validate_core_schema_serialization_names(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    schema: Any,
+    *,
+    definitions: Mapping[str, Mapping[str, Any]],
+    seen: set[int],
+    owner: type[Any] | None = None,
+) -> None:
+    if id(schema) in seen:
+        return
+    seen.add(id(schema))
+    if isinstance(schema, list | tuple):
+        for item in schema:
+            _validate_core_schema_serialization_names(
+                family,
+                projection,
+                item,
+                definitions=definitions,
+                seen=seen,
+                owner=owner,
+            )
+        return
+    if not isinstance(schema, Mapping):
+        return
+    serialization = schema.get("serialization")
+    if isinstance(serialization, Mapping) and serialization.get(
+        "when_used",
+        "always",
+    ) in ("always", "unless-none"):
+        return
+
+    schema_type = schema.get("type")
+    if schema_type == "definition-ref":
+        reference = schema.get("schema_ref")
+        resolved = definitions.get(reference) if isinstance(reference, str) else None
+        if resolved is not None:
+            _validate_core_schema_serialization_names(
+                family,
+                projection,
+                resolved,
+                definitions=definitions,
+                seen=seen,
+                owner=owner,
+            )
+        return
+
+    candidate_owner = schema.get("cls")
+    if isinstance(candidate_owner, type):
+        owner = candidate_owner
+    if schema_type in ("model", "dataclass"):
+        _validate_core_schema_serialization_names(
+            family,
+            projection,
+            schema.get("schema"),
+            definitions=definitions,
+            seen=seen,
+            owner=owner,
+        )
+        return
+
+    if schema_type in ("model-fields", "typed-dict"):
+        fields = schema.get("fields")
+        if isinstance(fields, Mapping):
+            entries = tuple(
+                (name, field)
+                for name, field in fields.items()
+                if isinstance(name, str) and isinstance(field, Mapping)
+            )
+            _validate_core_schema_object_fields(
+                family,
+                projection,
+                entries,
+                computed=schema.get("computed_fields"),
+                definitions=definitions,
+                seen=seen,
+                owner=owner,
+            )
+        return
+
+    if schema_type == "dataclass-args":
+        fields = schema.get("fields")
+        if isinstance(fields, list):
+            entries = tuple(
+                (name, field)
+                for field in fields
+                if isinstance(field, Mapping) and isinstance(name := field.get("name"), str)
+            )
+            _validate_core_schema_object_fields(
+                family,
+                projection,
+                entries,
+                computed=schema.get("computed_fields"),
+                definitions=definitions,
+                seen=seen,
+                owner=owner,
+            )
+        return
+
+    for value in schema.values():
+        _validate_core_schema_serialization_names(
+            family,
+            projection,
+            value,
+            definitions=definitions,
+            seen=seen,
+            owner=owner,
+        )
+
+
+def _validate_core_schema_object_fields(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    fields: tuple[tuple[str, Mapping[str, Any]], ...],
+    *,
+    computed: Any,
+    definitions: Mapping[str, Mapping[str, Any]],
+    seen: set[int],
+    owner: type[Any] | None,
+) -> None:
+    selected: dict[str, str] = {}
+    for field_name, field_schema in fields:
+        if field_schema.get("serialization_exclude") is True:
+            continue
+        serialization_alias = field_schema.get("serialization_alias")
+        output_name = field_name if serialization_alias is None else serialization_alias
+        description = f"field {field_name!r}"
+        _record_core_schema_output_name(
+            family,
+            projection,
+            owner=owner,
+            selected=selected,
+            output_name=output_name,
+            description=description,
+        )
+        _validate_core_schema_serialization_names(
+            family,
+            projection,
+            field_schema.get("schema"),
+            definitions=definitions,
+            seen=seen,
+        )
+
+    if not isinstance(computed, list):
+        return
+
+    for computed_schema in computed:
+        if not isinstance(computed_schema, Mapping):
+            continue
+        field_name = computed_schema.get("property_name")
+        if not isinstance(field_name, str):
+            continue
+        computed_alias = computed_schema.get("alias")
+        output_name = field_name if computed_alias is None else computed_alias
+        description = f"computed field {field_name!r}"
+        _record_core_schema_output_name(
+            family,
+            projection,
+            owner=owner,
+            selected=selected,
+            output_name=output_name,
+            description=description,
+        )
+        _validate_core_schema_serialization_names(
+            family,
+            projection,
+            computed_schema.get("return_schema"),
+            definitions=definitions,
+            seen=seen,
+        )
+
+
+def _record_core_schema_output_name(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    owner: type[Any] | None,
+    selected: dict[str, str],
+    output_name: Any,
+    description: str,
+) -> None:
+    if not isinstance(output_name, str):
+        return
+    previous = selected.get(output_name)
+    if previous is not None and previous != description:
+        _raise_duplicate_serialization_name(
+            family,
+            projection,
+            model=family.model if owner is None else owner,
+            output_name=output_name,
+            first=previous,
+            second=description,
+        )
+    selected[output_name] = description
+
+
+def _model_has_model_serializer(model: type[BaseModel]) -> bool:
+    decorators = getattr(model, "__pydantic_decorators__", None)
+    return bool(decorators is not None and getattr(decorators, "model_serializers", None))
+
+
+def _validate_explicit_nested_serializer_boundaries(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    wire_model: type[BaseModel],
+    *,
+    nested: tuple[_CompiledNestedFamily, ...],
+) -> None:
+    for route in nested:
+        first = projection.field(route.path[0]).version_name
+        if first is None:
+            continue
+        target_path = (first, *route.path[1:])
+        owners = [wire_model]
+        for index, field_name in enumerate(target_path):
+            next_owners: list[type[BaseModel]] = []
+            for owner in owners:
+                if owner.model_config.get("json_encoders"):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(owner)!r} configures "
+                        f"json_encoders along declared nested path {route.path!r}; "
+                        "custom encoders can replace child document values",
+                    )
+                for hook in _CUSTOM_MODEL_HOOKS:
+                    hook_owner = _first_defining_class(owner, hook)
+                    if hook_owner is not None and hook_owner is not BaseModel:
+                        _raise_projection_unsupported(
+                            family,
+                            projection,
+                            f"explicit wire model {_model_display(owner)!r} uses "
+                            f"custom model hook {hook} along declared nested path "
+                            f"{route.path!r}; custom schemas can relocate child "
+                            "document paths",
+                        )
+                if _model_has_model_serializer(owner):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(owner)!r} uses a "
+                        "model-level serializer along declared nested path "
+                        f"{route.path!r}; serializers can relocate child document paths",
+                    )
+                field_info = owner.model_fields.get(field_name)
+                if field_info is None:
+                    continue
+                if _model_has_field_serializer(owner, field_name):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(owner)!r} serializes field "
+                        f"{field_name!r} along declared nested path {route.path!r}; "
+                        "serializers can relocate child document paths",
+                    )
+                if _field_has_functional_serializer(field_info):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(owner)!r} uses an "
+                        f"annotation-level serializer on field {field_name!r} along "
+                        f"declared nested path {route.path!r}; serializers can relocate "
+                        "child document paths",
+                    )
+                if index == len(target_path) - 1:
+                    continue
+                _collect_immediate_base_models(
+                    field_info.annotation,
+                    models=next_owners,
+                    seen=set(),
+                )
+            owners = next_owners
+
+
+def _annotation_has_functional_serializer(annotation: Any, *, seen: set[int]) -> bool:
+    if isinstance(
+        annotation,
+        (PlainSerializer, _SERIALIZE_AS_ANY_METADATA_TYPE, WrapSerializer),
+    ):
+        return True
+    if id(annotation) in seen:
+        return False
+    seen.add(id(annotation))
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        return _annotation_has_functional_serializer(annotation.__value__, seen=seen)
+    arguments = get_args(annotation)
+    if get_origin(annotation) is Annotated:
+        base, *metadata = arguments
+        if any(_metadata_has_unsafe_nested_serialization(item) for item in metadata):
+            return True
+        return _annotation_has_functional_serializer(base, seen=seen)
+    return any(
+        argument is not Ellipsis and _annotation_has_functional_serializer(argument, seen=seen)
+        for argument in arguments
+    )
+
+
+def _field_has_functional_serializer(field_info: Any) -> bool:
+    return _annotation_has_functional_serializer(
+        field_info.annotation,
+        seen=set(),
+    ) or any(_metadata_has_unsafe_nested_serialization(item) for item in field_info.metadata)
+
+
+def _metadata_has_unsafe_nested_serialization(item: Any) -> bool:
+    return (
+        isinstance(
+            item,
+            (PlainSerializer, _SERIALIZE_AS_ANY_METADATA_TYPE, WrapSerializer),
+        )
+        or isinstance(item, GetPydanticSchema)
+        or _has_schema_hook(item)
+    )
+
+
+def _model_has_field_serializer(model: type[BaseModel], field_name: str) -> bool:
+    decorators = getattr(model, "__pydantic_decorators__", None)
+    serializers = None if decorators is None else getattr(decorators, "field_serializers", None)
+    if not serializers:
+        return False
+    return any(
+        field_name in decorator.info.fields or "*" in decorator.info.fields
+        for decorator in serializers.values()
+    )
+
+
+def _collect_immediate_base_models(
+    annotation: Any,
+    *,
+    models: list[type[BaseModel]],
+    seen: set[int],
+) -> None:
+    if id(annotation) in seen:
+        return
+    seen.add(id(annotation))
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        _collect_immediate_base_models(annotation.__value__, models=models, seen=seen)
+        return
+    if isinstance(annotation, TypeVar):
+        for value in _type_parameter_values(annotation):
+            _collect_immediate_base_models(value, models=models, seen=seen)
+        return
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        _collect_immediate_base_models(supertype, models=models, seen=seen)
+        return
+    try:
+        is_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
+    except TypeError:
+        is_model = False
+    if is_model:
+        models.append(annotation)
+        return
+    if get_origin(annotation) is Literal:
+        return
+    for argument in get_args(annotation):
+        if argument is Ellipsis:
+            continue
+        _collect_immediate_base_models(argument, models=models, seen=seen)
 
 
 def _alias_paths(alias: Any) -> tuple[tuple[str | int, ...], ...]:
@@ -1283,10 +2563,8 @@ def _add_nested_family_metadata_field(
 
 
 def _metadata_wrapper_config(family: SchemaFamily[Any]) -> ConfigDict:
-    extra = family.model.model_config.get("extra")
-    if extra is None:
-        return ConfigDict()
-    return ConfigDict(extra=extra)
+    del family
+    return ConfigDict(extra="forbid", frozen=True)
 
 
 def _metadata_model_name(

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -18,6 +18,7 @@ from pydantic_versions._compiler import (
 )
 from pydantic_versions._planning import _build_planning_catalog, _schema_path
 from pydantic_versions._runtime import (
+    _defaults_family,
     _dump_family,
     _runtime_label,
     _validate_family,
@@ -292,10 +293,11 @@ class SchemaFamily[T: BaseModel]:
         include_version: bool = True,
         **dump_kwargs: Any,
     ) -> dict[str, Any]:
-        return self.dump(
+        return _defaults_family(
+            self,
             version=version,
             include_version=include_version,
-            **dump_kwargs,
+            dump_kwargs=dump_kwargs,
         )
 
     def dump(

--- a/tests/compatibility/README.md
+++ b/tests/compatibility/README.md
@@ -27,3 +27,10 @@ The write command refuses a different package version. Review the resulting
 human-readable diff before committing it. Never regenerate solely to make a
 compatibility failure disappear: either preserve the stable contract or
 document and version the intentional change according to the stability policy.
+
+The immutable artifact also preserves 0.3.0's redundant family-owned version
+metadata inside nested child payloads. Before 1.0, rendering was corrected to
+let the parent mapping own that selection consistently for direct and
+collection children. The checker derives the current expected contract by
+removing only those three reviewed nested discriminator paths; every other
+payload and inspection value must still match the released golden exactly.

--- a/tests/compatibility/v0_3_0_contract.py
+++ b/tests/compatibility/v0_3_0_contract.py
@@ -60,6 +60,11 @@ _REVIEWED_NESTED_PLAN_OVERLAY: tuple[tuple[str, str, dict[str, Any]], ...] = (
         },
     ),
 )
+_REVIEWED_NESTED_METADATA_REMOVALS = (
+    "exact_embedded_v2",
+    "exact_transport_v2",
+    "lossy_embedded_v1",
+)
 
 
 def _upgrade_endpoint(data: dict[str, Any]) -> dict[str, Any]:
@@ -279,6 +284,9 @@ def render_artifact() -> str:
 
 def _expected_current_artifact(baseline: dict[str, Any]) -> dict[str, Any]:
     expected = deepcopy(baseline)
+    payloads = expected["payloads"]
+    for payload_name in _REVIEWED_NESTED_METADATA_REMOVALS:
+        payloads[payload_name]["credentials"].pop("schema_version")
     inspection = expected["inspection"]
     for plan_name, owning_step_id, nested_step in _REVIEWED_NESTED_PLAN_OVERLAY:
         steps = inspection[plan_name]["steps"]

--- a/tests/integration/test_application_exchange_scenario.py
+++ b/tests/integration/test_application_exchange_scenario.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 
 from pydantic_versions import (
     IrreversibleTransitionError,
@@ -216,3 +216,63 @@ def test_exchange_supports_transport_owned_version_metadata() -> None:
     received = CONSUMER_SCHEMA.validate(payload, version="2")
     assert received.current_model.retries == 6
     assert received.current_model.timeout == 12
+
+
+def test_exchange_uses_serialization_aliases_and_requires_a_matching_consumer_location() -> None:
+    class AliasedProducer(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=False)
+
+        worker_name: str = Field(
+            validation_alias="producerInput",
+            serialization_alias="worker",
+        )
+
+    producer = SchemaFamily(
+        model=AliasedProducer,
+        name="com.example.aliased-exchange",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    class StrictConsumer(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=False)
+
+        name: str = Field(validation_alias="worker")
+
+    strict_consumer = SchemaFamily(
+        model=StrictConsumer,
+        name=producer.name,
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    current = AliasedProducer.model_validate({"producerInput": "alpha"})
+
+    outgoing = producer.dump(version="1", data=current)
+    transported = json.loads(json.dumps(outgoing))
+
+    assert transported == {"worker": "alpha"}
+    assert strict_consumer.validate(transported, version="1").current_model.name == "alpha"
+
+    name_output = producer.dump(version="1", data=current, by_alias=False)
+    assert name_output == {"worker_name": "alpha"}
+    with pytest.raises(ValidationError):
+        strict_consumer.validate(name_output, version="1")
+
+    class CompatibleConsumer(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=False)
+
+        name: str = Field(validation_alias=AliasChoices("worker", "worker_name"))
+
+    compatible_consumer = SchemaFamily(
+        model=CompatibleConsumer,
+        name=producer.name,
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    assert (
+        compatible_consumer.validate(
+            name_output,
+            version="1",
+        ).current_model.name
+        == "alpha"
+    )

--- a/tests/integration/test_cross_release_compatibility.py
+++ b/tests/integration/test_cross_release_compatibility.py
@@ -21,6 +21,15 @@ def _fixture() -> dict[str, Any]:
 def test_current_code_matches_the_reviewed_v0_3_0_additive_overlay() -> None:
     baseline = FIXTURE_PATH.read_text(encoding="utf-8")
     assert render_artifact() == render_expected_current_artifact(baseline)
+    frozen = json.loads(baseline)
+    current = json.loads(render_artifact())
+    for payload_name in (
+        "exact_embedded_v2",
+        "exact_transport_v2",
+        "lossy_embedded_v1",
+    ):
+        assert "schema_version" in frozen["payloads"][payload_name]["credentials"]
+        assert "schema_version" not in current["payloads"][payload_name]["credentials"]
 
 
 def test_current_code_consumes_persisted_embedded_and_transport_payloads() -> None:

--- a/tests/unit/test_decorator_nested_boundaries.py
+++ b/tests/unit/test_decorator_nested_boundaries.py
@@ -40,7 +40,7 @@ def test_decorator_child_uses_its_historical_wire_projection() -> None:
     )
 
     assert rendered == {
-        "child": {"legacy_value": 7, "schema_version": "1"},
+        "child": {"legacy_value": 7},
         "schema_version": "1",
     }
     validated = validate_versioned(Parent, rendered)
@@ -122,8 +122,8 @@ def test_overlapping_union_preserves_authoritative_typed_branch() -> None:
     )
 
     assert rendered["items"] == [
-        {"value": "second:b2:b1", "schema_version": "1"},
-        {"value": "first:a2:a1", "schema_version": "1"},
+        {"value": "second:b2:b1"},
+        {"value": "first:a2:a1"},
     ]
     assert calls == ["a2", "b2", "a1", "b1"]
 
@@ -479,7 +479,6 @@ def test_exact_typed_replacement_on_final_parent_edge_is_fully_downgraded() -> N
 
     assert rendered["item"] == {
         "legacy_b": "replacement:b1",
-        "schema_version": "1",
     }
 
 
@@ -683,7 +682,7 @@ def test_decorator_boundaries_recurse_across_decorated_families() -> None:
         data=Parent(child=Child(grandchildren=[Grandchild(value=11)])),
     )
 
-    assert rendered["child"]["old_grandchildren"] == [{"legacy_value": 11, "schema_version": "1"}]
+    assert rendered["child"]["old_grandchildren"] == [{"legacy_value": 11}]
     assert validate_versioned(Parent, rendered).current_model.child.grandchildren[0].value == 11
 
 
@@ -719,14 +718,18 @@ def test_decorator_children_project_wrapper_defaults_without_running_opaque_fact
     class FactoryParent(BaseModel):
         wrapper: FactoryWrapper = Field(default_factory=FactoryWrapper)
 
-    expected = {
+    model_expected = {
         "wrapper": {"child": {"legacy_value": 7, "schema_version": "1"}},
         "schema_version": "1",
     }
-    assert model_for_version(InstanceParent, "1")().model_dump() == expected
-    assert dump_versioned(InstanceParent, version="1") == expected
-    assert model_for_version(FactoryParent, "1")().model_dump() == expected
-    assert dump_versioned(FactoryParent, version="1") == expected
+    dump_expected = {
+        "wrapper": {"child": {"legacy_value": 7}},
+        "schema_version": "1",
+    }
+    assert model_for_version(InstanceParent, "1")().model_dump() == model_expected
+    assert dump_versioned(InstanceParent, version="1") == dump_expected
+    assert model_for_version(FactoryParent, "1")().model_dump() == model_expected
+    assert dump_versioned(FactoryParent, version="1") == dump_expected
 
     @versioned_schema(
         name="direct_extra_default_parent",
@@ -741,7 +744,10 @@ def test_decorator_children_project_wrapper_defaults_without_running_opaque_fact
         "schema_version": "1",
     }
     assert model_for_version(DirectExtraParent, "1")().model_dump() == direct_expected
-    assert dump_versioned(DirectExtraParent, version="1") == direct_expected
+    assert dump_versioned(DirectExtraParent, version="1") == {
+        "child": {"legacy_value": 7},
+        "schema_version": "1",
+    }
 
 
 def test_decorator_children_project_defaults_through_every_builtin_shape() -> None:
@@ -770,7 +776,7 @@ def test_decorator_children_project_defaults_through_every_builtin_shape() -> No
         frozen: frozenset[Child] = frozenset({Child(value=7)})
         deep: list[dict[str, Wrapper]] = [{"x": Wrapper(child=Child(value=8))}]
 
-    expected_values = {
+    model_expected_values = {
         "listed": [{"legacy_value": 1, "schema_version": "1"}],
         "variadic": [{"legacy_value": 2, "schema_version": "1"}],
         "fixed": [{"legacy_value": 3, "schema_version": "1"}, "fixed"],
@@ -781,8 +787,19 @@ def test_decorator_children_project_defaults_through_every_builtin_shape() -> No
         "deep": [{"x": {"child": {"legacy_value": 8, "schema_version": "1"}}}],
         "schema_version": "1",
     }
-    assert model_for_version(Parent, "1")().model_dump(mode="json") == expected_values
-    assert dump_versioned(Parent, version="1") == expected_values
+    dump_expected_values = {
+        "listed": [{"legacy_value": 1}],
+        "variadic": [{"legacy_value": 2}],
+        "fixed": [{"legacy_value": 3}, "fixed"],
+        "mapped": {"x": {"legacy_value": 4}},
+        "optional": {"legacy_value": 5},
+        "setted": [{"legacy_value": 6}],
+        "frozen": [{"legacy_value": 7}],
+        "deep": [{"x": {"child": {"legacy_value": 8}}}],
+        "schema_version": "1",
+    }
+    assert model_for_version(Parent, "1")().model_dump(mode="json") == model_expected_values
+    assert dump_versioned(Parent, version="1") == dump_expected_values
 
     factory_calls: list[str] = []
 
@@ -847,9 +864,9 @@ def test_parent_callback_can_introduce_exact_typed_decorator_branches() -> None:
 
     assert rendered == {
         "items": [
-            {"legacy_value": "existing:child", "schema_version": "1"},
+            {"legacy_value": "existing:child"},
             0,
-            {"legacy_value": "introduced:child", "schema_version": "1"},
+            {"legacy_value": "introduced:child"},
         ],
         "schema_version": "1",
     }
@@ -960,8 +977,7 @@ def test_exact_typed_owner_replacement_rebinds_its_recursive_subtree() -> None:
 
     assert rendered == {
         "item": {
-            "grand": {"legacy_value": 12, "schema_version": "1"},
-            "schema_version": "1",
+            "grand": {"legacy_value": 12},
         },
         "schema_version": "1",
     }
@@ -1119,8 +1135,7 @@ def test_decorator_to_explicit_nested_family_round_trips_historical_names() -> N
 
     assert rendered == {
         "child": {
-            "grand": {"legacy_value": 1, "schema_version": "1"},
-            "schema_version": "1",
+            "grand": {"legacy_value": 1},
         },
         "schema_version": "1",
     }

--- a/tests/unit/test_decorator_nested_compilation.py
+++ b/tests/unit/test_decorator_nested_compilation.py
@@ -341,7 +341,11 @@ def test_unavailable_decorator_child_downgrade_names_the_child_family() -> None:
         child: CompilationUnavailableChild77
 
     with pytest.raises(IrreversibleTransitionError) as error:
-        dump_versioned(CompilationUnavailableParent77, version="1")
+        dump_versioned(
+            CompilationUnavailableParent77,
+            version="1",
+            data=CompilationUnavailableParent77(child=CompilationUnavailableChild77(value=1)),
+        )
 
     message = str(error.value)
     assert "compilation_unavailable_child_77" in message
@@ -503,7 +507,7 @@ def test_specialized_generic_wrapper_discovers_decorator_child() -> None:
         version="1",
         data=Parent(box=Box[Child](item=Child(value=4))),
     ) == {
-        "box": {"item": {"legacy_value": 4, "schema_version": "1"}},
+        "box": {"item": {"legacy_value": 4}},
         "schema_version": "1",
     }
 
@@ -642,7 +646,7 @@ def test_optional_wrapper_siblings_compare_metadata_contracts_per_site() -> None
         ),
     )
     assert rendered["wrapper"] == {
-        "family_child": {"value": 1, "schema_version": "1"},
+        "family_child": {"value": 1},
         "model_child": {"schema_version": "1", "value": 2},
     }
 

--- a/tests/unit/test_generated_wire_contracts.py
+++ b/tests/unit/test_generated_wire_contracts.py
@@ -1002,7 +1002,7 @@ def test_typed_extra_values_in_a_mixin_after_base_model_are_rejected() -> None:
     )
 
 
-def test_nested_metadata_wrappers_preserve_the_body_extra_mode() -> None:
+def test_nested_metadata_wrappers_reserve_the_complete_envelope() -> None:
     class IgnoredExtraPayload(BaseModel):
         value: int = 1
 
@@ -1037,13 +1037,9 @@ def test_nested_metadata_wrappers_preserve_the_body_extra_mode() -> None:
     ).model_for("1")
     payload = {"meta": {"version": "1", "note": "keep"}}
 
-    assert ignored.model_validate(payload).model_dump()["meta"] == {"version": "1"}
-    assert allowed.model_validate(payload).model_dump()["meta"] == {
-        "version": "1",
-        "note": "keep",
-    }
-    with pytest.raises(ValidationError):
-        forbidden.model_validate(payload)
+    for wire in (ignored, allowed, forbidden):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            wire.model_validate(payload)
 
 
 def test_every_family_owned_direct_discriminator_is_an_exact_literal() -> None:

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -1312,18 +1312,30 @@ def test_runtime_nested_cardinality_and_prune_coverage() -> None:
             target_label="v2",
         )
 
-    # _prune_nested_family_metadata_at_path with tuple, set, frozenset
-    item_meta = HashableDict({"schema_version": "v1", "val": 1})
+    # _prune_nested_family_metadata_at_path through declared collection shapes
+    class TupleParent(BaseModel):
+        items: tuple[ChildModel, ...]
+
+    class SetParent(BaseModel):
+        items: set[ChildModel]
+
+    tuple_item = HashableDict({"schema_version": "v2", "val": 1})
     _prune_nested_family_metadata_at_path(
-        payload=(item_meta,),
-        path=(),
+        payload={"items": (tuple_item,)},
+        model=TupleParent,
+        path=("items",),
         family=fam,
     )
+    assert tuple_item == {"val": 1}
+
+    set_item = HashableDict({"schema_version": "v2", "val": 1})
     _prune_nested_family_metadata_at_path(
-        payload={item_meta},
-        path=(),
+        payload={"items": {set_item}},
+        model=SetParent,
+        path=("items",),
         family=fam,
     )
+    assert set_item == {"val": 1}
 
 
 def test_runtime_more_pruning_and_nested_collection_kinds() -> None:

--- a/tests/unit/test_inventory_and_plans.py
+++ b/tests/unit/test_inventory_and_plans.py
@@ -1048,8 +1048,8 @@ def test_optional_annotated_nested_collections_keep_container_metadata_rules() -
     )
 
     assert rendered["listed"] == [{"value": 1}]
-    for field_name in ("tupled", "set_values", "frozen_values"):
-        assert rendered[field_name][0]["schema_version"] == "1"
+    for field_name, value in (("tupled", 2), ("set_values", 3), ("frozen_values", 4)):
+        assert rendered[field_name] == [{"value": value}]
 
 
 def test_optional_annotated_set_detects_nested_migration_collapse() -> None:

--- a/tests/unit/test_nested_runtime_paths.py
+++ b/tests/unit/test_nested_runtime_paths.py
@@ -80,9 +80,9 @@ def test_nested_projection_and_pruning_ignore_an_opaque_sibling() -> None:
     rendered = parent_family.dump(
         version="2",
         data={"opaque": opaque},
-        exclude_none=True,
     )
 
+    assert rendered["children"] is None
     assert rendered["opaque"] == opaque
 
 
@@ -452,7 +452,7 @@ def test_nested_render_validates_parent_and_child_only_once(model_input: bool) -
     rendered = parent_family.dump(version="1", data=data)
 
     assert rendered == {
-        "child": {"legacy_value": 5, "schema_version": "1"},
+        "child": {"legacy_value": 5},
         "schema_version": "1",
     }
     assert validation_counts == {"parent": 1, "child": 1}

--- a/tests/unit/test_render_current_validation.py
+++ b/tests/unit/test_render_current_validation.py
@@ -207,12 +207,13 @@ def test_model_owned_render_metadata_is_rebased_without_alias_leaks() -> None:
     assert family.dump(
         version="1",
         data={"wire_version": "2", "value": "7"},
-    ) == {"wire_version": "1", "value": 7}
-    assert family.dump(
-        version="1",
-        data={"schema_version": "2", "value": 7},
-        include_version=False,
-    ) == {"value": 7}
+    ) == {"schema_version": "1", "value": 7}
+    with pytest.raises(ValueError, match="model-owned.*include_version=False is unavailable"):
+        family.dump(
+            version="1",
+            data={"schema_version": "2", "value": 7},
+            include_version=False,
+        )
 
     with pytest.raises(SchemaVersionError, match="current-model input"):
         family.dump(
@@ -361,7 +362,7 @@ def test_generated_set_projection_runs_mutating_after_validators_once() -> None:
     )
 
     assert rendered == {
-        "children": [{"value": 2, "schema_version": "1"}],
+        "children": [{"value": 2}],
         "parent_runs": 1,
         "schema_version": "1",
     }
@@ -419,7 +420,7 @@ def test_nested_frozenset_projection_runs_model_post_init_once() -> None:
     assert rendered == {
         "groups": {
             "primary": [
-                [{"value": 11, "schema_version": "1"}],
+                [{"value": 11}],
             ],
         },
         "parent_runs": 1,
@@ -489,7 +490,7 @@ def test_generated_set_projection_runs_parent_hooks_on_authoritative_type_once()
             return self
 
     expected = {
-        "children": [{"value": 1, "schema_version": "1"}],
+        "children": [{"value": 1}],
         "schema_version": "1",
     }
     assert (
@@ -575,7 +576,7 @@ def test_generated_set_carrier_preserves_exact_init_and_private_lifecycle() -> N
         version="1",
         data=cast(Any, generated_current),
     ) == {
-        "children": [{"value": 1, "schema_version": "1"}],
+        "children": [{"value": 1}],
         "schema_version": "1",
     }
     assert events == [
@@ -661,9 +662,8 @@ def test_nested_carrier_hooks_use_authoritative_wrapper_types_once() -> None:
         data=cast(Any, generated_current),
     ) == {
         "wrapper": {
-            "leaves": [{"value": 2, "schema_version": "1"}],
+            "leaves": [{"value": 2}],
             "wrapper_runs": 1,
-            "schema_version": "1",
         },
         "parent_runs": 1,
         "schema_version": "1",
@@ -1060,7 +1060,8 @@ def test_mapping_render_honors_disabled_name_validation() -> None:
 
     with pytest.raises(ValidationError, match="wire"):
         family.dump(version="1", data={"value": 1})
-    assert family.dump(version="1", data={"wire": 1}) == {"value": 1}
+    assert family.dump(version="1", data={"wire": 1}) == {"wire": 1}
+    assert family.dump(version="1", data={"wire": 1}, by_alias=False) == {"value": 1}
 
 
 def test_render_metadata_checks_list_alias_paths() -> None:
@@ -1154,7 +1155,7 @@ def test_decorator_discovered_current_wire_set_projection_is_renderable() -> Non
     assert rendered["schema_version"] == "1"
     assert len(rendered["children"]) == 1
     assert {item["value"] for item in rendered["children"]} == {1}
-    assert {item["schema_version"] for item in rendered["children"]} == {"1"}
+    assert all("schema_version" not in item for item in rendered["children"])
 
 
 def test_decorator_set_projection_beneath_mapping_is_renderable() -> None:
@@ -1200,5 +1201,4 @@ def test_decorator_set_projection_beneath_mapping_is_renderable() -> None:
 
     assert rendered["schema_version"] == "1"
     primary = rendered["groups"]["primary"]
-    assert primary["schema_version"] == "1"
-    assert primary["leaves"] == [{"value": 1, "schema_version": "1"}]
+    assert primary == {"leaves": [{"value": 1}]}

--- a/tests/unit/test_schema_family.py
+++ b/tests/unit/test_schema_family.py
@@ -597,7 +597,12 @@ def test_future_declarations_are_rejected_instead_of_ignored() -> None:
     downgrade_family.compile()
 
     assert wire_family.describe().versions[0].wire_model == "explicit"
-    assert wire_family.model_for("1") is HistoricalConfig
+    historical_document = wire_family.model_for("1")
+    assert historical_document is not HistoricalConfig
+    assert historical_document.model_fields["value"].annotation is str
+    assert historical_document.model_validate(
+        {"value": "legacy", "schema_version": "1"}
+    ).model_dump() == {"value": "legacy", "schema_version": "1"}
 
 
 def test_current_and_mutually_exclusive_wire_declarations_are_rejected() -> None:

--- a/tests/unit/test_target_wire_contract.py
+++ b/tests/unit/test_target_wire_contract.py
@@ -1,0 +1,3231 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import copy, deepcopy
+from dataclasses import dataclass
+from functools import cached_property
+from inspect import signature
+from typing import Annotated, Any, Literal, TypedDict, cast
+
+import pytest
+from pydantic import (
+    AliasChoices,
+    AliasGenerator,
+    AliasPath,
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    computed_field,
+    create_model,
+    field_serializer,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+from pydantic.functional_serializers import PlainSerializer, SerializeAsAny
+from pydantic_core import core_schema
+
+from pydantic_versions import (
+    InvalidMigrationError,
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    UnsupportedWireModelError,
+    VersionMetadata,
+    VersionTransition,
+    field_default,
+    field_renamed,
+    matching_labels,
+)
+
+
+def _to_dict(data: Mapping[str, Any]) -> dict[str, Any]:
+    return dict(data)
+
+
+def test_defaults_construct_the_target_without_planning_or_downgrading() -> None:
+    factory_calls: list[str] = []
+
+    def historical_factory() -> list[str]:
+        factory_calls.append("historical")
+        return ["legacy"]
+
+    def unexpected_downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        pytest.fail(f"defaults unexpectedly executed a downgrade with {data!r}")
+
+    class Config(BaseModel):
+        items: list[str] = Field(default_factory=lambda: ["current"])
+
+    family = SchemaFamily(
+        model=Config,
+        name="target_defaults_without_downgrades",
+        versions=(
+            SchemaVersion(
+                "1",
+                patches=(field_default("items", default_factory=historical_factory),),
+            ),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=unexpected_downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+
+    assert family.defaults_for(version="1") == {
+        "items": ["legacy"],
+        "schema_version": "1",
+    }
+    assert family.dump(version="1") == {
+        "items": ["legacy"],
+        "schema_version": "1",
+    }
+    assert factory_calls == ["historical", "historical"]
+
+
+def test_empty_mapping_remains_conversion_input_and_is_not_defaults_syntax() -> None:
+    class Config(BaseModel):
+        required: str
+
+    family = SchemaFamily(
+        model=Config,
+        name="empty_mapping_is_data",
+        versions=(SchemaVersion("1"),),
+    )
+
+    with pytest.raises(ValidationError):
+        family.dump(version="1", data={})
+    with pytest.raises(ValidationError):
+        family.defaults_for(version="1")
+
+
+def test_target_default_factory_and_serializer_execute_once() -> None:
+    events: list[str] = []
+
+    def factory() -> int:
+        events.append("factory")
+        return 7
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = Field(default_factory=factory)
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            events.append("serializer")
+            return {"value": self.value}
+
+    family = SchemaFamily(
+        model=Current,
+        name="target_default_once",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"value": 7}
+    assert events == ["factory", "serializer"]
+
+
+def test_complete_dump_defaults_to_json_and_target_serialization_aliases() -> None:
+    class Config(BaseModel):
+        model_config = ConfigDict(validate_by_alias=True, validate_by_name=False)
+
+        worker_name: str = Field(
+            validation_alias="inputWorker",
+            serialization_alias="outputWorker",
+        )
+
+    family = SchemaFamily(
+        model=Config,
+        name="target_alias_contract",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    current = Config.model_validate({"inputWorker": "alpha"})
+
+    assert family.dump(version="1", data=current) == {"outputWorker": "alpha"}
+    assert family.dump(version="1", data=current, by_alias=False) == {"worker_name": "alpha"}
+
+
+def test_explicit_wire_serializer_defines_target_output_without_revalidation() -> None:
+    serializer_calls: list[int] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @field_serializer("value")
+        def serialize_value(self, value: int) -> str:
+            serializer_calls.append(value)
+            return f"legacy:{value}"
+
+    family = SchemaFamily(
+        model=Current,
+        name="explicit_serializer_contract",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"value": "legacy:1"}
+    assert family.dump(version="1", data=Current(value=2)) == {"value": "legacy:2"}
+    assert serializer_calls == [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("include", None),
+        ("exclude", None),
+        ("exclude_unset", False),
+        ("exclude_defaults", False),
+        ("exclude_none", False),
+        ("exclude_computed_fields", False),
+    ],
+)
+def test_complete_rendering_rejects_omission_options_by_presence(
+    option: str,
+    value: object,
+) -> None:
+    class Config(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Config,
+        name=f"reject_omission_{option}",
+        versions=(SchemaVersion("1"),),
+    )
+    kwargs: dict[str, Any] = {option: value}
+
+    with pytest.raises(ValueError, match=rf"unsupported model_dump option.*'{option}'"):
+        family.dump(version="1", data=Config(), **kwargs)
+    with pytest.raises(ValueError, match=rf"unsupported model_dump option.*'{option}'"):
+        family.defaults_for(version="1", **kwargs)
+
+
+def test_rendering_rejects_unknown_model_dump_options() -> None:
+    class Config(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Config,
+        name="reject_future_dump_option",
+        versions=(SchemaVersion("1"),),
+    )
+
+    with pytest.raises(ValueError, match="unsupported model_dump option.*'future_option'"):
+        family.defaults_for(version="1", future_option=True)
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("serialize_as_any", True),
+        ("polymorphic_serialization", True),
+    ],
+)
+def test_rendering_rejects_polymorphic_subclass_leak_options(
+    option: str,
+    value: object,
+) -> None:
+    class PublicCredential(BaseModel):
+        username: str
+
+    class SecretCredential(PublicCredential):
+        secret: str
+
+    class Current(BaseModel):
+        credential: PublicCredential
+
+    class Historical(BaseModel):
+        credential: PublicCredential = Field(
+            default_factory=lambda: SecretCredential(username="worker", secret="token")
+        )
+
+    family = SchemaFamily(
+        model=Current,
+        name=f"reject_polymorphic_{option}",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+    kwargs: dict[str, Any] = {option: value}
+
+    with pytest.raises(ValueError, match="outside the target wire contract"):
+        family.defaults_for(version="1", **kwargs)
+
+
+def test_false_polymorphic_options_preserve_declared_target_shape() -> None:
+    class PublicCredential(BaseModel):
+        username: str
+
+    class SecretCredential(PublicCredential):
+        secret: str
+
+    class Current(BaseModel):
+        credential: PublicCredential
+
+    class Historical(BaseModel):
+        credential: PublicCredential = Field(
+            default_factory=lambda: SecretCredential(username="worker", secret="token")
+        )
+
+    family = SchemaFamily(
+        model=Current,
+        name="false_polymorphic_options",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(
+        version="1",
+        serialize_as_any=False,
+        polymorphic_serialization=None,
+    ) == {"credential": {"username": "worker"}}
+    assert family.defaults_for(
+        version="1",
+        polymorphic_serialization=False,
+    ) == {"credential": {"username": "worker"}}
+
+
+def test_round_trip_mode_cannot_omit_computed_target_fields() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @computed_field
+        @property
+        def doubled(self) -> int:
+            return self.value * 2
+
+    family = SchemaFamily(
+        model=Current,
+        name="round_trip_computed_omission",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1", round_trip=False) == {
+        "value": 1,
+        "doubled": 2,
+    }
+    with pytest.raises(ValueError, match="round_trip=True.*omit computed"):
+        family.defaults_for(version="1", round_trip=True)
+
+
+def test_explicit_target_wraps_family_owned_metadata_after_serialization() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="explicit_family_metadata_wrapper",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    defaults = family.defaults_for(version="1")
+    assert defaults == {
+        "value": 1,
+        "schema_version": "1",
+    }
+    dumped = family.dump(version="1", data=Current(value=2))
+    assert dumped == {
+        "value": 2,
+        "schema_version": "1",
+    }
+    target = family.model_for("1")
+    assert target.model_validate(dumped).model_dump(mode="json") == dumped
+    assert family.validate(dumped).current_model == Current(value=2)
+    assert family.defaults_for(version="1", include_version=False) == {"value": 1}
+    assert target.model_json_schema(mode="validation")["properties"]["schema_version"] == {
+        "const": "1",
+        "default": "1",
+        "title": "Schema Version",
+        "type": "string",
+    }
+
+
+def test_model_owned_metadata_uses_selected_serialization_location() -> None:
+    class Config(BaseModel):
+        schema_version: str = Field(
+            default="2",
+            validation_alias="wire_version",
+            serialization_alias="emitted_version",
+        )
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Config,
+        name="model_metadata_serialization_location",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=VersionMetadata("wire_version", owner="model"),
+    )
+
+    assert family.defaults_for(version="1") == {
+        "emitted_version": "1",
+        "value": 1,
+    }
+    assert family.defaults_for(version="1", by_alias=False) == {
+        "schema_version": "1",
+        "value": 1,
+    }
+    with pytest.raises(ValueError, match="model-owned.*include_version=False is unavailable"):
+        family.defaults_for(version="1", include_version=False)
+
+
+def test_runtime_rejects_conflicting_family_owned_serializer_metadata() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"value": self.value, "schema_version": "wrong"}
+
+    family = SchemaFamily(
+        model=Current,
+        name="conflicting_family_serializer_metadata",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="conflicting version metadata.*wrong"):
+        family.defaults_for(version="1")
+    with pytest.raises(ValueError, match="conflicting version metadata.*wrong"):
+        family.defaults_for(version="1", include_version=False)
+
+
+def test_runtime_rejects_omitted_model_owned_serializer_metadata() -> None:
+    class Current(BaseModel):
+        schema_version: str = Field(default="2", alias="wire_version")
+        value: int = 1
+
+    class Historical(BaseModel):
+        schema_version: Literal["1"] = Field(default="1", alias="wire_version")
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"value": self.value}
+
+    family = SchemaFamily(
+        model=Current,
+        name="omitted_model_serializer_metadata",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata("wire_version", owner="model"),
+    )
+
+    with pytest.raises(ValueError, match="omitted model-owned version metadata"):
+        family.defaults_for(version="1")
+    with pytest.raises(ValueError, match="model-owned.*include_version=False is unavailable"):
+        family.defaults_for(version="1", include_version=False)
+
+
+def test_target_model_must_serialize_to_an_object() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return cast(Any, "not-an-object")
+
+    family = SchemaFamily(
+        model=Current,
+        name="object_shaped_target_output",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match="must serialize to an object"):
+        family.defaults_for(version="1", warnings=False)
+
+
+def test_nested_metadata_is_pruned_for_all_builtin_collection_shapes() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="pruned_collection_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        direct: Child
+        listed: list[Child]
+        variadic: tuple[Child, ...]
+        fixed: tuple[Child, Child]
+        set_values: set[Child]
+        frozen_values: frozenset[Child]
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="pruned_collection_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(
+            NestedFamily("direct", child_family, matching_labels()),
+            NestedFamily("listed", child_family, matching_labels()),
+            NestedFamily("variadic", child_family, matching_labels()),
+            NestedFamily("fixed", child_family, matching_labels()),
+            NestedFamily("set_values", child_family, matching_labels()),
+            NestedFamily("frozen_values", child_family, matching_labels()),
+        ),
+    )
+
+    rendered = parent_family.dump(
+        version="1",
+        data=Parent(
+            direct=Child(value=1),
+            listed=[Child(value=2)],
+            variadic=(Child(value=3),),
+            fixed=(Child(value=4), Child(value=5)),
+            set_values={Child(value=6)},
+            frozen_values=frozenset({Child(value=7)}),
+        ),
+    )
+
+    assert rendered == {
+        "direct": {"value": 1},
+        "listed": [{"value": 2}],
+        "variadic": [{"value": 3}],
+        "fixed": [{"value": 4}, {"value": 5}],
+        "set_values": [{"value": 6}],
+        "frozen_values": [{"value": 7}],
+        "schema_version": "1",
+    }
+
+
+def test_nested_metadata_pruning_translates_historical_names_before_aliases() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="renamed_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Wrapper(BaseModel):
+        child: Child = Field(serialization_alias="childWire")
+
+    class Parent(BaseModel):
+        wrapper: Wrapper
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="renamed_nested_parent",
+        versions=(
+            SchemaVersion("1", patches=(field_renamed("wrapper", "legacy_wrapper"),)),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily(("wrapper", "child"), child_family, matching_labels()),),
+    )
+    current = Parent(wrapper=Wrapper(child=Child(value=4)))
+
+    assert parent_family.dump(version="1", data=current) == {
+        "legacy_wrapper": {"childWire": {"value": 4}},
+        "schema_version": "1",
+    }
+    assert parent_family.dump(version="1", data=current, by_alias=False) == {
+        "legacy_wrapper": {"child": {"value": 4}},
+        "schema_version": "1",
+    }
+
+
+def test_nested_model_owned_metadata_is_verified_after_parent_serialization() -> None:
+    class Child(BaseModel):
+        schema_version: str = "2"
+        value: int = 1
+
+    class HistoricalChild(BaseModel):
+        schema_version: Literal["1"] = "1"
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"schema_version": "wrong", "value": self.value}
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="nested_model_metadata_verification_child",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalChild),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="nested_model_metadata_verification_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(ValueError, match="serialized version metadata.*wrong.*expected '1'"):
+        parent_family.dump(
+            version="1",
+            data=Parent(child=Child(schema_version="2", value=7)),
+        )
+
+
+def test_nested_target_serializer_must_remain_object_shaped() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    class HistoricalChild(BaseModel):
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return cast(Any, [self.value])
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="nested_object_shape_child",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalChild),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="nested_object_shape_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(ValueError, match="Nested target wire model.*must serialize to an object"):
+        parent_family.dump(version="1", data=Parent(child=Child(value=7)), warnings=False)
+
+
+def test_validate_default_policy_is_preserved_for_target_defaults() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class AcceptedHistorical(BaseModel):
+        value: int = Field(default=cast(Any, "not-an-int"), validate_default=False)
+
+    class RejectedHistorical(BaseModel):
+        value: int = Field(default="not-an-int", validate_default=True)
+
+    accepted = SchemaFamily(
+        model=Current,
+        name="accepted_unvalidated_target_default",
+        versions=(
+            SchemaVersion("1", wire_model=AcceptedHistorical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+    rejected = SchemaFamily(
+        model=Current,
+        name="rejected_invalid_target_default",
+        versions=(
+            SchemaVersion("1", wire_model=RejectedHistorical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert accepted.defaults_for(version="1", warnings=False) == {"value": "not-an-int"}
+    with pytest.raises(ValidationError):
+        rejected.defaults_for(version="1")
+
+
+def test_validate_default_validator_runs_once() -> None:
+    events: list[int] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = Field(default=2, validate_default=True)
+
+        @field_validator("value")
+        @classmethod
+        def record(cls, value: int) -> int:
+            events.append(value)
+            return value
+
+    family = SchemaFamily(
+        model=Current,
+        name="target_default_validator_once",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"value": 2}
+    assert events == [2]
+
+
+@pytest.mark.parametrize("collision", ["field", "choice", "path", "computed"])
+def test_explicit_wire_body_cannot_collide_with_family_metadata(collision: str) -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    if collision == "field":
+
+        class Historical(BaseModel):
+            schema_version: str = "body"
+
+    elif collision == "choice":
+
+        class Historical(BaseModel):
+            value: int = Field(default=1, validation_alias=AliasChoices("schema_version", "value"))
+
+    elif collision == "path":
+
+        class Historical(BaseModel):
+            value: int = Field(default=1, validation_alias=AliasPath("schema_version", "value"))
+
+    else:
+
+        class Historical(BaseModel):
+            value: int = 1
+
+            @computed_field(alias="schema_version")
+            @property
+            def marker(self) -> str:
+                return "body"
+
+    family = SchemaFamily(
+        model=Current,
+        name=f"explicit_metadata_collision_{collision}",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="version metadata collides"):
+        family.compile()
+
+
+@pytest.mark.parametrize("collision", ["fields", "computed", "nested"])
+def test_duplicate_serialization_output_names_fail_compilation(collision: str) -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    if collision == "fields":
+
+        class Payload(BaseModel):
+            first: int = Field(default=1, serialization_alias="shared")
+            second: int = Field(default=2, serialization_alias="shared")
+
+    elif collision == "computed":
+
+        class Payload(BaseModel):
+            first: int = Field(default=1, serialization_alias="shared")
+
+            @computed_field(alias="shared")
+            @property
+            def second(self) -> int:
+                return 2
+
+    else:
+
+        class Inner(BaseModel):
+            first: int = Field(default=1, serialization_alias="shared")
+            second: int = Field(default=2, serialization_alias="shared")
+
+        class Payload(BaseModel):
+            inner: Inner = Field(default_factory=Inner)
+
+    family = SchemaFamily(
+        model=Current,
+        name=f"duplicate_serialization_{collision}",
+        versions=(
+            SchemaVersion("1", wire_model=Payload),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="duplicate output name 'shared'"):
+        family.compile()
+
+
+def test_family_document_adapter_preserves_public_model_operations() -> None:
+    validated: list[int] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        value: int = 1
+
+        @model_validator(mode="after")
+        def require_exact_body_type(self) -> Historical:
+            assert type(self) is Historical
+            validated.append(self.value)
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="public_family_document_adapter",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+    construct_target = cast(Any, target)
+
+    direct = construct_target(value=3, schema_version="1")
+    assert direct.model_dump(mode="json") == {"value": 3, "schema_version": "1"}
+    assert validated == [3]
+
+    constructed = target.model_construct(value=4, schema_version="1")
+    assert constructed.model_dump(mode="json") == {"value": 4, "schema_version": "1"}
+    assert validated == [3]
+
+    copied = direct.model_copy(update={"value": 9})
+    assert copied.model_dump(mode="json") == {"value": 9, "schema_version": "1"}
+    assert direct.model_dump(mode="json") == {"value": 3, "schema_version": "1"}
+    assert validated == [3]
+
+    with pytest.raises(ValueError, match="expected '1'"):
+        direct.model_copy(update={"schema_version": "wrong"})
+
+
+def test_family_document_adapter_uses_active_json_schema_definitions() -> None:
+    class Inner(BaseModel):
+        name: str
+
+    class Current(BaseModel):
+        inner: Inner
+
+    class Historical(BaseModel):
+        inner: Inner
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_nested_json_schema",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+
+    for mode in ("validation", "serialization"):
+        schema = target.model_json_schema(mode=mode)
+        assert schema["properties"]["inner"]["$ref"].startswith("#/$defs/")
+        assert schema["properties"]["schema_version"]["const"] == "1"
+        assert "Inner" in schema["$defs"]
+
+    payload = {"inner": {"name": "worker"}, "schema_version": "1"}
+    assert target.model_validate(payload).model_dump(mode="json") == payload
+
+
+def test_family_document_adapter_supports_nested_metadata_paths() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_nested_metadata_path",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+    target = family.model_for("1")
+    payload = {"value": 2, "contract": {"version": "1"}}
+
+    assert target.model_validate(payload).model_dump(mode="json") == payload
+    assert family.validate(payload).current_model == Current(value=2)
+    assert family.dump(version="1", data=Current(value=2)) == payload
+    schema = target.model_json_schema()
+    contract_schema = schema["properties"]["contract"]
+    assert contract_schema["additionalProperties"] is False
+    assert contract_schema["required"] == ["version"]
+    assert contract_schema["properties"]["version"]["const"] == "1"
+
+    document = cast(Any, target).model_validate(payload)
+    with pytest.raises(ValidationError, match="frozen"):
+        document.contract.version = "wrong"
+    assert document.model_dump(mode="json") == payload
+
+
+def test_family_document_adapter_does_not_rerun_alias_generators() -> None:
+    aliases: list[str] = []
+
+    def stateful_alias(field_name: str) -> str:
+        alias = f"{field_name}_{len(aliases) + 1}"
+        aliases.append(alias)
+        return alias
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(alias_generator=stateful_alias, populate_by_name=True)
+
+        value: int = 1
+
+    body_alias = Historical.model_fields["value"].alias
+    calls_after_body = tuple(aliases)
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_stateful_alias_generator",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+
+    assert tuple(aliases) == calls_after_body
+    assert target.model_fields["value"].alias == body_alias
+    assert body_alias in signature(target).parameters
+    document = cast(Any, target)(**{cast(str, body_alias): 3}, schema_version="1")
+    assert document.model_dump(mode="json", by_alias=True) == {
+        cast(str, body_alias): 3,
+        "schema_version": "1",
+    }
+
+
+def test_family_document_adapter_forwards_serialization_context_once() -> None:
+    serializer_calls: list[int] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @field_serializer("value")
+        def serialize_value(self, value: int, info: Any) -> str:
+            serializer_calls.append(value)
+            return f"{info.context['prefix']}:{value}"
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_serialization_context",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    assert family.defaults_for(version="1", context={"prefix": "legacy"}) == {
+        "value": "legacy:1",
+        "schema_version": "1",
+    }
+    assert serializer_calls == [1]
+
+
+def test_family_document_adapter_synchronizes_assignment_side_effects_and_extras() -> None:
+    class Current(BaseModel):
+        value: int = 1
+        doubled: int = 2
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+        value: int = 1
+        doubled: int = 2
+
+        @model_validator(mode="after")
+        def synchronize_doubled(self) -> Historical:
+            object.__setattr__(self, "doubled", self.value * 2)
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_assignment_synchronization",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+    document = cast(Any, target)(
+        value=2,
+        doubled=0,
+        schema_version="1",
+        note="initial",
+    )
+
+    document.value = 4
+    document.note = "updated"
+    assert document.model_extra is not None
+    document.model_extra["added"] = "in-place"
+    del document.model_extra["note"]
+
+    assert document.doubled == 8
+    assert document.added == "in-place"
+    with pytest.raises(AttributeError):
+        _ = document.note
+    assert document.model_dump(mode="json") == {
+        "value": 4,
+        "doubled": 8,
+        "added": "in-place",
+        "schema_version": "1",
+    }
+
+
+def test_family_document_adapter_delegates_declared_private_state_only() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+        _marker: str = PrivateAttr(default="initial")
+
+        def bump(self) -> Historical:
+            self.value += 1
+            return self
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"value": self.value, "marker": self._marker}
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_private_state",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+    document = cast(Any, target)(value=2, schema_version="1")
+
+    document._marker = "updated"
+
+    assert document._marker == "updated"
+    assert document.model_dump(mode="json") == {
+        "value": 2,
+        "marker": "updated",
+        "schema_version": "1",
+    }
+    with pytest.raises(AttributeError):
+        document.bump()
+
+
+def test_family_document_adapter_exposes_declared_computed_fields() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @computed_field
+        @property
+        def doubled(self) -> int:
+            return self.value * 2
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_computed_field",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+    document = cast(Any, target)(value=3, schema_version="1")
+
+    assert target.model_computed_fields == Historical.model_computed_fields
+    assert document.doubled == 6
+    assert "doubled=6" in repr(document)
+    assert document.model_dump(mode="json") == {
+        "value": 3,
+        "doubled": 6,
+        "schema_version": "1",
+    }
+
+
+def test_family_document_adapter_synchronizes_field_and_extra_deletion() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_deletion_synchronization",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+    document = cast(Any, target)(value=2, note="temporary", schema_version="1")
+
+    del document.note
+    assert document.model_dump(mode="json") == {"value": 2, "schema_version": "1"}
+
+    del document.value
+    assert document.model_dump(mode="json", warnings=False) == {"schema_version": "1"}
+
+    with pytest.raises(AttributeError, match="cannot be deleted"):
+        del document.schema_version
+
+
+def test_family_document_adapter_shares_the_public_fields_set() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_fields_set_synchronization",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(schema_version="1")
+
+    assert document.model_dump(mode="json", exclude_unset=True) == {"schema_version": "1"}
+    document.model_fields_set.add("value")
+    assert document.model_dump(mode="json", exclude_unset=True) == {
+        "value": 1,
+        "schema_version": "1",
+    }
+
+
+def test_family_document_adapter_copy_protocol_does_not_share_the_body() -> None:
+    class Nested(BaseModel):
+        value: int = 1
+
+    class Current(BaseModel):
+        nested: Nested = Field(default_factory=Nested)
+
+    class Historical(BaseModel):
+        nested: Nested = Field(default_factory=Nested)
+        _marker: str = PrivateAttr(default="original")
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"nested": self.nested, "marker": self._marker}
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_copy_protocol",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(schema_version="1")
+
+    shallow = copy(document)
+    shallow._marker = "shallow"
+    shallow.nested.value = 2
+
+    assert document.model_dump(mode="json") == {
+        "nested": {"value": 2},
+        "marker": "original",
+        "schema_version": "1",
+    }
+    assert shallow.model_dump(mode="json") == {
+        "nested": {"value": 2},
+        "marker": "shallow",
+        "schema_version": "1",
+    }
+
+    deep = deepcopy(document)
+    deep._marker = "deep"
+    deep.nested.value = 3
+
+    assert document.model_dump(mode="json") == {
+        "nested": {"value": 2},
+        "marker": "original",
+        "schema_version": "1",
+    }
+    assert deep.model_dump(mode="json") == {
+        "nested": {"value": 3},
+        "marker": "deep",
+        "schema_version": "1",
+    }
+
+
+def test_family_document_adapter_rejects_serializer_owned_metadata_even_when_equal() -> None:
+    serializer_calls: list[int] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            serializer_calls.append(self.value)
+            return {"value": self.value, "schema_version": "1"}
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_equal_metadata_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="conflicting version metadata '1'.*reserved"):
+        family.defaults_for(version="1")
+    assert serializer_calls == [1]
+
+
+def test_family_document_adapter_rejects_serializer_owned_metadata_root() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"value": self.value, "contract": {"secret": "body"}}
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_nested_metadata_root_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    with pytest.raises(ValueError, match="reserved path component 'contract'"):
+        family.defaults_for(version="1")
+
+
+def test_automatic_projection_ignores_non_wire_metadata_collisions() -> None:
+    class Current(BaseModel):
+        hidden: str = Field(default="private", alias="schema_version", exclude=True)
+        value: int = 1
+
+        @computed_field(alias="schema_version")
+        @property
+        def computed_marker(self) -> str:
+            return "computed"
+
+    family = SchemaFamily(
+        model=Current,
+        name="non_wire_metadata_collisions",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata("schema_version", owner="family"),
+    )
+
+    assert family.defaults_for(version="1") == {
+        "value": 1,
+        "schema_version": "1",
+    }
+
+
+def test_excluded_field_does_not_create_duplicate_serialization_name() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        hidden: int = Field(default=1, serialization_alias="shared", exclude=True)
+        visible: int = Field(default=2, serialization_alias="shared")
+
+    family = SchemaFamily(
+        model=Current,
+        name="excluded_duplicate_serialization_name",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"shared": 2}
+
+
+def test_model_serializer_controls_duplicate_field_output_names() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        first: int = Field(default=1, serialization_alias="shared")
+        second: int = Field(default=2, serialization_alias="shared")
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, int]:
+            return {"first": self.first, "second": self.second}
+
+    family = SchemaFamily(
+        model=Current,
+        name="serializer_controls_output_names",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"first": 1, "second": 2}
+
+
+def test_field_serializer_controls_nested_duplicate_output_names() -> None:
+    class Inner(BaseModel):
+        first: int = Field(default=1, serialization_alias="shared")
+        second: int = Field(default=2, serialization_alias="shared")
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        inner: Inner = Field(default_factory=Inner)
+
+        @field_serializer("inner")
+        def serialize_inner(self, inner: Inner) -> dict[str, int]:
+            return {"first": inner.first, "second": inner.second}
+
+    family = SchemaFamily(
+        model=Current,
+        name="field_serializer_controls_nested_output_names",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"inner": {"first": 1, "second": 2}}
+
+
+def test_duplicate_serialization_names_inside_typed_dict_fail_compilation() -> None:
+    class Inner(BaseModel):
+        first: int = Field(default=1, serialization_alias="shared")
+        second: int = Field(default=2, serialization_alias="shared")
+
+    class Payload(TypedDict):
+        inner: Inner
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        payload: Payload
+
+    family = SchemaFamily(
+        model=Current,
+        name="typed_dict_duplicate_serialization_name",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="duplicate output name 'shared'"):
+        family.compile()
+
+
+def test_nested_explicit_model_serializer_fails_closed() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="serializer_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Current(BaseModel):
+        child: Child
+
+    class Historical(BaseModel):
+        child: Child
+
+        @model_serializer
+        def relocate_child(self) -> dict[str, Any]:
+            return {"relocated": self.child}
+
+    parent_family = SchemaFamily(
+        model=Current,
+        name="serializer_nested_parent",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="model-level serializer.*relocate child document paths",
+    ):
+        parent_family.compile()
+
+
+def test_nested_explicit_field_serializer_fails_closed() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="field_serializer_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    child_document = child_family.model_for("1")
+
+    class Current(BaseModel):
+        child: Child
+
+    class RelocatingHistoricalBase(BaseModel):
+        @field_serializer("child", check_fields=False)
+        def relocate_child(self, child: BaseModel) -> dict[str, Any]:
+            return {"payload": child.model_dump(mode="json")}
+
+    historical = create_model(
+        "FieldSerializerHistorical",
+        __base__=RelocatingHistoricalBase,
+        child=(child_document, ...),
+    )
+
+    parent_family = SchemaFamily(
+        model=Current,
+        name="field_serializer_nested_parent",
+        versions=(
+            SchemaVersion("1", wire_model=historical),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="serializes field 'child'.*relocate child document paths",
+    ):
+        parent_family.compile()
+
+
+@pytest.mark.parametrize("serializer_kind", ["model", "field"])
+def test_nested_explicit_wrapper_serializer_fails_closed(serializer_kind: str) -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name=f"wrapper_serializer_child_{serializer_kind}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    child_document = child_family.model_for("1")
+
+    if serializer_kind == "model":
+
+        class RelocatingWrapperBase(BaseModel):
+            @model_serializer
+            def relocate_child(self) -> dict[str, Any]:
+                return {"payload": self.__dict__["child"]}
+
+    else:
+
+        class RelocatingWrapperBase(BaseModel):
+            @field_serializer("child", check_fields=False)
+            def relocate_child(self, child: BaseModel) -> dict[str, Any]:
+                return {"payload": child.model_dump(mode="json")}
+
+    historical_wrapper = create_model(
+        f"HistoricalWrapper{serializer_kind.title()}",
+        __base__=RelocatingWrapperBase,
+        child=(child_document, ...),
+    )
+
+    class CurrentWrapper(BaseModel):
+        child: Child
+
+    class Current(BaseModel):
+        wrapper: CurrentWrapper
+
+    historical = create_model(
+        f"WrapperSerializerHistorical{serializer_kind.title()}",
+        wrapper=(historical_wrapper, ...),
+    )
+
+    parent_family = SchemaFamily(
+        model=Current,
+        name=f"wrapper_serializer_parent_{serializer_kind}",
+        versions=(
+            SchemaVersion("1", wire_model=historical),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily(("wrapper", "child"), child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="relocate child document paths"):
+        parent_family.compile()
+
+
+def test_duplicate_serialization_names_on_typed_dict_fields_fail_compilation() -> None:
+    class Payload(TypedDict):
+        first: Annotated[int, Field(serialization_alias="shared")]
+        second: Annotated[int, Field(serialization_alias="shared")]
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        payload: Payload
+
+    family = SchemaFamily(
+        model=Current,
+        name="typed_dict_field_alias_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="duplicate output name 'shared'"):
+        family.compile()
+
+
+def test_duplicate_serialization_names_on_dataclass_fields_fail_compilation() -> None:
+    @dataclass
+    class Payload:
+        first: Annotated[int, Field(serialization_alias="shared")] = 1
+        second: Annotated[int, Field(serialization_alias="shared")] = 2
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        payload: Payload = Field(default_factory=Payload)
+
+    family = SchemaFamily(
+        model=Current,
+        name="dataclass_field_alias_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="duplicate output name 'shared'"):
+        family.compile()
+
+
+def test_unconditional_computed_field_serializer_owns_its_output_shape() -> None:
+    class Inner(BaseModel):
+        first: int = Field(default=1, serialization_alias="shared")
+        second: int = Field(default=2, serialization_alias="shared")
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        @computed_field
+        @property
+        def inner(self) -> Inner:
+            return Inner()
+
+        @field_serializer("inner")
+        def serialize_inner(self, inner: Inner) -> dict[str, int]:
+            return {"first": inner.first, "second": inner.second}
+
+    family = SchemaFamily(
+        model=Current,
+        name="computed_serializer_output_boundary",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"inner": {"first": 1, "second": 2}}
+
+
+def test_unconditional_plain_serializer_owns_its_output_shape() -> None:
+    class Inner(BaseModel):
+        first: int = Field(default=1, serialization_alias="shared")
+        second: int = Field(default=2, serialization_alias="shared")
+
+    safe_inner = Annotated[
+        Inner,
+        PlainSerializer(
+            lambda value: {"first": value.first, "second": value.second},
+            return_type=dict[str, int],
+        ),
+    ]
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        inner: safe_inner = Field(default_factory=Inner)
+
+    family = SchemaFamily(
+        model=Current,
+        name="plain_serializer_output_boundary",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    assert family.defaults_for(version="1") == {"inner": {"first": 1, "second": 2}}
+
+
+@pytest.mark.parametrize("serializer_kind", ["field", "model", "plain"])
+def test_json_only_serializers_do_not_hide_python_mode_alias_collisions(
+    serializer_kind: str,
+) -> None:
+    class Inner(BaseModel):
+        first: int = Field(default=1, serialization_alias="shared")
+        second: int = Field(default=2, serialization_alias="shared")
+
+    class Current(BaseModel):
+        value: int = 1
+
+    if serializer_kind == "field":
+
+        class Historical(BaseModel):
+            inner: Inner = Field(default_factory=Inner)
+
+            @field_serializer("inner", when_used="json")
+            def serialize_inner(self, inner: Inner) -> dict[str, int]:
+                return {"first": inner.first, "second": inner.second}
+
+    elif serializer_kind == "model":
+
+        class Historical(BaseModel):
+            inner: Inner = Field(default_factory=Inner)
+
+            @model_serializer(when_used="json")
+            def serialize_model(self) -> dict[str, Any]:
+                return {"inner": {"first": self.inner.first, "second": self.inner.second}}
+
+    else:
+        json_inner = Annotated[
+            Inner,
+            PlainSerializer(
+                lambda value: {"first": value.first, "second": value.second},
+                return_type=dict[str, int],
+                when_used="json",
+            ),
+        ]
+
+        class Historical(BaseModel):
+            inner: json_inner = Field(default_factory=Inner)
+
+    family = SchemaFamily(
+        model=Current,
+        name=f"json_only_serializer_collision_{serializer_kind}",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="duplicate output name 'shared'"):
+        family.compile()
+
+
+def test_empty_serialization_alias_collisions_fail_compilation() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        first: int = Field(default=1, serialization_alias="")
+        second: int = Field(default=2, serialization_alias="")
+
+    family = SchemaFamily(
+        model=Current,
+        name="empty_serialization_alias_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="duplicate output name ''"):
+        family.compile()
+
+
+def test_empty_model_metadata_serialization_alias_is_verified() -> None:
+    class Config(BaseModel):
+        schema_version: Literal["1"] = Field(
+            default="1",
+            validation_alias="wire_version",
+            serialization_alias="",
+        )
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Config,
+        name="empty_model_metadata_alias",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata("wire_version", owner="model"),
+    )
+
+    assert family.defaults_for(version="1") == {"": "1", "value": 1}
+
+
+@pytest.mark.parametrize("declared", ["1", "wrong"])
+def test_family_document_adapter_rejects_reserved_metadata_on_exact_body(
+    declared: str,
+) -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="exact_body_reserved_metadata",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+    body = Historical(value=2, schema_version=declared)
+
+    with pytest.raises(ValidationError, match="reserved family-owned metadata root"):
+        target.model_validate(body)
+
+
+def test_family_document_adapter_checks_attribute_owned_metadata() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(from_attributes=True)
+
+        value: int = 1
+
+    class Source:
+        value = 2
+        schema_version = "wrong"
+
+    class MissingMetadata:
+        value = 3
+
+    class BrokenMetadata:
+        value = 4
+
+        @property
+        def schema_version(self) -> str:
+            msg = "metadata getter failed"
+            raise RuntimeError(msg)
+
+    family = SchemaFamily(
+        model=Current,
+        name="attribute_metadata_validation",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+
+    with pytest.raises(ValidationError, match="expected '1'"):
+        target.model_validate(Source(), from_attributes=True)
+    with pytest.raises(ValidationError, match="could not be read"):
+        target.model_validate(BrokenMetadata(), from_attributes=True)
+    assert target.model_validate(MissingMetadata(), from_attributes=True).model_dump() == {
+        "value": 3,
+        "schema_version": "1",
+    }
+
+
+@pytest.mark.parametrize(
+    "contract",
+    [
+        {"version": "1", "other": "body"},
+        {"other": "body"},
+    ],
+)
+def test_nested_family_metadata_reserves_its_complete_root(
+    contract: dict[str, str],
+) -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="reserved_nested_metadata_root",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    with pytest.raises(ValidationError, match="reserves the entire root"):
+        family.model_for("1").model_validate({"value": 2, "contract": contract})
+
+
+def test_family_document_adapter_schema_callbacks_execute_once() -> None:
+    schema_extra_calls: list[str] = []
+    title_calls: list[str] = []
+
+    def add_schema_extra(schema: dict[str, Any], model: type[BaseModel]) -> None:
+        schema_extra_calls.append(model.__name__)
+        schema["x-schema-extra"] = len(schema_extra_calls)
+        properties = schema.setdefault("properties", {})
+        properties["contract"] = {"description": "Reserved version envelope"}
+
+    def title_for(model: type) -> str:
+        title_calls.append(model.__name__)
+        return f"Title-{model.__name__}"
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(
+            json_schema_extra=add_schema_extra,
+            model_title_generator=title_for,
+        )
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_schema_callback_ownership",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+    target = family.model_for("1")
+    schema_extra_calls.clear()
+    title_calls.clear()
+
+    schema = target.model_json_schema()
+
+    assert schema["x-schema-extra"] == 1
+    assert schema["title"] == "Title-Historical"
+    assert schema["properties"]["contract"] == {
+        "additionalProperties": False,
+        "description": "Reserved version envelope",
+        "properties": {
+            "version": {
+                "const": "1",
+                "default": "1",
+                "title": "Version",
+                "type": "string",
+            }
+        },
+        "required": ["version"],
+        "type": "object",
+    }
+    assert schema_extra_calls == ["Historical"]
+    assert title_calls == ["Historical"]
+
+
+def test_family_document_adapter_rejects_custom_schema_hook_before_execution() -> None:
+    calls: list[str] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+        @classmethod
+        def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Any) -> Any:
+            calls.append(cls.__name__)
+            return handler(core_schema)
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_custom_schema_hook",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="cannot safely compose custom model hook"):
+        family.compile()
+    assert calls == []
+
+
+def test_family_document_adapter_does_not_replay_none_alias_generators() -> None:
+    calls: list[str] = []
+
+    def no_alias(field_name: str) -> None:
+        calls.append(field_name)
+        return None
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=AliasGenerator(
+                alias=cast(Any, no_alias),
+                validation_alias=cast(Any, no_alias),
+                serialization_alias=cast(Any, no_alias),
+            ),
+        )
+
+        value: int = 1
+
+    after_body = tuple(calls)
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_none_alias_generator",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+
+    assert tuple(calls) == after_body
+    assert target.model_fields["value"].alias is None
+    assert target.model_fields["value"].validation_alias is None
+    assert target.model_fields["value"].serialization_alias is None
+
+
+def test_family_document_adapter_preserves_default_field_deletion() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_default_deletion",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(schema_version="1")
+
+    del document.value
+
+    with pytest.raises(AttributeError):
+        _ = document.value
+    assert "value" not in document.__dict__
+    assert document.model_dump(warnings=False) == {"schema_version": "1"}
+
+
+def test_family_document_adapter_deepcopy_uses_the_callers_memo() -> None:
+    class Current(BaseModel):
+        items: list[int] = Field(default_factory=list)
+
+    class Historical(BaseModel):
+        items: list[int] = Field(default_factory=list)
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_deepcopy_memo",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(items=[1], schema_version="1")
+
+    copied = deepcopy([document, document.items])
+
+    assert copied[0].items is copied[1]
+    assert copied[0] is not document
+    existing = document.model_copy()
+    assert document.__deepcopy__({id(document): existing}) is existing
+
+
+def test_family_document_adapter_private_state_participates_in_equality() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+        _marker: str = PrivateAttr(default="a")
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return {"value": self.value, "marker": self._marker}
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_private_equality",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = cast(Any, family.model_for("1"))
+    first = target(schema_version="1")
+    second = target(schema_version="1")
+
+    second._marker = "b"
+
+    assert first != second
+    assert first.model_dump() != second.model_dump()
+
+
+def test_family_document_adapter_declared_state_wins_over_extras() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+        _marker: str = PrivateAttr(default="private")
+
+        @computed_field
+        @cached_property
+        def doubled(self) -> int:
+            return self.value * 2
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_declared_state_precedence",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1")).model_validate(
+        {
+            "value": 2,
+            "doubled": 999,
+            "_marker": "extra",
+            "schema_version": "1",
+        },
+    )
+
+    assert document.doubled == 4
+    assert document._marker == "private"
+    del document.doubled
+    assert document.doubled == 4
+
+
+def test_family_document_adapter_resynchronizes_failed_assignment() -> None:
+    class Current(BaseModel):
+        value: int = 1
+        side: int = 2
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(validate_assignment=True)
+
+        value: int = 1
+        side: int = 2
+
+        @model_validator(mode="after")
+        def synchronize(self) -> Historical:
+            object.__setattr__(self, "side", self.value * 2)
+            if self.value == 13:
+                msg = "unlucky value"
+                raise ValueError(msg)
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_failed_assignment_sync",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(value=2, schema_version="1")
+
+    with pytest.raises(ValidationError, match="unlucky value"):
+        document.value = 13
+
+    assert document.value == 13
+    assert document.side == 26
+    assert document.model_dump() == {"value": 13, "side": 26, "schema_version": "1"}
+
+
+def test_family_document_adapter_honors_revalidation_policies() -> None:
+    calls: list[int] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int = 1
+
+        @model_validator(mode="after")
+        def record(self) -> Historical:
+            calls.append(self.value)
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_always_revalidation",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = cast(Any, family.model_for("1"))
+    document = target(value=2, schema_version="1")
+    calls.clear()
+
+    revalidated = target.model_validate(document)
+
+    assert revalidated is not document
+    assert calls == [2]
+
+
+def test_family_document_adapter_is_final() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(revalidate_instances="subclass-instances")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_subclass_revalidation",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    target = family.model_for("1")
+
+    with pytest.raises(TypeError, match="document model.*is final"):
+        type("SubTarget", (target,), {})
+
+
+def test_optional_nested_child_serializer_cannot_impersonate_absence() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    class HistoricalChild(BaseModel):
+        value: int = 1
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, Any]:
+            return cast(Any, None)
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="optional_none_serializer_child",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalChild),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child | None = None
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="optional_none_serializer_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    assert parent_family.defaults_for(version="1") == {
+        "child": None,
+        "schema_version": "1",
+    }
+    with pytest.raises(ValueError, match="must serialize to an object"):
+        parent_family.dump(version="1", data=Parent(child=Child(value=2)))
+
+
+@pytest.mark.parametrize("collection", [False, True])
+def test_annotation_serializer_cannot_rewrite_declared_nested_path(
+    collection: bool,
+) -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name=f"functional_nested_child_{collection}",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+    annotation = list[Child] if collection else Child
+    serialized_annotation = Annotated[
+        annotation,
+        PlainSerializer(
+            lambda _value: [] if collection else {},
+            return_type=list[dict[str, Any]] if collection else dict[str, Any],
+        ),
+    ]
+
+    current_parent = create_model(
+        f"CurrentFunctionalNestedParent{collection}",
+        children=(annotation, ...),
+    )
+
+    historical_parent = create_model(
+        f"FunctionalNestedParent{collection}",
+        children=(serialized_annotation, ...),
+    )
+    path = "children"
+    parent_family = SchemaFamily(
+        model=current_parent,
+        name=f"functional_nested_parent_{collection}",
+        versions=(
+            SchemaVersion("1", wire_model=historical_parent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily(path, child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="annotation-level serializer"):
+        parent_family.compile()
+
+
+def test_nested_collection_visitor_preserves_nested_optional_shapes() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="deep_collection_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        children: list[list[Child | None]]
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="deep_collection_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+    )
+
+    assert parent_family.dump(
+        version="1",
+        data=Parent(children=[[Child(value=2), None], [Child(value=3)]]),
+    ) == {
+        "children": [[{"value": 2}, None], [{"value": 3}]],
+        "schema_version": "1",
+    }
+
+
+@pytest.mark.parametrize("collection_kind", ["set", "frozenset"])
+def test_nested_serialization_preserves_set_cardinality(collection_kind: str) -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class HistoricalChild(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+        @model_serializer
+        def serialize_model(self) -> dict[str, int]:
+            return {"value": 0}
+
+    child_family = SchemaFamily(
+        model=Child,
+        name=f"serialized_{collection_kind}_child",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalChild),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=_to_dict,
+                downgrade=_to_dict,
+                downgrade_semantics="exact",
+            ),
+        ),
+        version_metadata=None,
+    )
+    annotation = set[Child] if collection_kind == "set" else frozenset[Child]
+    parent_model = create_model(
+        f"Serialized{collection_kind.title()}Parent",
+        children=(annotation, ...),
+    )
+    parent_family = SchemaFamily(
+        model=parent_model,
+        name=f"serialized_{collection_kind}_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+    )
+    values = {Child(value=1), Child(value=2)}
+    container = values if collection_kind == "set" else frozenset(values)
+
+    with pytest.raises(InvalidMigrationError, match="cannot preserve set cardinality"):
+        parent_family.dump(
+            version="1",
+            data=cast(Any, parent_model)(children=container),
+        )
+
+
+@pytest.mark.parametrize(
+    ("extra_key", "message"),
+    [
+        ("child", "duplicate locations"),
+        ("childWire", "overwrites the declared location"),
+    ],
+)
+def test_serialized_nested_alias_collision_fails_closed(
+    extra_key: str,
+    message: str,
+) -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="serialized_alias_collision_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+    child_document = child_family.model_for("1")
+
+    class CurrentParent(BaseModel):
+        child: Child
+
+    class HistoricalParentBase(BaseModel):
+        model_config = ConfigDict(extra="allow", validate_by_name=True)
+
+        @model_validator(mode="after")
+        def inject_colliding_extra(self) -> HistoricalParentBase:
+            if self.__pydantic_extra__ is not None:
+                self.__pydantic_extra__[extra_key] = {"fake": True}
+            return self
+
+    historical_parent = create_model(
+        "HistoricalAliasCollisionParent",
+        __base__=HistoricalParentBase,
+        child=(child_document, Field(..., serialization_alias="childWire")),
+    )
+    parent_family = SchemaFamily(
+        model=CurrentParent,
+        name=f"serialized_alias_collision_parent_{extra_key}",
+        versions=(
+            SchemaVersion("1", wire_model=historical_parent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        parent_family.dump(version="1", data=CurrentParent(child=Child()))
+
+
+def test_automatic_nested_metadata_wrapper_rejects_siblings() -> None:
+    class Config(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Config,
+        name="automatic_reserved_metadata_root",
+        versions=(SchemaVersion("1"),),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        family.model_for("1").model_validate(
+            {"value": 2, "contract": {"version": "1", "tenant": "evil"}},
+        )
+
+
+def test_family_document_adapter_shallow_copy_preserves_metadata_identity() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_metadata_copy_identity",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+    document = cast(Any, family.model_for("1"))(contract={"version": "1"})
+
+    assert copy(document).contract is document.contract
+    assert document.model_copy().contract is document.contract
+
+    copied_graph = deepcopy([document, document.contract])
+
+    assert copied_graph[0].contract is copied_graph[1]
+
+
+def test_nested_serialize_as_any_cannot_leak_subclass_fields() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="serialize_as_any_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    class CurrentParent(BaseModel):
+        children: list[Child]
+
+    class HistoricalParent(BaseModel):
+        children: list[SerializeAsAny[Child]]
+
+    family = SchemaFamily(
+        model=CurrentParent,
+        name="serialize_as_any_nested_parent",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="annotation-level serializer"):
+        family.compile()
+
+
+def test_custom_annotation_schema_cannot_serialize_a_managed_path() -> None:
+    calls: list[str] = []
+
+    class EmptySerializer:
+        def __get_pydantic_core_schema__(self, source: Any, handler: Any) -> Any:
+            calls.append("schema")
+            return core_schema.no_info_after_validator_function(
+                lambda value: value,
+                handler(source),
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda _value: {},
+                    return_schema=core_schema.dict_schema(),
+                ),
+            )
+
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="custom_schema_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    class CurrentParent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: Annotated[Child, EmptySerializer()]
+
+    calls.clear()
+    family = SchemaFamily(
+        model=CurrentParent,
+        name="custom_schema_nested_parent",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="annotation-level serializer"):
+        family.compile()
+    assert calls == []
+
+
+def test_custom_model_schema_cannot_serialize_a_managed_path() -> None:
+    calls: list[str] = []
+
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="custom_model_schema_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    class CurrentParent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: Child
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, source: Any, handler: Any) -> Any:
+            calls.append("schema")
+            return core_schema.no_info_after_validator_function(
+                lambda value: value,
+                handler(source),
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda _value: {"child": {}},
+                    return_schema=core_schema.dict_schema(),
+                ),
+            )
+
+    calls.clear()
+    family = SchemaFamily(
+        model=CurrentParent,
+        name="custom_model_schema_nested_parent",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="custom model hook"):
+        family.compile()
+    assert calls == []
+
+
+def test_json_encoder_cannot_serialize_a_managed_path() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="json_encoder_nested_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        version_metadata=None,
+    )
+
+    class CurrentParent(BaseModel):
+        child: Child
+
+    with pytest.warns(DeprecationWarning, match="json_encoders"):
+
+        class HistoricalParent(BaseModel):
+            model_config = ConfigDict(json_encoders={Child: lambda _value: {}})
+
+            child: Child
+
+    family = SchemaFamily(
+        model=CurrentParent,
+        name="json_encoder_nested_parent",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="json_encoders"):
+        family.compile()
+
+
+def test_attribute_metadata_rejects_nested_envelope_siblings() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(from_attributes=True)
+
+        value: int = 1
+
+    class Source:
+        value = 2
+        contract = {"version": "1", "tenant": "unexpected"}
+
+    family = SchemaFamily(
+        model=Current,
+        name="attribute_nested_metadata_envelope",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    with pytest.raises(ValidationError, match="reserves the entire root"):
+        family.model_for("1").model_validate(Source(), from_attributes=True)
+
+
+def test_invalid_non_attribute_input_does_not_probe_metadata_properties() -> None:
+    reads: list[str] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    class Source:
+        value = 2
+
+        @property
+        def schema_version(self) -> str:
+            reads.append("schema_version")
+            return "wrong"
+
+    family = SchemaFamily(
+        model=Current,
+        name="metadata_attribute_probe_order",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="does not enable attribute validation"):
+        family.model_for("1").model_validate(Source())
+    assert reads == []
+
+
+def test_wrong_attribute_metadata_is_rejected_before_body_validators() -> None:
+    events: list[str] = []
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(from_attributes=True)
+
+        value: int = 1
+
+        @model_validator(mode="before")
+        @classmethod
+        def record_validation(cls, value: Any) -> Any:
+            events.append("body-validator")
+            return value
+
+    class Source:
+        value = 2
+        schema_version = "wrong"
+
+    family = SchemaFamily(
+        model=Current,
+        name="attribute_metadata_preflight_order",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="expected '1'"):
+        family.model_for("1").model_validate(Source(), from_attributes=True)
+    assert events == []
+
+
+def test_plain_attribute_metadata_envelope_is_verified_exactly() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(from_attributes=True)
+
+        value: int = 1
+
+    class Contract:
+        def __init__(self) -> None:
+            self.version = "1"
+
+    class Source:
+        value = 2
+        contract = Contract()
+
+    family = SchemaFamily(
+        model=Current,
+        name="plain_attribute_metadata_envelope",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    assert family.model_for("1").model_validate(Source()).model_dump() == {
+        "value": 2,
+        "contract": {"version": "1"},
+    }
+
+    class ContractModel(BaseModel):
+        version: Literal["1"] = "1"
+
+    class ModelSource:
+        value = 3
+        contract = ContractModel()
+
+    assert family.model_for("1").model_validate(ModelSource()).model_dump() == {
+        "value": 3,
+        "contract": {"version": "1"},
+    }
+
+    class ContractWithExtra(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        version: Literal["1"] = "1"
+
+    class ExtraSource:
+        value = 3
+        contract = ContractWithExtra(tenant="unexpected")
+
+    with pytest.raises(ValidationError, match="reserves the entire root"):
+        family.model_for("1").model_validate(ExtraSource())
+
+    class SlotsContract:
+        __slots__ = ("version",)
+
+        def __init__(self) -> None:
+            self.version = "1"
+
+    class SlotsSource:
+        value = 4
+        contract = SlotsContract()
+
+    with pytest.raises(ValidationError, match="reserves the entire root"):
+        family.model_for("1").model_validate(SlotsSource())
+
+
+@pytest.mark.parametrize(
+    ("contract", "message"),
+    [
+        (1, "non-object component"),
+        ({"envelope": {"version": "1"}, "sibling": True}, "reserves the entire root"),
+        ({"envelope": 1}, "non-object component"),
+        ({"envelope": {"version": "wrong"}}, "expected '1'"),
+    ],
+)
+def test_deep_family_metadata_envelope_fails_closed(
+    contract: Any,
+    message: str,
+) -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name=f"deep_metadata_envelope_{message}_{type(contract).__name__}",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(
+            ("contract", "envelope", "version"),
+            owner="family",
+        ),
+    )
+
+    with pytest.raises(ValidationError, match=message):
+        family.model_for("1").model_validate({"value": 2, "contract": contract})
+
+
+def test_family_document_adapter_rejects_private_api_collisions() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+        _replace_document_adapter_state: str = PrivateAttr(default="collision")
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_private_api_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="conflicts with.*adapter API"):
+        family.compile()
+
+
+def test_family_document_adapter_construct_removes_metadata_from_body_fields_set() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_construct_fields_set",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+    document = family.model_for("1").model_construct(
+        _fields_set={"value", "contract"},
+        value=2,
+        contract={"version": "1"},
+    )
+
+    assert document.model_fields_set == {"value"}
+    assert document.model_dump() == {"value": 2, "contract": {"version": "1"}}
+
+
+def test_target_extras_cannot_overwrite_declared_serialization_aliases() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = Field(default=1, serialization_alias="wireValue")
+
+        @model_validator(mode="after")
+        def inject_collision(self) -> Historical:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["wireValue"] = "not-an-integer"
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="top_level_extra_output_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match="extras overwrite declared serialization"):
+        family.defaults_for(version="1")
+
+
+def test_nested_target_extras_cannot_overwrite_declared_serialization_aliases() -> None:
+    class HistoricalInner(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = Field(default=1, serialization_alias="wireValue")
+
+        @model_validator(mode="after")
+        def inject_collision(self) -> HistoricalInner:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["wireValue"] = "not-an-integer"
+            return self
+
+    class Current(BaseModel):
+        inner: dict[str, Any] = Field(default_factory=dict)
+
+    class Historical(BaseModel):
+        inner: HistoricalInner = Field(default_factory=HistoricalInner)
+
+    family = SchemaFamily(
+        model=Current,
+        name="recursive_extra_output_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match="extras overwrite declared serialization"):
+        family.defaults_for(version="1")
+
+
+def test_typed_target_extras_recurse_into_nested_model_collisions() -> None:
+    class Inner(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        __pydantic_extra__: dict[str, Any] = Field(init=False)
+        value: int = Field(default=1, serialization_alias="wireValue")
+
+        @model_validator(mode="after")
+        def add_collision(self) -> Inner:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["wireValue"] = "CORRUPTED"
+            return self
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        __pydantic_extra__: dict[str, Inner] = Field(init=False)
+        value: int = 1
+
+        @model_validator(mode="after")
+        def add_inner(self) -> Historical:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["holder"] = Inner()
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="typed_extra_nested_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match="extras overwrite declared serialization.*wireValue"):
+        family.defaults_for(version="1")
+
+
+def test_target_extras_cannot_overwrite_computed_serialization_aliases() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+        @computed_field(alias="wireComputed")
+        @property
+        def computed(self) -> int:
+            return self.value * 2
+
+        @model_validator(mode="after")
+        def inject_collision(self) -> Historical:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["wireComputed"] = "not-an-integer"
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="computed_extra_output_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match="extras overwrite declared serialization"):
+        family.defaults_for(version="1")
+
+
+def test_nested_fixed_tuple_shape_is_preserved_during_metadata_pruning() -> None:
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="fixed_tuple_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+    )
+
+    class Parent(BaseModel):
+        children: tuple[Child, Child]
+
+    family = SchemaFamily(
+        model=Parent,
+        name="fixed_tuple_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        nested=(NestedFamily("children", child_family, matching_labels()),),
+    )
+
+    assert family.dump(
+        version="1",
+        data=Parent(children=(Child(value=2), Child(value=3))),
+    ) == {
+        "children": [{"value": 2}, {"value": 3}],
+        "schema_version": "1",
+    }
+
+
+def test_family_document_adapter_preserves_declared_values_when_extras_reuse_names() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+        @model_validator(mode="after")
+        def inject_collision(self) -> Historical:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["value"] = "extra"
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_declared_extra_collision",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(value=2, schema_version="1")
+
+    assert document.value == 2
+    assert document.model_extra == {"value": "extra"}
+
+
+def test_family_document_adapter_preserves_internal_name_extras() -> None:
+    internal_names = (
+        "_FamilyDocumentAdapterBase__document_body",
+        "_document_body_model",
+        "_from_document_body",
+        "_replace_document_adapter_state",
+    )
+
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_internal_name_extras",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    body = Historical.model_validate(
+        {"value": 2, **{name: f"wire-{index}" for index, name in enumerate(internal_names)}},
+    )
+    document = cast(Any, family.model_for("1")).model_validate(body)
+
+    for index, name in enumerate(internal_names):
+        assert getattr(document, name) == f"wire-{index}"
+    dumped = document.model_dump()
+    assert all(dumped[name] == f"wire-{index}" for index, name in enumerate(internal_names))
+
+    with pytest.raises(AttributeError, match="Internal document state"):
+        setattr(document, internal_names[0], "replacement")
+    with pytest.raises(AttributeError, match="Internal document state"):
+        delattr(document, internal_names[0])
+
+    object.__setattr__(document, internal_names[0], object())
+    with pytest.raises(ValueError, match="lost its validated explicit wire body"):
+        document.model_dump()
+
+
+def test_family_document_adapter_snapshots_foreign_body_scalar_state() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_foreign_body_snapshot",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    body = Historical(value=2)
+    document = cast(Any, family.model_for("1")).model_validate(body)
+
+    body.value = 9
+
+    assert document.value == 2
+    assert document.model_dump() == {"value": 2, "schema_version": "1"}
+
+
+def test_family_document_adapter_does_not_replay_deleted_default_factories() -> None:
+    calls: list[str] = []
+
+    def factory() -> list[int]:
+        calls.append("factory")
+        return [1]
+
+    class Current(BaseModel):
+        items: list[int] = Field(default_factory=list)
+        marker: int = 0
+
+    class Historical(BaseModel):
+        items: list[int] = Field(default_factory=factory)
+        marker: int = 0
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_deleted_factory_state",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(schema_version="1")
+
+    del document.items
+    document.marker = 2
+    document.model_dump(warnings=False)
+
+    assert calls == ["factory"]
+
+
+def test_family_document_adapter_refreshes_after_body_back_reference_mutation() -> None:
+    class Current(BaseModel):
+        value: int = 1
+
+    class Historical(BaseModel):
+        value: int = 1
+        _references: list[Any] = PrivateAttr(default_factory=list)
+
+        @model_validator(mode="after")
+        def retain_self(self) -> Historical:
+            self._references = [self]
+            return self
+
+    family = SchemaFamily(
+        model=Current,
+        name="adapter_body_back_reference",
+        versions=(
+            SchemaVersion("1", wire_model=Historical),
+            SchemaVersion("2"),
+        ),
+    )
+    document = cast(Any, family.model_for("1"))(value=2, schema_version="1")
+
+    references = document._references
+    references[0].value = 7
+
+    assert document.value == 7
+    assert dict(document)["value"] == 7
+    assert "value=7" in repr(document)
+    assert document == document.model_copy()
+    assert family.validate(document, version="1").current_model.value == 7

--- a/tests/unit/test_versioned_schema.py
+++ b/tests/unit/test_versioned_schema.py
@@ -187,8 +187,11 @@ def test_validate_versioned_normalizes_alias_paths_in_upgrade_output() -> None:
 
 
 def test_dump_versioned_renders_defaults_for_requested_schema() -> None:
-    with pytest.raises(IrreversibleTransitionError):
-        dump_versioned(AppConfig, version="1")
+    assert dump_versioned(AppConfig, version="1") == {
+        "timeout": 5.0,
+        "attempts": 3,
+        "schema_version": "1",
+    }
 
 
 def test_dump_versioned_executes_explicit_downgrades_in_reverse_edge_order() -> None:
@@ -301,7 +304,9 @@ def test_explicit_wire_model_enables_typeful_historical_rendering_and_validation
     )
 
     assert rendered == {"timeout": "9.5", "schema_version": "1"}
-    assert model_for_version(HistoricalTypeConfig, "1") is HistoricalTimeoutConfig
+    historical_document = model_for_version(HistoricalTypeConfig, "1")
+    assert historical_document is not HistoricalTimeoutConfig
+    assert historical_document.model_validate(rendered).model_dump() == rendered
 
 
 def test_dump_versioned_accepts_current_model_data_for_historical_schema() -> None:
@@ -1168,9 +1173,9 @@ def test_nested_runtime_handles_set_tuple_and_frozenset_payloads() -> None:
     assert len(rendered["values"]) == 2
     assert len(rendered["tuple_values"]) == 2
     assert len(rendered["frozenset_values"]) == 1
-    assert all(item["schema_version"] == "1" for item in rendered["values"])
-    assert all(item["schema_version"] == "1" for item in rendered["tuple_values"])
-    assert all(item["schema_version"] == "1" for item in rendered["frozenset_values"])
+    assert all("schema_version" not in item for item in rendered["values"])
+    assert all("schema_version" not in item for item in rendered["tuple_values"])
+    assert all("schema_version" not in item for item in rendered["frozenset_values"])
 
 
 def test_nested_runtime_set_conversion_preserves_collection_membership_or_raises() -> None:


### PR DESCRIPTION
## Summary

- construct `defaults_for()` directly from the selected target wire model and keep empty mappings as real current input
- make complete rendering default to JSON serialization aliases while rejecting omission, polymorphic, round-trip, and unknown options that can weaken the target contract
- compose explicit wire bodies with family-owned metadata through a final document adapter that preserves once-only Pydantic behavior and fails closed on unsafe metadata, serializer, alias, schema, and extra collisions
- remove redundant family-owned child discriminators across declared and decorator-discovered nested routes while retaining and verifying model-owned metadata
- preserve the immutable 0.3.0 golden and derive the three reviewed nested-metadata corrections explicitly
- document the Pydantic validation/serialization boundary and producer-consumer alias alignment

## Verification

- `uv run make ci` — 529 tests, 90.02% coverage
- `uv run zensical build --strict`
- `uv run python tests/compatibility/v0_3_0_contract.py --check`
- Pydantic 2.12.3 isolated focused suite — 139 tests
- `uv build` — wheel and sdist
- locked dependency audit — no known vulnerabilities
- independent adversarial review — no remaining actionable findings

Closes #66