### PR TITLE
ci: add a production dead-code gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Check linting
         run: uv run ruff check .
 
+      - name: Check for dead production code
+        run: uv run vulture
+
   docs:
     name: Docs Build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           uv run --no-sync ruff format --check .
           uv run --no-sync ruff check .
+          uv run --no-sync vulture
           uv run --no-sync ty check
           uv run --no-sync mypy --strict tests/typing/schema_family_contract.py
           uv run --no-sync pytest --cov=pydantic_versions --cov-report=term

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ make ci
 - `make format`: format with Ruff.
 - `make lint`: lint and auto-fix with Ruff.
 - `make typecheck`: run `ty` plus the external mypy consumer contract.
+- `make dead-code`: scan production code with Vulture and reviewed local exceptions.
 - `make test`: run the test suite.
 - `make docs-build`: build the documentation site.
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # pydantic-versions Makefile
 # Core development commands for local work and CI parity.
 
-.PHONY: all install format lint typecheck test test-cov check ci build clean help
+.PHONY: all install format lint typecheck dead-code test test-cov check ci build clean help
 .PHONY: docs-build docs-build-strict docs-serve
 
 # Default target - run all checks
-all: format lint typecheck test
+all: format lint typecheck dead-code test
 
 # Install dependencies
 install:
@@ -24,6 +24,10 @@ typecheck:
 	uv run ty check
 	uv run mypy --strict tests/typing/schema_family_contract.py
 
+# Scan production code for unreachable or unreferenced definitions
+dead-code:
+	uv run vulture
+
 # Run all tests
 test:
 	uv run pytest
@@ -32,11 +36,12 @@ test:
 test-cov:
 	uv run pytest --cov=src --cov-report=html --cov-report=term
 
-# Run lint and typecheck (no formatting)
+# Run lint, typecheck, and dead-code analysis (no formatting)
 check:
 	uv run ruff check .
 	uv run ty check
 	uv run mypy --strict tests/typing/schema_family_contract.py
+	uv run vulture
 
 # CI check - all validations without modifications
 ci:
@@ -44,6 +49,7 @@ ci:
 	uv run ruff check .
 	uv run ty check
 	uv run mypy --strict tests/typing/schema_family_contract.py
+	uv run vulture
 	uv run pytest --cov=src --cov-report=xml --cov-report=term
 	@echo "All CI checks passed!"
 
@@ -78,7 +84,8 @@ help:
 	@echo "  format            - Format code with Ruff"
 	@echo "  lint              - Lint code with Ruff (auto-fix)"
 	@echo "  typecheck         - Run ty and the external mypy consumer contract"
-	@echo "  check             - Run lint + typecheck (no formatting)"
+	@echo "  dead-code         - Scan production code with Vulture"
+	@echo "  check             - Run lint, typecheck, and dead-code analysis"
 	@echo ""
 	@echo "Testing:"
 	@echo "  test              - Run all tests"
@@ -88,7 +95,7 @@ help:
 	@echo "  docs-serve        - Serve docs locally at http://127.0.0.1:8000"
 	@echo ""
 	@echo "CI/CD:"
-	@echo "  all               - Run format, lint, typecheck, test"
+	@echo "  all               - Run format, lint, typecheck, dead-code, test"
 	@echo "  ci                - Run all checks (no modifications)"
 	@echo "  build             - Build the package"
 	@echo "  clean             - Clean cache and build files"

--- a/README.md
+++ b/README.md
@@ -108,5 +108,6 @@ Useful commands:
 - `make format`: format with Ruff.
 - `make lint`: lint and auto-fix with Ruff.
 - `make typecheck`: run `ty` plus the external mypy consumer contract.
+- `make dead-code`: scan production code with Vulture and reviewed local exceptions.
 - `make test`: run pytest.
 - `make docs-build`: build the docs site.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added public-behavior regression coverage for canonical containers, opaque
   values, decorator-discovered nested families, generated schemas, aliases,
   default factories, and invalid declared contracts.
+- Added a production-only Vulture gate with rule-specific local exceptions for
+  dynamic Pydantic hooks and externally consumed public methods.
 
 ### Changed
 - Raised the enforced statement-coverage floor from 90% to 95% and report the
@@ -89,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   participate in deterministic plans, and fail closed for unsupported shapes.
 
 ### Removed
+- Removed a coverage-masked runtime wrapper with no production caller and two
+  undocumented legacy type aliases that were never part of the package-root
+  public contract.
 - Removed the unused `VersionedValidationError` placeholder from the public
   package surface before the 1.0.0 contract freeze.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,6 +19,7 @@ make ci
 - `make format`: format with Ruff.
 - `make lint`: lint and auto-fix with Ruff.
 - `make typecheck`: run `ty` plus the external mypy consumer contract.
+- `make dead-code`: scan production code with Vulture and reviewed local exceptions.
 - `make test`: run the test suite.
 - `make docs-build`: build the documentation site.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "pytest-cov>=4.0",
     "ruff>=0.14.13",
     "ty>=0.0.12",
+    "vulture>=2.16",
     "zensical>=0.0.42",
     "twine>=7.0.0",
 ]
@@ -106,3 +107,8 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",
 ]
+
+[tool.vulture]
+min_confidence = 60
+paths = ["src"]
+sort_by_size = true

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -2915,27 +2915,6 @@ def _has_duplicate_payload(payload: list[Any]) -> bool:
     return False
 
 
-def _prune_nested_family_metadata(
-    *,
-    payload: dict[str, Any],
-    compiled: _CompiledFamily,
-    parent_label: str | None = None,
-) -> None:
-    target_label = compiled.current_version if parent_label is None else parent_label
-    target = compiled.version(target_label)
-    for nested in compiled.nested:
-        target_path = _target_nested_path(target, nested.path)
-        if target_path is None:
-            continue
-        _prune_nested_family_metadata_at_path(
-            payload=payload,
-            model=target.model,
-            path=target_path,
-            family=nested.family._compiled_family(),
-            target_label=nested.child_label(target_label),
-        )
-
-
 def _prune_nested_family_metadata_payload(
     payload: Any,
     family: _CompiledFamily,

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -404,7 +404,7 @@ def _build_family_document_adapter(
             )
             raise TypeError(msg)
 
-        def __init__(self, /, **data: Any) -> None:
+        def __init__(self, /, **data: Any) -> None:  # noqa: V103 - Pydantic entry point
             validated = type(self).model_validate(data)
             _FamilyDocumentAdapterBase._replace_document_adapter_state(self, validated)
 
@@ -795,7 +795,9 @@ def _build_family_document_adapter(
         __module__=family.model.__module__,
         **fields,
     )
-    adapter.__pydantic_computed_fields__ = dict(body_model.model_computed_fields)
+    adapter.__pydantic_computed_fields__ = dict(  # noqa: V101 - Pydantic reads this
+        body_model.model_computed_fields,
+    )
     _validate_object_schema(family, projection, adapter, mode="validation")
     _validate_object_schema(family, projection, adapter, mode="serialization")
     return adapter
@@ -852,7 +854,7 @@ def _copy_document_field_info(field_info: Any) -> Any:
             field_info.serialization_alias,
         )
     ):
-        copied.alias_priority = 2
+        copied.alias_priority = 2  # noqa: V101 - Pydantic reads copied metadata
     return copied
 
 

--- a/src/pydantic_versions/core.py
+++ b/src/pydantic_versions/core.py
@@ -43,9 +43,6 @@ from pydantic_versions.exceptions import (
 from pydantic_versions.family import SchemaFamily, _family_for
 from pydantic_versions.patches import VersionPatch
 
-MigrationFunc = TransitionFunc
-VersionField = VersionPath
-
 _PENDING_ATTR = "__pydantic_versions_pending__"
 
 

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -227,10 +227,10 @@ class SchemaFamily[T: BaseModel]:
                 raise SchemaFamilySelectionError(msg)
         return self
 
-    def describe(self) -> SchemaInventory:
+    def describe(self) -> SchemaInventory:  # noqa: V105 - public consumer API
         return self._compiled_family().catalog.inventory
 
-    def plan_validation(self, source_version: str) -> ConversionPlan:
+    def plan_validation(self, source_version: str) -> ConversionPlan:  # noqa: V105 - public API
         requested = _runtime_label(source_version, family_name=self.name)
         compiled = self._compiled_family()
         return compiled.catalog.validation_plans[compiled.index(requested)]
@@ -286,7 +286,7 @@ class SchemaFamily[T: BaseModel]:
     def validate(self, data: Any, *, version: str | None = None) -> VersionedValidation[T]:
         return _validate_family(self, data, version=version)
 
-    def defaults_for(
+    def defaults_for(  # noqa: V105 - public consumer API
         self,
         *,
         version: str,

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -1356,7 +1356,6 @@ def test_runtime_more_pruning_and_nested_collection_kinds() -> None:
     from pydantic_versions._runtime import (
         _apply_nested_family_migrations,
         _nested_family_collection_kind,
-        _prune_nested_family_metadata,
         _prune_nested_family_metadata_at_path,
         _prune_nested_family_metadata_payload,
     )
@@ -1402,12 +1401,10 @@ def test_runtime_more_pruning_and_nested_collection_kinds() -> None:
     )
     assert kind is None
 
-    # _prune_nested_family_metadata with nested
-    payload = {"items": [{"schema_version": "v1", "val": 1}]}
-    _prune_nested_family_metadata(payload=payload, compiled=parent_compiled)
-
     # _prune_nested_family_metadata_payload with nested
+    payload = {"items": [{"schema_version": "v1", "val": 1}]}
     _prune_nested_family_metadata_payload(payload, parent_compiled)
+    assert payload == {"items": [{"val": 1}]}
 
     # _prune_nested_family_metadata_at_path set & frozenset multi-level path
     item = HashableDict({"val": 1})

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -28,6 +28,7 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
     audit_input = build.index('--requirement "$RUNNER_TEMP/audit-requirements.txt"')
     project_sync = build.index("uv sync --frozen --no-editable --no-build-isolation")
     quality_gates = build.index("uv run --no-sync ruff format --check .")
+    dead_code_gate = build.index("uv run --no-sync vulture")
     installed_package_tests = build.index(
         "uv run --no-sync pytest --cov=pydantic_versions --cov-report=term",
     )
@@ -44,6 +45,7 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
         < audit_input
         < project_sync
         < quality_gates
+        < dead_code_gate
         < installed_package_tests
         < package_build
         < metadata_check
@@ -64,6 +66,49 @@ def test_release_build_repeats_security_and_distribution_gates() -> None:
     ]
     assert build.count("uv run ") == build.count("uv run --no-sync ")
     assert build.count("uv build ") == build.count(build_command)
+
+
+def test_dead_code_gate_scans_production_with_local_exceptions() -> None:
+    pyproject = tomllib.loads(
+        (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"),
+    )
+    vulture = pyproject["tool"]["vulture"]
+
+    assert "vulture>=2.16" in pyproject["dependency-groups"]["dev"]
+    assert vulture == {
+        "min_confidence": 60,
+        "paths": ["src"],
+        "sort_by_size": True,
+    }
+
+    vulture_exceptions = {
+        f"{path.relative_to(PROJECT_ROOT).as_posix()}:{line.strip()}"
+        for path in (PROJECT_ROOT / "src").rglob("*.py")
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if "# noqa: V" in line
+    }
+    assert vulture_exceptions == {
+        "src/pydantic_versions/_wire.py:adapter.__pydantic_computed_fields__ = dict(  "
+        "# noqa: V101 - Pydantic reads this",
+        "src/pydantic_versions/_wire.py:copied.alias_priority = 2  "
+        "# noqa: V101 - Pydantic reads copied metadata",
+        "src/pydantic_versions/_wire.py:def __init__(self, /, **data: Any) -> None:  "
+        "# noqa: V103 - Pydantic entry point",
+        "src/pydantic_versions/family.py:def defaults_for(  # noqa: V105 - public consumer API",
+        "src/pydantic_versions/family.py:def describe(self) -> SchemaInventory:  "
+        "# noqa: V105 - public consumer API",
+        "src/pydantic_versions/family.py:def plan_validation(self, source_version: str) -> "
+        "ConversionPlan:  # noqa: V105 - public API",
+    }
+
+    makefile = (PROJECT_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert makefile.count("\tuv run vulture\n") == 3
+
+    ci_workflow = (PROJECT_ROOT / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8",
+    )
+    assert ci_workflow.count("run: uv run vulture") == 1
+    assert _release_workflow().count("uv run --no-sync vulture") == 1
 
 
 def test_release_uses_the_locked_build_backend_after_the_audit() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1265,6 +1265,7 @@ dev = [
     { name = "ruff" },
     { name = "twine" },
     { name = "ty" },
+    { name = "vulture" },
     { name = "zensical" },
 ]
 
@@ -1283,6 +1284,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14.13" },
     { name = "twine", specifier = ">=7.0.0" },
     { name = "ty", specifier = ">=0.0.12" },
+    { name = "vulture", specifier = ">=2.16" },
     { name = "zensical", specifier = ">=0.0.42" },
 ]
 
@@ -1675,6 +1677,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add Vulture 2.16 as a production-only dead-code gate in local checks, pull-request CI, and release validation
- use rule-specific line-local suppressions for dynamic Pydantic members and externally invoked `SchemaFamily` methods, with an exact repository-contract inventory
- remove the unreachable nested-metadata wrapper and undocumented legacy `core` aliases found by the audit
- replace the no-assertion coverage probe with an asserted pruning behavior check

## Why Vulture, not `albertas/deadcode`

The suggested `deadcode` 2.4.1 does identify the same unused wrapper on Python 3.12, but it crashes on supported Python 3.14 and returns exit status 0 when findings exist. Vulture 2.16 is maintained, supports Python 3.14, and returns exit status 3 for dead code, so it can enforce the result without a parsing wrapper.

The configured path intentionally scans `src` only, not tests. Suppressions are rule-specific and local to six reviewed definitions or assignments; the contract test rejects additions or broader replacements. Including tests as reachability roots would reproduce the original problem: a direct-private coverage probe could hide production-dead code.

## Validation

- `uv run make ci` — 618 passed, 95.06% coverage
- `uv run make docs-build-strict` — passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check` — passed
- `uv build` and `uv run twine check --strict dist/*` — passed
- Vulture 2.16 clean on Python 3.12, 3.13, and 3.14
- temporary unused private-function probe — reported and exited 3
- unrelated methods sharing suppressed public names — still reported and exited 3

Closes #96