### PR TITLE
docs: keep contributor guides synchronized

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ make ci
 
 - `make format`: format with Ruff.
 - `make lint`: lint and auto-fix with Ruff.
-- `make typecheck`: run `ty`.
+- `make typecheck`: run `ty` plus the external mypy consumer contract.
 - `make test`: run the test suite.
 - `make docs-build`: build the documentation site.
 
@@ -50,7 +50,8 @@ archives, and changelog tooling without relying on GitHub metadata. Record:
 One large atomic commit is valid. Use proportional detail for small mechanical
 changes and keep unrelated changes in separate logical commits.
 
-The tracked [`.gitmessage`](.gitmessage) template suggests this layout:
+The tracked [`.gitmessage`](https://github.com/dariuszpanas/pydantic-versions/blob/main/.gitmessage)
+template suggests this layout:
 
 ```text
 <type>[optional scope][!]: <imperative summary>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidMigrationError`.
 
 ### Fixed
+- Kept the repository-root and rendered contributor guides synchronized and
+  aligned their type-check instructions with the enforced `ty` and mypy gate.
 - Preserved opaque `Any` values and mapping keys through canonical rendering
   when Pydantic cannot serialize them directly, without recursive fallback.
 - Kept callback-supplied nested wrapper models hashable when projected through

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,8 @@ archives, and changelog tooling without relying on GitHub metadata. Record:
 One large atomic commit is valid. Use proportional detail for small mechanical
 changes and keep unrelated changes in separate logical commits.
 
-The tracked [`.gitmessage`](../.gitmessage) template suggests this layout:
+The tracked [`.gitmessage`](https://github.com/dariuszpanas/pydantic-versions/blob/main/.gitmessage)
+template suggests this layout:
 
 ```text
 <type>[optional scope][!]: <imperative summary>

--- a/tests/unit/test_package_metadata.py
+++ b/tests/unit/test_package_metadata.py
@@ -4,6 +4,8 @@ from pathlib import Path
 ROOT = Path(__file__).parents[2]
 README = ROOT / "README.md"
 LLMS_TXT = ROOT / "docs" / "llms.txt"
+CONTRIBUTING = ROOT / "CONTRIBUTING.md"
+RENDERED_CONTRIBUTING = ROOT / "docs" / "contributing.md"
 DOCS_URL = "https://pydantic-versions.readthedocs.io/en/latest/"
 DOCS_ORIGIN = "https://pydantic-versions.readthedocs.io/"
 DOCS_BADGE_URL = "https://img.shields.io/readthedocs/pydantic-versions/latest.svg"
@@ -35,3 +37,10 @@ def test_llms_index_links_to_existing_documentation_sources() -> None:
         assert linked_page.endswith("/") and "?" not in linked_page and "#" not in linked_page
         source = ROOT / "docs" / Path(*linked_page.removesuffix("/").split("/"))
         assert source.with_suffix(".md").is_file(), linked_page_url
+
+
+def test_rendered_contributor_guide_matches_the_repository_guide() -> None:
+    rendered = RENDERED_CONTRIBUTING.read_text(encoding="utf-8")
+    repository = CONTRIBUTING.read_text(encoding="utf-8")
+
+    assert rendered == repository


### PR DESCRIPTION
## Summary

- correct the root contributor guide so make typecheck reflects both ty and the strict external mypy contract
- make the root and rendered contributor guides content-identical using one portable .gitmessage source link
- add a regression check that prevents the two copies from drifting again

## Validation

- uv run make ci (617 passed; 95.05% coverage)
- uv run zensical build --strict
- uv run pytest tests/unit/test_package_metadata.py -q
- uv run python scripts/check_conventional_commits.py --range origin/main..HEAD
- git diff --check

Closes #92