### PR TITLE
fix(release): install audited project non-editably

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,29 +69,29 @@ jobs:
             --requirement "$RUNNER_TEMP/audit-requirements.txt"
 
       - name: Install project with the audited build backend
-        run: uv sync --frozen --python 3.12 --no-build-isolation
+        run: uv sync --frozen --python 3.12 --no-editable --no-build-isolation
 
       - name: Validate release metadata
         id: release-metadata
         run: >-
-          uv run python scripts/validate_release.py
+          uv run --no-sync python scripts/validate_release.py
           "$EXPECTED_RELEASE_VERSION"
           --github-output "$GITHUB_OUTPUT"
 
       - name: Run release quality gates
         run: |
-          uv run ruff format --check .
-          uv run ruff check .
-          uv run ty check
-          uv run mypy --strict tests/typing/schema_family_contract.py
-          uv run pytest --cov=src --cov-report=term
-          uv run zensical build --strict
+          uv run --no-sync ruff format --check .
+          uv run --no-sync ruff check .
+          uv run --no-sync ty check
+          uv run --no-sync mypy --strict tests/typing/schema_family_contract.py
+          uv run --no-sync pytest --cov=pydantic_versions --cov-report=term
+          uv run --no-sync zensical build --strict
 
       - name: Build package
         run: uv build --no-build-isolation
 
       - name: Check distribution metadata
-        run: uv run twine check --strict dist/*
+        run: uv run --no-sync twine check --strict dist/*
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,10 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed fields into migrations and authoritative current models by extracting
   private canonical payloads recursively from declared source fields only.
 - Hardened the tag-driven release path with locked dependency and build-backend
-  audits, strict distribution metadata checks, immutable tags restricted to
-  reviewed default-branch commits, private vulnerability reporting, CodeQL,
-  secret scanning, and disabled checkout credentials; manual release rehearsals
-  do not publish unless a main-branch TestPyPI upload is explicitly requested.
+  audits, non-editable project installation without subsequent dependency
+  synchronization, strict distribution metadata checks, immutable tags
+  restricted to reviewed default-branch commits, private vulnerability
+  reporting, CodeQL, secret scanning, and disabled checkout credentials; manual
+  release rehearsals do not publish unless a main-branch TestPyPI upload is
+  explicitly requested.
 
 ## [0.3.0] - 2026-08-20
 

--- a/docs/reference/stability-policy.md
+++ b/docs/reference/stability-policy.md
@@ -130,13 +130,14 @@ payloads and reproduce the stable inspection data. Fixture changes require
 review and an explanation under this policy; CI never updates them implicitly.
 
 The tag-driven release path repeats the locked dependency and build-backend
-audit, strict documentation build, distribution metadata validation, and
-isolated wheel and source-archive tests before publishing. Release tags are
-immutable, and a tag is rejected unless its commit is on the default branch, so
-published artifacts and attestations remain tied to reviewed source. The
-workflow can also rehearse every build and package test from an explicitly
-selected commit without publishing; TestPyPI upload is a main-branch-only,
-separate opt-in action.
+audit, installs the project non-editably with the audited backend, and disables
+subsequent environment synchronization. It then runs a strict documentation
+build and distribution metadata validation and tests the wheel and source
+archive in isolation before publishing. Release tags are immutable, and a tag
+is rejected unless its commit is on the default branch, so published artifacts
+and attestations remain tied to reviewed source. The workflow can also rehearse
+every build and package test from an explicitly selected commit without
+publishing; TestPyPI upload is a main-branch-only, separate opt-in action.
 
 Once the package solves its defined problem, work is driven by concrete user
 feedback, bug and security reports, dependency/runtime updates, current

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -29,11 +29,14 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
     dependency_audit = build.index("uv run --no-sync pip-audit --strict")
     audit_input = build.index('--requirement "$RUNNER_TEMP/audit-requirements.txt"')
     project_sync = build.index(
-        "uv sync --frozen --python 3.12 --no-build-isolation",
+        "uv sync --frozen --python 3.12 --no-editable --no-build-isolation",
     )
-    quality_gates = build.index("uv run ruff format --check .")
+    quality_gates = build.index("uv run --no-sync ruff format --check .")
+    installed_package_tests = build.index(
+        "uv run --no-sync pytest --cov=pydantic_versions --cov-report=term",
+    )
     package_build = build.index("uv build --no-build-isolation")
-    metadata_check = build.index("uv run twine check --strict dist/*")
+    metadata_check = build.index("uv run --no-sync twine check --strict dist/*")
     artifact_upload = build.index("actions/upload-artifact@")
 
     assert (
@@ -44,11 +47,14 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
         < audit_input
         < project_sync
         < quality_gates
+        < installed_package_tests
         < package_build
         < metadata_check
         < artifact_upload
     )
+    assert "pytest --cov=src" not in build
     assert "continue-on-error" not in build
+    assert build.count("uv run ") == build.count("uv run --no-sync ")
 
 
 def test_release_uses_the_locked_build_backend_after_the_audit() -> None:


### PR DESCRIPTION
## Summary

- install the project non-editably with the already-audited Hatchling backend
- prevent every later `uv run` command in the build job from implicitly synchronizing or resolving dependencies
- measure release-job coverage against the installed package, which is the code actually under test
- extend the fail-closed workflow contract and align release-policy documentation

## Failure reproduced

The first post-merge non-publishing rehearsal, [run 32606449246](https://github.com/dariuszpanas/pydantic-versions/actions/runs/32606449246), failed before artifact creation because the default editable install invoked Hatchling's optional `editables` path. Every publication and GitHub Release job was skipped.

A local exact-path reproduction also proved that a plain later `uv run` would silently replace a non-editable install with an editable one. This change therefore guards both the initial install and every subsequent command.

## Validation

- exact local release build path — passed
  - locked graph audit: no known vulnerabilities
  - 542 installed-package tests; 90.02% coverage
  - strict docs, no-isolation wheel/sdist build, strict Twine checks: passed
- `uv run make ci` — passed (542 tests; 90.02% coverage)
- `uv lock --check` — passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check` — passed
- `uvx zizmor --pedantic .github/workflows/release.yml` — passed (one documented ignore)
- workflow contract tests — 6 passed

After merge, the same `0.3.0`, `publish_testpypi=false` hosted rehearsal will be repeated. No tag or publication is part of this PR.

Closes #84