### PR TITLE
fix(docs): execute canonical package examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ uv add pydantic-versions
 Schema versions are independent from software versions. A config payload can declare
 the schema it uses, and the latest software can still validate and upgrade it:
 
+<!-- pv-doc-test: readme-example -->
 ```python
 from pydantic import BaseModel
 from pydantic_versions import (
     SchemaFamily,
     SchemaVersion,
-    VersionTransition,
     field_default,
     field_removed,
 )
@@ -48,11 +48,6 @@ class AppConfig(BaseModel):
     timeout: float = 10.0
     retries: int = 3
     new_feature: bool = False
-
-
-def upgrade_v1(data: dict) -> dict:
-    data.setdefault("new_feature", False)
-    return data
 
 
 APP_CONFIG_SCHEMA = SchemaFamily(
@@ -68,7 +63,6 @@ APP_CONFIG_SCHEMA = SchemaFamily(
         ),
         SchemaVersion("2"),
     ),
-    transitions=(VersionTransition("1", "2", upgrade=upgrade_v1),),
     missing_version="1",
 )
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed redundant family-owned discriminators from embedded child output
   across built-in and decorator-discovered nested routes while retaining
   model-owned child metadata.
+- Repaired the canonical README and guide examples and added an executable
+  documentation gate that keeps their behavior and the manual API reference in
+  sync with the installed public package.
 - Replaced the redirecting Read the Docs badge source with a directly rendered
   Shields endpoint so the documentation status appears on PyPI.
 - Rejected nested-family mappings, heterogeneous branches, and child-model

--- a/docs/guide/complex-config-example.md
+++ b/docs/guide/complex-config-example.md
@@ -2,13 +2,13 @@
 
 This page uses a larger config to show why schema versioning matters. The
 example is intentionally config-shaped: nested Pydantic models, lists, defaults,
-renamed fields, removed fields, and version metadata stored outside the core
-model.
+renamed fields, and version metadata stored outside the core model.
 
 ## A Plain Pydantic Config
 
 Imagine a deployment tool that reads YAML and validates it with Pydantic:
 
+<!-- pv-doc-test: complex-plain -->
 ```python
 from typing import Literal
 
@@ -80,26 +80,29 @@ with subtly different behavior. That creates a bad operational choice:
 - update every config immediately during a software rollout;
 - add one-off compatibility code around each loader.
 
-`pydantic-versions` is meant to keep that compatibility policy next to the model
-definition instead.
+`pydantic-versions` keeps that compatibility policy beside the ordinary current
+models instead.
 
-## A Versioned Current Model
+## Define The Current Models
 
-The decorated model is the current schema. Historical versions are generated
-from it with patches:
+Define each current model exactly once. The rest of this page is one executable
+sequence, so every family and transition is registered before validation first
+compiles it.
 
+<!-- pv-doc-test: complex-versioned -->
 ```python
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_versions import (
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    VersionMetadata,
+    VersionTransition,
     field_default,
-    field_removed,
     field_renamed,
-    migration,
-    schema_version,
-    validate_versioned,
-    versioned_schema,
+    matching_labels,
 )
 
 
@@ -127,19 +130,6 @@ class ObservabilityConfig(BaseModel):
     exporter: Literal["none", "otlp", "prometheus"] = "none"
 
 
-@versioned_schema(
-    name="pipeline_config",
-    versions=["1", "2"],
-    current="2",
-    version_field="schema_version",
-)
-@schema_version(
-    "1",
-    patches=[
-        field_renamed("name", "service_name"),
-        field_renamed("observability", "telemetry"),
-    ],
-)
 class PipelineConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -148,125 +138,212 @@ class PipelineConfig(BaseModel):
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
 ```
 
-The top-level v1 field names are now understood:
+## Declare The Nested History
 
+The retry policy owns its history. Version 1 used `attempts` and a one-second
+default; version 2 uses the current names and defaults.
+
+<!-- pv-doc-test: complex-versioned -->
 ```python
-result = validate_versioned(
-    PipelineConfig,
-    {
-        "schema_version": "1",
-        "service_name": "invoice-ingest",
-        "workers": [
-            {
-                "name": "parser",
-                "image": "ghcr.io/example/parser:1.0",
-                "replicas": 2,
-            }
-        ],
-        "telemetry": {"enabled": False},
-    },
+RETRY_SCHEMA = SchemaFamily(
+    model=RetryPolicy,
+    name="retry_policy",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_renamed("max_attempts", "attempts"),
+                field_default("backoff_seconds", 1.0),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
 )
+
+assert RETRY_SCHEMA.defaults_for(version="1") == {
+    "attempts": 3,
+    "backoff_seconds": 1.0,
+    "schema_version": "1",
+}
+```
+
+The parent explicitly connects `workers[*].retry` to that family. The
+`matching_labels()` mapping selects retry v1 for pipeline v1 and retry v2 for
+pipeline v2. Direct and optional children and homogeneous lists, tuples, sets,
+and frozen sets are supported; mapping values and heterogeneous branches are
+rejected because runtime conversion cannot dispatch them unambiguously.
+
+## Register Value Transitions Before First Use
+
+Patches handle field-level compatibility. Use a transition for value-level or
+shape-level changes that need code. Here, disabled telemetry is normalized to
+the `"none"` exporter. The downgrade is declared at the same time so historical
+rendering remains available; it is lossy because the normalization cannot
+recover a prior non-`"none"` exporter.
+
+<!-- pv-doc-test: complex-versioned -->
+```python
+def upgrade_pipeline_v1(data: dict) -> dict:
+    observability = data.setdefault("observability", {})
+    if observability.get("enabled") is False:
+        observability["exporter"] = "none"
+    return data
+
+
+def downgrade_pipeline_v2(data: dict) -> dict:
+    return data
+
+
+PIPELINE_SCHEMA = SchemaFamily(
+    model=PipelineConfig,
+    name="pipeline_config",
+    versions=(
+        SchemaVersion(
+            "1",
+            patches=(
+                field_renamed("name", "service_name"),
+                field_renamed("observability", "telemetry"),
+            ),
+        ),
+        SchemaVersion("2"),
+    ),
+    transitions=(
+        VersionTransition(
+            "1",
+            "2",
+            upgrade=upgrade_pipeline_v1,
+            downgrade=downgrade_pipeline_v2,
+            downgrade_semantics="lossy",
+        ),
+    ),
+    nested=(
+        NestedFamily(
+            ("workers", "retry"),
+            RETRY_SCHEMA,
+            matching_labels(),
+        ),
+    ),
+)
+```
+
+Construct the complete graph before calling `validate()`, `model_for()`,
+`describe()`, or a planning method. Those operations compile the family;
+declarations cannot be added afterward.
+
+## Validate Historical Input
+
+The old field names and the nested v1 retry values now reach the current
+models:
+
+<!-- pv-doc-test: complex-versioned -->
+```python
+historical_pipeline = {
+    "schema_version": "1",
+    "service_name": "invoice-ingest",
+    "workers": [
+        {
+            "name": "parser",
+            "image": "ghcr.io/example/parser:1.0",
+            "replicas": 2,
+            "retry": {"attempts": 5},
+        }
+    ],
+    "telemetry": {"enabled": False, "exporter": "otlp"},
+}
+
+result = PIPELINE_SCHEMA.validate(historical_pipeline)
 
 assert result.source_version == "1"
 assert result.current_version == "2"
 assert result.current_model.name == "invoice-ingest"
 assert result.current_model.observability.enabled is False
-```
-
-## Nested Schema Changes
-
-Nested models can be versioned too. If `RetryPolicy` changed between schema
-versions, decorate it separately:
-
-```python
-@versioned_schema(name="retry_policy", versions=["1", "2"], current="2")
-@schema_version(
-    "1",
-    patches=[
-        field_renamed("max_attempts", "attempts"),
-        field_default("backoff_seconds", 1.0),
-    ],
+assert result.current_model.observability.exporter == "none"
+assert result.current_model.workers[0].retry == RetryPolicy(
+    max_attempts=5,
+    backoff_seconds=1.0,
 )
-class RetryPolicy(BaseModel):
-    max_attempts: int = 3
-    backoff_seconds: float = 2.0
 ```
-
-Then a versioned model can explicitly connect that family through direct or
-optional fields and homogeneous lists, tuples, sets, or frozen sets. Mapping
-values and heterogeneous unions are rejected during family compilation because
-runtime conversion cannot dispatch them unambiguously.
-
-## When Patches Are Not Enough
-
-Patches handle field-level compatibility. Use migrations for value-level or
-shape-level changes that need code.
-
-In this example, v1 had a `telemetry.enabled: false` value. In v2, the product
-decides that disabled telemetry should also force the exporter to `"none"`:
-
-```python
-@migration(PipelineConfig, "1", "2")
-def migrate_pipeline_v1_to_v2(data: dict) -> dict:
-    observability = data.setdefault("observability", {})
-    if observability.get("enabled") is False:
-        observability["exporter"] = "none"
-    return data
-```
-
-Migration functions receive dictionaries using current field names. They run
-after source-version validation and historical rename mapping, then the result
-is validated again with the current model.
 
 ## Version Metadata Outside The Model
 
-Some formats keep version metadata in wrapper fields. Kubernetes-style resources
-often use `apiVersion`; other configs may store version information under
-`metadata`.
+Some formats keep version metadata in wrapper fields. Kubernetes-style
+resources often use `apiVersion`; other configs may store version information
+under `metadata`. Wrapper families can connect their `spec` field to the
+pipeline family with an explicit label mapping.
 
-Use a top-level custom field:
-
+<!-- pv-doc-test: complex-versioned -->
 ```python
-@versioned_schema(
-    name="pipeline_crd",
-    versions=["example.com/v1", "example.com/v2"],
-    current="example.com/v2",
-    version_field="apiVersion",
-)
 class PipelineResource(BaseModel):
     kind: Literal["Pipeline"]
     spec: PipelineConfig
-```
 
-Or a nested path:
 
-```python
-@versioned_schema(
-    name="pipeline_document",
-    versions=["1", "2"],
-    current="2",
-    version_field=("metadata", "schema_version"),
+PIPELINE_RESOURCE_SCHEMA = SchemaFamily(
+    model=PipelineResource,
+    name="pipeline_crd",
+    versions=(
+        SchemaVersion("example.com/v1"),
+        SchemaVersion("example.com/v2"),
+    ),
+    nested=(
+        NestedFamily(
+            "spec",
+            PIPELINE_SCHEMA,
+            {
+                "example.com/v1": "1",
+                "example.com/v2": "2",
+            },
+        ),
+    ),
+    version_metadata=VersionMetadata("apiVersion"),
 )
+
+
 class PipelineDocument(BaseModel):
     spec: PipelineConfig
+
+
+PIPELINE_DOCUMENT_SCHEMA = SchemaFamily(
+    model=PipelineDocument,
+    name="pipeline_document",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+    nested=(NestedFamily("spec", PIPELINE_SCHEMA, matching_labels()),),
+    version_metadata=VersionMetadata(("metadata", "schema_version")),
+)
+
+resource = PIPELINE_RESOURCE_SCHEMA.model_for("example.com/v1").model_validate(
+    {
+        "apiVersion": "example.com/v1",
+        "kind": "Pipeline",
+        "spec": historical_pipeline,
+    }
+)
+document = PIPELINE_DOCUMENT_SCHEMA.model_for("1").model_validate(
+    {
+        "metadata": {"schema_version": "1"},
+        "spec": historical_pipeline,
+    }
+)
+
+assert resource.model_dump()["apiVersion"] == "example.com/v1"
+assert document.model_dump()["metadata"] == {"schema_version": "1"}
 ```
 
-For nested paths, the metadata wrapper does not have to be part of the
+For nested metadata paths, the wrapper does not have to be part of the
 authoritative application model. The generated wire model validates the
-complete wrapper, and family-owned metadata is removed only from the private
+complete document, and family-owned metadata is removed from the private
 transition value before final application-model validation.
 
-## Rendering Older Configs
+## Render Older Configs
 
-You can render the old shape for examples, generated starter configs, or
-compatibility output:
+The paired downgrade makes the historical route available. Rendering applies
+the top-level projection and the explicitly connected retry v1 wire contract.
+The parent mapping owns the embedded child selection, so the retry payload does
+not repeat its standalone `schema_version` discriminator:
 
+<!-- pv-doc-test: complex-versioned -->
 ```python
-from pydantic_versions import dump_versioned
-
-
-v1_example = dump_versioned(
-    PipelineConfig,
+v1_example = PIPELINE_SCHEMA.dump(
     version="1",
     data=PipelineConfig(
         name="invoice-ingest",
@@ -274,15 +351,23 @@ v1_example = dump_versioned(
             WorkerConfig(
                 name="parser",
                 image="ghcr.io/example/parser:2.0",
-                retry=RetryPolicy(max_attempts=5),
+                retry=RetryPolicy(
+                    max_attempts=3,
+                    backoff_seconds=1.0,
+                ),
             )
         ],
+        observability=ObservabilityConfig(enabled=False),
     ),
 )
 
-assert "service_name" in v1_example
-assert "telemetry" in v1_example
+assert v1_example["service_name"] == "invoice-ingest"
+assert v1_example["telemetry"] == {"enabled": False, "exporter": "none"}
 assert "name" not in v1_example
+assert v1_example["workers"][0]["retry"] == {
+    "attempts": 3,
+    "backoff_seconds": 1.0,
+}
 ```
 
 This makes the compatibility contract explicit: the latest software can keep

--- a/docs/guide/external-families.md
+++ b/docs/guide/external-families.md
@@ -9,6 +9,7 @@ than one interpretation of the same current model.
 
 The model module does not need to import `pydantic_versions`:
 
+<!-- pv-doc-test: external-families -->
 ```python
 # models.py
 from pydantic import BaseModel
@@ -22,21 +23,15 @@ class AppConfig(BaseModel):
 
 Declare its history elsewhere:
 
+<!-- pv-doc-test: external-families -->
 ```python
 # schema_history.py
-from models import AppConfig
 from pydantic_versions import (
     SchemaFamily,
     SchemaVersion,
-    VersionTransition,
     field_default,
     field_removed,
 )
-
-
-def upgrade_v1(data: dict) -> dict:
-    data.setdefault("new_feature", False)
-    return data
 
 
 APP_CONFIG_SCHEMA = SchemaFamily(
@@ -52,9 +47,12 @@ APP_CONFIG_SCHEMA = SchemaFamily(
         ),
         SchemaVersion("2"),
     ),
-    transitions=(VersionTransition("1", "2", upgrade=upgrade_v1),),
 )
 ```
+
+When these definitions live in separate files, `schema_history.py` imports
+`AppConfig` from `models.py`; the snippets on this page are also one executable
+sequence.
 
 The final declared label is current. Historical versions are projected
 independently from the current model; patches are not accumulated from one
@@ -64,6 +62,7 @@ historical declaration into the next.
 
 Direct family calls cannot be confused with another history:
 
+<!-- pv-doc-test: external-families -->
 ```python
 result = APP_CONFIG_SCHEMA.validate(
     {"schema_version": "1", "retries": 2},
@@ -77,10 +76,18 @@ assert result.current_model == AppConfig(
 
 v1_model = APP_CONFIG_SCHEMA.model_for("1")
 v1_defaults = APP_CONFIG_SCHEMA.defaults_for(version="1")
+
+assert v1_model.model_validate(v1_defaults).model_dump() == v1_defaults
+assert v1_defaults == {
+    "timeout": 5.0,
+    "retries": 3,
+    "schema_version": "1",
+}
 ```
 
 The compatibility free functions also accept a family as their first argument:
 
+<!-- pv-doc-test: external-families -->
 ```python
 from pydantic_versions import model_for_version, validate_versioned
 
@@ -90,6 +97,9 @@ result = validate_versioned(
     APP_CONFIG_SCHEMA,
     {"schema_version": "1", "retries": 2},
 )
+
+assert model_for_version(APP_CONFIG_SCHEMA, "1") is v1_model
+assert result.current_model.retries == 2
 ```
 
 ## Reuse one model in two families
@@ -98,6 +108,7 @@ Families own their declarations, compiled projections, transitions, and
 generated-model cache. Two families can therefore reuse the same application
 model without overwriting each other:
 
+<!-- pv-doc-test: external-families -->
 ```python
 PUBLIC_CONFIG = SchemaFamily(
     model=AppConfig,
@@ -119,6 +130,7 @@ basis for choosing and raises `SchemaFamilySelectionError`.
 Applications that still need model-only helper calls can select one family
 during configuration startup:
 
+<!-- pv-doc-test: external-families -->
 ```python
 PUBLIC_CONFIG.as_default()
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -26,6 +26,7 @@ supported.
 Start with the model your current application wants to use. It does not need a
 version decorator or a `pydantic_versions` import:
 
+<!-- pv-doc-test: getting-started -->
 ```python
 # models.py
 from pydantic import BaseModel
@@ -41,9 +42,9 @@ class AppConfig(BaseModel):
 
 Put the growing history in a dedicated module:
 
+<!-- pv-doc-test: getting-started -->
 ```python
 # schema_history.py
-from models import AppConfig
 from pydantic_versions import (
     SchemaFamily,
     SchemaVersion,
@@ -75,12 +76,15 @@ This says:
 - version `1` did not have `new_feature`.
 
 Adding another historical version changes `schema_history.py`, not the
-authoritative application model.
+authoritative application model. When these definitions live in separate
+files, `schema_history.py` imports `AppConfig` from `models.py`; the snippets on
+this page are also one executable sequence.
 
 ## Validate historical input
 
 Users can keep older config files:
 
+<!-- pv-doc-test: getting-started -->
 ```python
 old_config = {
     "schema_version": "1",
@@ -103,10 +107,11 @@ after validation.
 
 ## Render a historical config
 
-Use `dump()` when you need defaults or output for a specific schema version:
+Use `defaults_for()` when you need defaults for a specific schema version:
 
+<!-- pv-doc-test: getting-started -->
 ```python
-v1_config = APP_CONFIG_SCHEMA.dump(version="1")
+v1_config = APP_CONFIG_SCHEMA.defaults_for(version="1")
 
 assert v1_config == {
     "timeout": 5.0,
@@ -120,12 +125,18 @@ assert v1_config == {
 Patches describe field-level schema differences. Declare adjacent forward
 transitions for custom value changes:
 
+<!-- pv-doc-test: getting-started -->
 ```python
 from pydantic_versions import VersionTransition
 
 
 def upgrade_v1(data: dict) -> dict:
     data.setdefault("new_feature", False)
+    return data
+
+
+def downgrade_v2(data: dict) -> dict:
+    data.pop("new_feature", None)
     return data
 
 
@@ -142,7 +153,15 @@ APP_CONFIG_SCHEMA = SchemaFamily(
         ),
         SchemaVersion("2"),
     ),
-    transitions=(VersionTransition("1", "2", upgrade=upgrade_v1),),
+    transitions=(
+        VersionTransition(
+            "1",
+            "2",
+            upgrade=upgrade_v1,
+            downgrade=downgrade_v2,
+            downgrade_semantics="lossy",
+        ),
+    ),
 )
 ```
 
@@ -150,12 +169,15 @@ This replaces the earlier family declaration with the same v1 projection plus
 an upgrade. Transitions run after historical validation and before final
 current-model validation. Every declared transition must connect adjacent
 labels, so accepted upgrade code cannot become an unreachable registration.
+The paired downgrade keeps historical rendering available; it is marked lossy
+because v1 cannot represent `new_feature`.
 
 ## Keep the decorator style when it stays small
 
 The 0.1 decorators remain compatibility and convenience adapters. They build a
 default family and delegate to the same compiler:
 
+<!-- pv-doc-test: getting-started -->
 ```python
 from pydantic_versions import schema_version, versioned_schema
 

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -16,15 +16,36 @@ asymmetric model may require a separately aligned consumer contract.
 
 ## Render defaults
 
+The following snippets form one executable example:
+
+<!-- pv-doc-test: rendering -->
 ```python
+from pydantic import BaseModel
+from pydantic_versions import (
+    dump_versioned,
+    field_default,
+    field_renamed,
+    schema_version,
+    versioned_schema,
+)
+
+
 @versioned_schema(name="app_config", versions=["1", "2"], current="2")
-@schema_version("1", patches=[field_default("timeout", 5.0)])
+@schema_version(
+    "1",
+    patches=[
+        field_default("timeout", 5.0),
+        field_renamed("retries", "attempts"),
+    ],
+)
 class AppConfig(BaseModel):
     timeout: float = 10.0
+    retries: int = 3
 
 
 assert dump_versioned(AppConfig, version="1") == {
     "timeout": 5.0,
+    "attempts": 3,
     "schema_version": "1",
 }
 ```
@@ -44,14 +65,18 @@ required current fields still fail validation.
 
 Current model instances and mappings can be rendered into historical field names:
 
+<!-- pv-doc-test: rendering -->
 ```python
-@schema_version("1", patches=[field_renamed("retries", "attempts")])
-class AppConfig(BaseModel):
-    retries: int = 3
-
-
-dumped = dump_versioned(AppConfig, version="1", data=AppConfig(retries=5))
-assert dumped["attempts"] == 5
+dumped = dump_versioned(
+    AppConfig,
+    version="1",
+    data=AppConfig(timeout=12.0, retries=5),
+)
+assert dumped == {
+    "timeout": 12.0,
+    "attempts": 5,
+    "schema_version": "1",
+}
 ```
 
 Supplied `data` always describes the current schema. The `version` argument is
@@ -153,8 +178,10 @@ partial view outside this API when an application deliberately needs one.
 Set `include_version=False` when family-owned version metadata is stored outside
 the rendered payload:
 
+<!-- pv-doc-test: rendering -->
 ```python
 dumped = dump_versioned(AppConfig, version="1", include_version=False)
+assert dumped == {"timeout": 5.0, "attempts": 3}
 ```
 
 This is an explicit body-only mode. Its result is not a complete document for
@@ -167,6 +194,7 @@ raises `ValueError` before target construction or serialization.
 
 Nested version fields are rendered into the requested path:
 
+<!-- pv-doc-test: rendering -->
 ```python
 @versioned_schema(
     name="metadata_config",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -85,8 +85,12 @@ class VersionMetadata:
 ```
 
 Describes the version-discriminator path and its ownership. Full collision and
-alias semantics are defined by the 0.2 architecture decision and implemented by
-the later top-level conversion work.
+alias semantics are part of the runtime contract: family-owned metadata is
+validated on the generated document and removed before authoritative model
+validation, while a model-owned top-level field or direct alias remains part of
+the model payload. See [Rendering Configs](../guide/rendering.md) and
+[Version Discovery](../guide/version-discovery.md) for the supported paths and
+conflict behavior.
 
 ### Generated wire models
 
@@ -328,21 +332,57 @@ render plan means that no safe reverse transition is declared.
 
 ## Decorator compatibility
 
-`versioned_schema(name, versions, current, version_field="schema_version", missing_version=None, transitions=(), ...)`
+<!-- pv-api-signature: versioned_schema -->
+```python
+def versioned_schema(
+    *,
+    name: str,
+    versions: Sequence[str],
+    current: str,
+    version_field: VersionPath = "schema_version",
+    missing_version: str | None = None,
+    metadata_owner: Literal["family", "model"] | None = None,
+    transitions: Sequence[VersionTransition] = (),
+    nested: Sequence[NestedFamily] = (),
+) -> Callable[[type[T]], type[T]]: ...
+```
 
 Builds a default family for a Pydantic model and returns the original model
 class. `current` must equal the final label. The deterministic `transitions=`
 argument uses `VersionTransition` records.
 
-`schema_version(version, patches=())`
+<!-- pv-api-signature: schema_version -->
+```python
+def schema_version(
+    version: str,
+    *,
+    patches: Sequence[VersionPatch] = (),
+    wire_model: type[BaseModel] | None = None,
+) -> Callable[[type[T]], type[T]]: ...
+```
 
 Applies patches to one declared historical version.
 
-`schema_versions(versions, patches=())`
+<!-- pv-api-signature: schema_versions -->
+```python
+def schema_versions(
+    versions: Sequence[str],
+    *,
+    patches: Sequence[VersionPatch] = (),
+    wire_model: type[BaseModel] | None = None,
+) -> Callable[[type[T]], type[T]]: ...
+```
 
 Applies the same patches to multiple explicitly declared historical versions.
 
-`migration(subject, from_version, to_version)`
+<!-- pv-api-signature: migration -->
+```python
+def migration(
+    subject: type[T] | SchemaFamily[T],
+    from_version: str,
+    to_version: str,
+) -> Callable[[F], F]: ...
+```
 
 Registers a legacy forward upgrade before first compilation. `subject` may be a
 family or a model with an explicit default family. Late, reverse, skipped, and
@@ -440,7 +480,7 @@ class VersionedValidation[T: BaseModel]:
   - `MissingSchemaVersionError`
   - `UnknownSchemaVersionError`
   - `DuplicateSchemaVersionError`
-- `InvalidMigrationError`
+  - `InvalidMigrationError`
 
 `UnsupportedWireModelError` reports that automatic projection cannot safely
 produce the required object-shaped Pydantic v2 wire contract. It is raised

--- a/tests/integration/test_documentation_examples.py
+++ b/tests/integration/test_documentation_examples.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pydantic_versions as public_api
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+API_REFERENCE = REPOSITORY / "docs" / "reference" / "api.md"
+
+_EXECUTABLE_BLOCK = re.compile(
+    r"<!-- pv-doc-test: (?P<session>[a-z0-9-]+) -->\n"
+    r"```python\n(?P<source>.*?)\n```",
+    re.DOTALL,
+)
+_API_SIGNATURE_BLOCK = re.compile(
+    r"<!-- pv-api-signature: (?P<name>[a-z_]+) -->\n"
+    r"```python\n(?P<source>.*?)\n```",
+    re.DOTALL,
+)
+_EXCEPTION_ITEM = re.compile(
+    r"^(?P<indent> *)- `(?P<name>[A-Za-z][A-Za-z0-9]*)`$",
+    re.MULTILINE,
+)
+
+_CANONICAL_DOCUMENTS = (
+    (Path("README.md"), {"readme-example": 1}),
+    (Path("docs/guide/getting-started.md"), {"getting-started": 6}),
+    (Path("docs/guide/external-families.md"), {"external-families": 6}),
+    (Path("docs/guide/rendering.md"), {"rendering": 4}),
+    (
+        Path("docs/guide/complex-config-example.md"),
+        {"complex-plain": 1, "complex-versioned": 6},
+    ),
+)
+
+
+def _executable_sessions(path: Path) -> dict[str, list[str]]:
+    sessions: defaultdict[str, list[str]] = defaultdict(list)
+    for match in _EXECUTABLE_BLOCK.finditer(path.read_text(encoding="utf-8")):
+        sessions[match.group("session")].append(match.group("source"))
+    return dict(sessions)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_counts"),
+    _CANONICAL_DOCUMENTS,
+    ids=(
+        "readme",
+        "getting-started",
+        "external-families",
+        "rendering",
+        "complex-config",
+    ),
+)
+def test_canonical_documentation_examples_execute_from_the_installed_package(
+    relative_path: Path,
+    expected_counts: dict[str, int],
+    tmp_path: Path,
+) -> None:
+    document = REPOSITORY / relative_path
+    sessions = _executable_sessions(document)
+
+    assert {name: len(blocks) for name, blocks in sessions.items()} == expected_counts
+    for session, blocks in sessions.items():
+        source = "\n\n".join(blocks)
+        working_directory = tmp_path / session
+        working_directory.mkdir()
+        completed = subprocess.run(
+            [sys.executable, "-I", "-c", source],
+            cwd=working_directory,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert completed.returncode == 0, (
+            f"{relative_path.as_posix()} session {session!r} failed\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+
+
+def _annotation_source(annotation: Any) -> str | None:
+    if annotation is inspect.Parameter.empty:
+        return None
+    if isinstance(annotation, str):
+        return annotation
+    return inspect.formatannotation(annotation)
+
+
+def _runtime_signature_shape(
+    callable_: Any,
+) -> tuple[tuple[str, str, str | None, str | None], ...]:
+    return tuple(
+        (
+            name,
+            parameter.kind.name,
+            _annotation_source(parameter.annotation),
+            None if parameter.default is inspect.Parameter.empty else repr(parameter.default),
+        )
+        for name, parameter in inspect.signature(callable_).parameters.items()
+    )
+
+
+def _documented_signature_shape(
+    source: str,
+) -> tuple[str, tuple[tuple[str, str, str | None, str | None], ...], str]:
+    parsed = ast.parse(source)
+    assert len(parsed.body) == 1
+    function = parsed.body[0]
+    assert isinstance(function, ast.FunctionDef)
+
+    arguments = function.args
+    positional = (*arguments.posonlyargs, *arguments.args)
+    first_default = len(positional) - len(arguments.defaults)
+    shape: list[tuple[str, str, str | None, str | None]] = []
+    for index, argument in enumerate(positional):
+        kind = "POSITIONAL_ONLY" if index < len(arguments.posonlyargs) else "POSITIONAL_OR_KEYWORD"
+        default = arguments.defaults[index - first_default] if index >= first_default else None
+        shape.append(
+            (
+                argument.arg,
+                kind,
+                None if argument.annotation is None else ast.unparse(argument.annotation),
+                None if default is None else ast.unparse(default),
+            )
+        )
+    if arguments.vararg is not None:
+        shape.append(
+            (
+                arguments.vararg.arg,
+                "VAR_POSITIONAL",
+                None
+                if arguments.vararg.annotation is None
+                else ast.unparse(arguments.vararg.annotation),
+                None,
+            )
+        )
+    shape.extend(
+        (
+            argument.arg,
+            "KEYWORD_ONLY",
+            None if argument.annotation is None else ast.unparse(argument.annotation),
+            None if default is None else ast.unparse(default),
+        )
+        for argument, default in zip(
+            arguments.kwonlyargs,
+            arguments.kw_defaults,
+            strict=True,
+        )
+    )
+    if arguments.kwarg is not None:
+        shape.append(
+            (
+                arguments.kwarg.arg,
+                "VAR_KEYWORD",
+                None
+                if arguments.kwarg.annotation is None
+                else ast.unparse(arguments.kwarg.annotation),
+                None,
+            )
+        )
+    assert function.returns is not None
+    return function.name, tuple(shape), ast.unparse(function.returns)
+
+
+def test_documented_decorator_signatures_match_the_public_api() -> None:
+    reference = API_REFERENCE.read_text(encoding="utf-8")
+    expected_names = {
+        "migration",
+        "schema_version",
+        "schema_versions",
+        "versioned_schema",
+    }
+    blocks: defaultdict[str, list[str]] = defaultdict(list)
+    for match in _API_SIGNATURE_BLOCK.finditer(reference):
+        blocks[match.group("name")].append(match.group("source"))
+
+    assert {name: len(sources) for name, sources in blocks.items()} == dict.fromkeys(
+        expected_names,
+        1,
+    )
+    documented = {name: _documented_signature_shape(sources[0]) for name, sources in blocks.items()}
+
+    for name, (declared_name, signature, return_annotation) in documented.items():
+        assert declared_name == name
+        runtime = getattr(public_api, name)
+        assert signature == _runtime_signature_shape(runtime)
+        assert return_annotation == _annotation_source(inspect.signature(runtime).return_annotation)
+
+
+def test_documented_exception_hierarchy_matches_the_public_api() -> None:
+    reference = API_REFERENCE.read_text(encoding="utf-8")
+    hierarchy = reference.split("## Exceptions", maxsplit=1)[1].split(
+        "See the [stability",
+        maxsplit=1,
+    )[0]
+    expected_names = (
+        "SchemaVersionError",
+        "SchemaCompilationError",
+        "UnsupportedWireModelError",
+        "SchemaFamilySelectionError",
+        "IrreversibleTransitionError",
+        "MissingSchemaVersionError",
+        "UnknownSchemaVersionError",
+        "DuplicateSchemaVersionError",
+        "InvalidMigrationError",
+    )
+    documented_parents: dict[str, str] = {}
+    ancestors: list[str] = []
+    for match in _EXCEPTION_ITEM.finditer(hierarchy):
+        indentation = len(match.group("indent"))
+        assert indentation % 2 == 0
+        depth = indentation // 2
+        assert depth <= len(ancestors)
+
+        name = match.group("name")
+        assert name not in documented_parents
+        documented_parents[name] = "Exception" if depth == 0 else ancestors[depth - 1]
+        ancestors = [*ancestors[:depth], name]
+
+    runtime_parents = {
+        name: getattr(public_api, name).__bases__[0].__name__ for name in expected_names
+    }
+    assert documented_parents == runtime_parents


### PR DESCRIPTION
## Summary

- repair the canonical README, getting-started, external-family, rendering, and complex nested examples
- execute marked documentation sessions against the installed package in isolated subprocesses
- fail closed when public decorator signatures, defaults, annotations, return types, or exception inheritance drift
- align the guide output with the target-wire contract completed in #66

## Validation

- `uv run make ci`: passed (536 tests; 90.02% coverage)
- `uv run zensical build --strict`: passed
- Pydantic 2.12.3 documentation gate: passed (7 tests)
- `uv run python tests/compatibility/v0_3_0_contract.py --check`: passed
- `uv build`: passed
- independent final review: no actionable findings

Closes #68