### PR TITLE
fix(release): bind build to audited environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,12 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install
 
       - name: Install dependencies
         run: |
           uv lock --check
-          uv sync --frozen --python 3.12 --no-install-project
+          uv sync --frozen --no-install-project
 
       - name: Audit locked dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
             --requirement "$RUNNER_TEMP/audit-requirements.txt"
 
       - name: Install project with the audited build backend
-        run: uv sync --frozen --python 3.12 --no-editable --no-build-isolation
+        run: uv sync --frozen --no-editable --no-build-isolation
 
       - name: Validate release metadata
         id: release-metadata
@@ -88,7 +88,7 @@ jobs:
           uv run --no-sync zensical build --strict
 
       - name: Build package
-        run: uv build --no-build-isolation
+        run: uv build --python .venv/bin/python --no-build-isolation
 
       - name: Check distribution metadata
         run: uv run --no-sync twine check --strict dist/*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,12 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   removed fields into migrations and authoritative current models by extracting
   private canonical payloads recursively from declared source fields only.
 - Hardened the tag-driven release path with locked dependency and build-backend
-  audits, non-editable project installation without subsequent dependency
-  synchronization, strict distribution metadata checks, immutable tags
-  restricted to reviewed default-branch commits, private vulnerability
-  reporting, CodeQL, secret scanning, and disabled checkout credentials; manual
-  release rehearsals do not publish unless a main-branch TestPyPI upload is
-  explicitly requested.
+  audits, a pinned Python environment, non-editable project installation without
+  subsequent dependency synchronization, artifact builds bound to the audited
+  environment, strict distribution metadata checks, immutable tags restricted
+  to reviewed default-branch commits, private vulnerability reporting, CodeQL,
+  secret scanning, and disabled checkout credentials; manual release rehearsals
+  do not publish unless a main-branch TestPyPI upload is explicitly requested.
 
 ## [0.3.0] - 2026-08-20
 

--- a/docs/reference/stability-policy.md
+++ b/docs/reference/stability-policy.md
@@ -130,14 +130,16 @@ payloads and reproduce the stable inspection data. Fixture changes require
 review and an explanation under this policy; CI never updates them implicitly.
 
 The tag-driven release path repeats the locked dependency and build-backend
-audit, installs the project non-editably with the audited backend, and disables
-subsequent environment synchronization. It then runs a strict documentation
-build and distribution metadata validation and tests the wheel and source
-archive in isolation before publishing. Release tags are immutable, and a tag
-is rejected unless its commit is on the default branch, so published artifacts
-and attestations remain tied to reviewed source. The workflow can also rehearse
-every build and package test from an explicitly selected commit without
-publishing; TestPyPI upload is a main-branch-only, separate opt-in action.
+audit, creates the environment with the repository's pinned Python, installs
+the project non-editably with the audited backend, and disables subsequent
+environment synchronization. It binds the distribution build to that same
+environment, runs a strict documentation build and distribution metadata
+validation, and tests the wheel and source archive in isolation before
+publishing. Release tags are immutable, and a tag is rejected unless its commit
+is on the default branch, so published artifacts and attestations remain tied
+to reviewed source. The workflow can also rehearse every build and package test
+from an explicitly selected commit without publishing; TestPyPI upload is a
+main-branch-only, separate opt-in action.
 
 Once the package solves its defined problem, work is driven by concrete user
 feedback, bug and security reports, dependency/runtime updates, current

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -22,20 +22,17 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
     build = _job(workflow, "build", "test")
 
     lock_check = build.index("uv lock --check")
-    dependency_sync = build.index(
-        "uv sync --frozen --python 3.12 --no-install-project",
-    )
+    dependency_sync = build.index("uv sync --frozen --no-install-project")
     frozen_export = build.index("uv export --frozen --no-emit-project")
     dependency_audit = build.index("uv run --no-sync pip-audit --strict")
     audit_input = build.index('--requirement "$RUNNER_TEMP/audit-requirements.txt"')
-    project_sync = build.index(
-        "uv sync --frozen --python 3.12 --no-editable --no-build-isolation",
-    )
+    project_sync = build.index("uv sync --frozen --no-editable --no-build-isolation")
     quality_gates = build.index("uv run --no-sync ruff format --check .")
     installed_package_tests = build.index(
         "uv run --no-sync pytest --cov=pydantic_versions --cov-report=term",
     )
-    package_build = build.index("uv build --no-build-isolation")
+    build_command = "uv build --python .venv/bin/python --no-build-isolation"
+    package_build = build.index(build_command)
     metadata_check = build.index("uv run --no-sync twine check --strict dist/*")
     artifact_upload = build.index("actions/upload-artifact@")
 
@@ -53,8 +50,20 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
         < artifact_upload
     )
     assert "pytest --cov=src" not in build
+    assert "run: uv python install\n" in build
+    assert "uv python install 3.12" not in build
     assert "continue-on-error" not in build
+    sync_commands = [
+        line.strip().removeprefix("run: ")
+        for line in build.splitlines()
+        if line.strip().startswith(("uv sync ", "run: uv sync "))
+    ]
+    assert sync_commands == [
+        "uv sync --frozen --no-install-project",
+        "uv sync --frozen --no-editable --no-build-isolation",
+    ]
     assert build.count("uv run ") == build.count("uv run --no-sync ")
+    assert build.count("uv build ") == build.count(build_command)
 
 
 def test_release_uses_the_locked_build_backend_after_the_audit() -> None:


### PR DESCRIPTION
## What changed

- use the repository `.python-version` throughout release setup
- build distributions with the audited virtual environment explicitly
- lock that invariant into the executable release-workflow contract
- document the reproducible build boundary in the stability policy and changelog

## Why

Nonpublishing release rehearsal [32607076419](https://github.com/dariuszpanas/pydantic-versions/actions/runs/32607076419) passed the dependency audit, noneditable installation, and all quality gates, then failed because bare `uv build --no-build-isolation` selected Python 3.12.12 outside the audited `.venv`. Hatchling was present in the audited environment but unavailable to that different interpreter.

Binding `uv build` to `.venv/bin/python` keeps the no-build-isolation build on the interpreter that contains the locked and audited backend. Letting `uv python install` read `.python-version` also keeps setup and sync on the same repository pin.

## Validation

- `uv run make ci` — 542 tests passed; 90.02% coverage
- exact release build path — 542 installed-package tests passed; strict docs, build, and Twine checks passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check`
- `uv lock --check`
- `uvx zizmor --pedantic .github/workflows/release.yml` — no findings (one documented ignore)
- Conventional Commit validation passed

Closes #84