### PR TITLE
fix: bound generated caches to family lifetimes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidMigrationError`.
 
 ### Fixed
+- Scoped generated set-element models and cached render validators to their
+  owning compiled family, preventing temporary families from accumulating in
+  process-global caches while preserving stable identities and thread-safe
+  reuse. Families now fail closed if their authoritative Pydantic model is
+  forcibly rebuilt after compilation.
 - Kept the repository-root and rendered contributor guides synchronized and
   aligned their type-check instructions with the enforced `ty` and mypy gate.
 - Preserved opaque `Any` values and mapping keys through canonical rendering

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -95,6 +95,19 @@ configuration, or custom schema hooks that automatic generation would
 otherwise weaken or discard. Those models remain supported as unchanged field
 annotations when no decorator route requires their projection.
 
+Compilation snapshots the authoritative model's Pydantic core schema. A
+subsequent forced `model_rebuild()` invalidates that family, even when the
+rebuilt schema is semantically equivalent, because its generated projections
+and conversion plans still describe the original schema object. Runtime family
+operations then raise `SchemaCompilationError`. Dependent parent families are
+invalidated transitively because their wire models embed the child projection.
+Discard the affected family graph and recreate its declarations from fully
+rebuilt models. An ordinary no-op `model_rebuild()` remains safe.
+Do not race a forced rebuild with compilation or runtime family operations.
+For decorator-managed default families, redeclare the affected model classes
+and reinitialize the application, or switch callers to a newly constructed
+explicit `SchemaFamily` graph.
+
 An excluded field is also absent from the generated wire model. This is the
 supported way to keep server-internal state on the authoritative model while
 using that model as the source for a document contract. The exclusion is not
@@ -231,4 +244,6 @@ family name, and exact label.
 Consequently, labels whose readable forms sanitize to the same text, such as
 `1.0` and `1-0`, still receive distinct Python class names and JSON Schema
 components. Repeated compilation of one family reuses its cached generated
-model objects, while separate family identities do not share them.
+model objects, while separate family identities do not share them. Temporary
+families do not enter a process-global generated-model cache, so their private
+set-element wrappers can be collected with the family that owns them.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -42,7 +42,14 @@ declaration sequence and has no default-selection side effect.
 
 Compilation is idempotent and thread-safe. A family owns its generated-model
 identities and cache, so two families can reuse one current model without
-sharing state.
+sharing state. Rebuild incomplete authoritative models before compilation. A
+forced `model_rebuild()` after compilation invalidates the compiled family;
+dependent parent families are invalidated transitively. Discard the affected
+family graph and recreate its declarations from fully rebuilt models rather
+than mixing stale projections with replacement Pydantic core schemas.
+Forced rebuilds must not race family operations. A decorator-managed default
+cannot be rebound on the same model class; redeclare and reinitialize those
+models, or use a new explicit family graph.
 
 ### `SchemaVersion`
 

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -4,6 +4,8 @@ import hashlib
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from threading import Lock
 from types import UnionType
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_args, get_origin
 
@@ -133,6 +135,14 @@ class _CompiledDecoratorNestedFamily:
         raise SchemaCompilationError(msg)
 
 
+class _CompiledFamilyRuntimeCache:
+    __slots__ = ("adapter", "lock")
+
+    def __init__(self) -> None:
+        self.adapter: object | None = None
+        self.lock = Lock()
+
+
 @dataclass(frozen=True)
 class _CompiledFamily:
     model: type[BaseModel]
@@ -144,6 +154,12 @@ class _CompiledFamily:
     catalog: _PlanningCatalog
     nested: tuple[_CompiledNestedFamily, ...]
     decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...]
+    _model_core_schema: object = dataclass_field(repr=False, compare=False)
+    _runtime_cache: _CompiledFamilyRuntimeCache = dataclass_field(
+        default_factory=_CompiledFamilyRuntimeCache,
+        repr=False,
+        compare=False,
+    )
 
     @property
     def labels(self) -> tuple[str, ...]:

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -1244,8 +1244,7 @@ def _validated_current_render_payload[T: BaseModel](
         )
         if isinstance(data, current_wire):
             current_model = _current_wire_validation_adapter(
-                family.model,
-                family_name=compiled.name,
+                compiled,
             ).validate_python(
                 validation_payload,
                 by_name=True,
@@ -1329,6 +1328,21 @@ def _without_family_render_metadata(
 
 
 def _current_wire_validation_adapter(
+    compiled: _CompiledFamily,
+) -> SchemaValidator:
+    cache = compiled._runtime_cache
+    with cache.lock:
+        adapter = cache.adapter
+        if adapter is None:
+            adapter = _build_current_wire_validation_adapter(
+                compiled.model,
+                family_name=compiled.name,
+            )
+            cache.adapter = adapter
+        return cast(SchemaValidator, adapter)
+
+
+def _build_current_wire_validation_adapter(
     model: type[BaseModel],
     *,
     family_name: str,

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -4,7 +4,8 @@ import json
 import sys
 from collections.abc import Iterable, Mapping, Sequence
 from copy import copy, deepcopy
-from dataclasses import is_dataclass
+from dataclasses import dataclass, is_dataclass
+from dataclasses import field as dataclass_field
 from functools import reduce
 from operator import or_
 from types import GenericAlias, MemberDescriptorType, UnionType
@@ -220,7 +221,11 @@ _CUSTOM_MODEL_HOOKS = (
     "__get_pydantic_json_schema__",
     "model_json_schema",
 )
-_HASHABLE_MODEL_CACHE: dict[type[BaseModel], type[BaseModel]] = {}
+
+
+@dataclass
+class _WireCompilationContext:
+    hashable_models: dict[type[BaseModel], type[BaseModel]] = dataclass_field(default_factory=dict)
 
 
 def _validate_automatic_wire_model(family: SchemaFamily[Any]) -> None:
@@ -256,6 +261,8 @@ def _build_model_for_projection(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
     wire_model: type[BaseModel] | None,
+    *,
+    compilation: _WireCompilationContext,
     nested: tuple[_CompiledNestedFamily, ...] = (),
     decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...] = (),
 ) -> type[BaseModel]:
@@ -297,6 +304,7 @@ def _build_model_for_projection(
         return _build_model_for_projection_unchecked(
             family,
             projection,
+            compilation=compilation,
             nested=nested,
             decorator_nested=decorator_nested,
         )
@@ -1141,6 +1149,8 @@ def _validate_explicit_wire_model_metadata(
 def _build_model_for_projection_unchecked(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
+    *,
+    compilation: _WireCompilationContext,
     nested: tuple[_CompiledNestedFamily, ...] = (),
     decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...] = (),
 ) -> type[BaseModel]:
@@ -1204,6 +1214,7 @@ def _build_model_for_projection_unchecked(
             field_dict["annotation"],
             projection.label,
             family,
+            compilation=compilation,
             nested=nested,
             decorator_nested=decorator_nested,
             field_path=(compiled_field.current_name,),
@@ -3258,10 +3269,14 @@ def _compat_child_family(
     return child
 
 
-def _set_element_wire_model(model: type[BaseModel]) -> type[BaseModel]:
+def _set_element_wire_model(
+    model: type[BaseModel],
+    *,
+    compilation: _WireCompilationContext,
+) -> type[BaseModel]:
     if model.model_config.get("frozen"):
         return model
-    cached = _HASHABLE_MODEL_CACHE.get(model)
+    cached = compilation.hashable_models.get(model)
     if cached is not None:
         return cached
     frozen_model = create_model(
@@ -3271,7 +3286,7 @@ def _set_element_wire_model(model: type[BaseModel]) -> type[BaseModel]:
         __config__=ConfigDict(frozen=True),
     )
     frozen_model.model_rebuild(force=True)
-    _HASHABLE_MODEL_CACHE[model] = frozen_model
+    compilation.hashable_models[model] = frozen_model
     return frozen_model
 
 
@@ -3280,6 +3295,7 @@ def _rewrite_annotation(
     version: str,
     family: SchemaFamily[Any],
     *,
+    compilation: _WireCompilationContext,
     nested: tuple[_CompiledNestedFamily, ...],
     decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
     field_path: tuple[str, ...],
@@ -3301,7 +3317,11 @@ def _rewrite_annotation(
     ):
         used_nested.add(child.path)
         family_model = child.family.model_for(child.child_label(version))
-        return _set_element_wire_model(family_model) if in_set_element else family_model
+        return (
+            _set_element_wire_model(family_model, compilation=compilation)
+            if in_set_element
+            else family_model
+        )
     decorator_child = (
         _find_decorator_family_for_model(decorator_nested, field_path, annotation)
         if allow_child_projection
@@ -3309,7 +3329,11 @@ def _rewrite_annotation(
     )
     if decorator_child is not None:
         family_model = decorator_child.family.model_for(version)
-        return _set_element_wire_model(family_model) if in_set_element else family_model
+        return (
+            _set_element_wire_model(family_model, compilation=compilation)
+            if in_set_element
+            else family_model
+        )
 
     if isinstance(annotation, _TYPE_ALIAS_TYPES):
         _validate_type_alias(family, field_name, annotation)
@@ -3330,6 +3354,7 @@ def _rewrite_annotation(
                 annotation,
                 version,
                 family,
+                compilation=compilation,
                 field_name=field_name,
                 field_path=field_path,
                 nested=nested_families,
@@ -3351,6 +3376,7 @@ def _rewrite_annotation(
             base,
             version,
             family,
+            compilation=compilation,
             nested=nested,
             decorator_nested=decorator_nested,
             field_path=field_path,
@@ -3389,6 +3415,7 @@ def _rewrite_annotation(
             arg,
             version,
             family,
+            compilation=compilation,
             field_name=field_name,
             field_path=field_path,
             allow_child_projection=allow_child_projection and legacy_container,
@@ -3428,6 +3455,7 @@ def _rewrite_nested_model(
     version: str,
     owner: SchemaFamily[Any],
     *,
+    compilation: _WireCompilationContext,
     field_name: str,
     field_path: tuple[str, ...],
     nested: tuple[_CompiledNestedFamily, ...],
@@ -3474,6 +3502,7 @@ def _rewrite_nested_model(
                 source["annotation"],
                 version,
                 owner,
+                compilation=compilation,
                 nested=nested,
                 decorator_nested=decorator_nested,
                 field_path=field_path + (source_name,),
@@ -3510,7 +3539,10 @@ def _rewrite_nested_model(
         )
         nested_projection.model_rebuild(force=True)
         if in_set_element:
-            nested_projection = _set_element_wire_model(nested_projection)
+            nested_projection = _set_element_wire_model(
+                nested_projection,
+                compilation=compilation,
+            )
     except UnsupportedWireModelError:
         raise
     except Exception as exc:

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -27,6 +27,7 @@ from pydantic_versions._wire import (
     _build_model_for_projection,
     _compile_decorator_nested_families,
     _validate_automatic_wire_model,
+    _WireCompilationContext,
 )
 from pydantic_versions.declarations import (
     _DEFAULT_VERSION_METADATA,
@@ -134,12 +135,14 @@ class SchemaFamily[T: BaseModel]:
     def compile(self) -> Self:
         with _FAMILY_LOCK:
             if self._compiled is not None:
+                self._ensure_compiled_graph_unchanged(self._compiled)
                 return self
             if self._compiling:
                 msg = f"Recursive schema-family compilation is not yet supported for {self.name!r}"
                 raise SchemaCompilationError(msg)
             self._compiling = True
             try:
+                model_core_schema = self.model.__pydantic_core_schema__
                 self._validate_declarations()
                 nested = _validate_compilation_boundary(
                     name=self.name,
@@ -158,6 +161,7 @@ class SchemaFamily[T: BaseModel]:
                     projections=projections,
                     transitions=self.transitions,
                 )
+                wire_compilation = _WireCompilationContext()
                 compiled_versions = tuple(
                     _CompiledVersion(
                         projection=projection,
@@ -165,6 +169,7 @@ class SchemaFamily[T: BaseModel]:
                             self,
                             projection,
                             declaration.wire_model,
+                            compilation=wire_compilation,
                             nested=nested,
                             decorator_nested=decorator_nested,
                         ),
@@ -199,6 +204,13 @@ class SchemaFamily[T: BaseModel]:
                     nested,
                     decorator_nested,
                 )
+                if self.model.__pydantic_core_schema__ is not model_core_schema:
+                    msg = (
+                        f"Authoritative model {self.model.__name__!r} for schema family "
+                        f"{self.name!r} was rebuilt during compilation; finish rebuilding "
+                        "the model before calling compile() again"
+                    )
+                    raise SchemaCompilationError(msg)
                 self._compiled = _CompiledFamily(
                     model=self.model,
                     name=self.name,
@@ -209,6 +221,7 @@ class SchemaFamily[T: BaseModel]:
                     catalog=catalog,
                     nested=nested,
                     decorator_nested=decorator_nested,
+                    _model_core_schema=model_core_schema,
                 )
             finally:
                 self._compiling = False
@@ -322,6 +335,33 @@ class SchemaFamily[T: BaseModel]:
             msg = f"Schema family {self.name!r} did not publish compiled state"
             raise SchemaCompilationError(msg)
         return self._compiled
+
+    def _ensure_compiled_graph_unchanged(
+        self,
+        compiled: _CompiledFamily,
+        *,
+        visited: set[int] | None = None,
+    ) -> None:
+        checked = set() if visited is None else visited
+        if id(self) in checked:
+            return
+        checked.add(id(self))
+        if self.model.__pydantic_core_schema__ is not compiled._model_core_schema:
+            msg = (
+                f"Authoritative model {self.model.__name__!r} for schema family {self.name!r} "
+                "was rebuilt after compilation; discard this family and recreate the "
+                "schema-family declaration from the rebuilt model"
+            )
+            raise SchemaCompilationError(msg)
+        for nested in (*compiled.nested, *compiled.decorator_nested):
+            child_family = nested.family
+            child_compiled = child_family._compiled
+            # A parent cannot publish until every nested projection has compiled.
+            assert child_compiled is not None
+            child_family._ensure_compiled_graph_unchanged(
+                child_compiled,
+                visited=checked,
+            )
 
     def _validate_declarations(self) -> None:
         _validate_family_declarations(

--- a/tests/unit/test_cache_lifecycle.py
+++ b/tests/unit/test_cache_lifecycle.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import gc
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Lock
+from types import GenericAlias
+from typing import Any, cast, get_args
+
+import pytest
+from pydantic import BaseModel, create_model
+
+import pydantic_versions._runtime as runtime
+import pydantic_versions.family as family_module
+from pydantic_versions import NestedFamily, SchemaCompilationError, SchemaFamily, SchemaVersion
+
+type _ModelRef = weakref.ReferenceType[type[BaseModel]]
+
+
+def _set_element_model(model: type[BaseModel], field_name: str) -> type[BaseModel]:
+    arguments = get_args(model.model_fields[field_name].annotation)
+    assert len(arguments) == 1
+    element = arguments[0]
+    assert isinstance(element, type) and issubclass(element, BaseModel)
+    return element
+
+
+def test_hashable_wire_models_are_reused_only_within_one_family() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="cache_child",
+        versions=(SchemaVersion("stable"),),
+        version_metadata=None,
+    )
+    labels = {"old": "stable", "current": "stable"}
+
+    class Parent(BaseModel):
+        children: set[Child]
+        frozen_children: frozenset[Child]
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="cache_parent",
+        versions=(SchemaVersion("old"), SchemaVersion("current")),
+        nested=(
+            NestedFamily("children", child_family, labels),
+            NestedFamily("frozen_children", child_family, labels),
+        ),
+        version_metadata=None,
+    )
+    occurrences = tuple(
+        _set_element_model(parent_family.model_for(version), field_name)
+        for version in ("old", "current")
+        for field_name in ("children", "frozen_children")
+    )
+
+    assert len({id(model) for model in occurrences}) == 1
+
+    class OtherParent(BaseModel):
+        children: set[Child]
+
+    other_family = SchemaFamily(
+        model=OtherParent,
+        name="other_cache_parent",
+        versions=(SchemaVersion("old"), SchemaVersion("current")),
+        nested=(NestedFamily("children", child_family, labels),),
+        version_metadata=None,
+    )
+
+    assert _set_element_model(other_family.model_for("old"), "children") is not occurrences[0]
+
+
+def _discarded_hashable_model_refs(
+    start: int,
+    count: int,
+) -> tuple[tuple[_ModelRef, _ModelRef], ...]:
+    references = []
+    for index in range(start, start + count):
+        child_model = create_model(
+            f"LifecycleChild{index}",
+            __module__=__name__,
+            value=(int, ...),
+        )
+        child_family = SchemaFamily(
+            model=child_model,
+            name=f"lifecycle_child_{index}",
+            versions=(SchemaVersion("stable"),),
+            version_metadata=None,
+        )
+        children_annotation: Any = GenericAlias(set, child_model)
+        parent_model = create_model(
+            f"LifecycleParent{index}",
+            __module__=__name__,
+            children=(children_annotation, ...),
+        )
+        parent_family = SchemaFamily(
+            model=parent_model,
+            name=f"lifecycle_parent_{index}",
+            versions=(SchemaVersion("stable"),),
+            nested=(NestedFamily("children", child_family, {"stable": "stable"}),),
+            version_metadata=None,
+        )
+        parent_wire = parent_family.model_for("stable")
+        child_wire = child_family.model_for("stable")
+        wrapper = _set_element_model(parent_wire, "children")
+        references.append((weakref.ref(wrapper), weakref.ref(child_wire)))
+    return tuple(references)
+
+
+def test_discarded_families_do_not_accumulate_in_a_global_model_cache() -> None:
+    first_batch = _discarded_hashable_model_refs(0, 128)
+    gc.collect()
+
+    # Python's typing machinery keeps a bounded cache of recent parameterized
+    # annotations. Churn a second batch so that retention cannot be mistaken for
+    # a pydantic-versions process-global cache.
+    _discarded_hashable_model_refs(128, 128)
+    gc.collect()
+
+    assert all(wrapper() is None and child() is None for wrapper, child in first_batch)
+
+
+def test_current_wire_validator_is_built_once_under_concurrent_use(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Payload(BaseModel):
+        value: int
+
+    family = SchemaFamily(
+        model=Payload,
+        name="cached_current_validator",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    current_wire = family.model_for("1").model_validate({"value": 7})
+    original_builder = runtime._build_current_wire_validation_adapter
+    builder_lock = Lock()
+    builder_calls = 0
+
+    def counting_builder(model: type[BaseModel], *, family_name: str) -> Any:
+        nonlocal builder_calls
+        with builder_lock:
+            builder_calls += 1
+        return original_builder(model, family_name=family_name)
+
+    monkeypatch.setattr(runtime, "_build_current_wire_validation_adapter", counting_builder)
+    workers = 8
+    barrier = Barrier(workers)
+
+    def render() -> dict[str, Any]:
+        barrier.wait()
+        return family.dump(version="1", data=cast(Any, current_wire))
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = tuple(executor.map(lambda _: render(), range(workers)))
+
+    assert results == ({"value": 7},) * workers
+    assert family.dump(version="1", data=cast(Any, current_wire)) == {"value": 7}
+    assert builder_calls == 1
+
+
+def test_forced_model_rebuild_invalidates_an_existing_family() -> None:
+    class Payload(BaseModel):
+        value: int
+
+    family = SchemaFamily(
+        model=Payload,
+        name="rebuild_boundary",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    generated = family.model_for("1")
+    original_schema = Payload.__pydantic_core_schema__
+
+    assert Payload.model_rebuild() is None
+    assert Payload.__pydantic_core_schema__ is original_schema
+    assert family.model_for("1") is generated
+
+    assert Payload.model_rebuild(force=True) is True
+    with pytest.raises(SchemaCompilationError, match="rebuilt after compilation"):
+        family.compile()
+    with pytest.raises(SchemaCompilationError, match="rebuilt after compilation"):
+        family.validate({"value": 1}, version="1")
+
+    replacement = SchemaFamily(
+        model=Payload,
+        name="replacement_after_rebuild",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    assert replacement.validate({"value": 2}, version="1").current_model == Payload(value=2)
+
+
+def test_nested_model_rebuild_invalidates_dependent_families() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="rebuilt_child",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="dependent_parent",
+        versions=(SchemaVersion("1"),),
+        nested=(NestedFamily("child", child_family, {"1": "1"}),),
+        version_metadata=None,
+    )
+    parent_family.compile()
+
+    assert Child.model_rebuild(force=True) is True
+    with pytest.raises(SchemaCompilationError, match="schema family 'rebuilt_child'"):
+        parent_family.model_for("1")
+
+
+def test_rebuild_detected_during_compilation_does_not_publish_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Payload(BaseModel):
+        value: int
+
+    family = SchemaFamily(
+        model=Payload,
+        name="rebuild_during_compilation",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    original_validator = family_module._validate_automatic_wire_model
+
+    def rebuild_after_validation(candidate: SchemaFamily[Any]) -> None:
+        original_validator(candidate)
+        candidate.model.model_rebuild(force=True)
+
+    monkeypatch.setattr(
+        family_module,
+        "_validate_automatic_wire_model",
+        rebuild_after_validation,
+    )
+    with pytest.raises(SchemaCompilationError, match="rebuilt during compilation"):
+        family.compile()
+
+    assert family._compiled is None
+    monkeypatch.setattr(
+        family_module,
+        "_validate_automatic_wire_model",
+        original_validator,
+    )
+    assert family.compile() is family

--- a/tests/unit/test_internal_coverage_gaps.py
+++ b/tests/unit/test_internal_coverage_gaps.py
@@ -1672,10 +1672,12 @@ def test_wire_grouped_metadata_and_schema_hook_type_alias() -> None:
 
 
 def test_wire_decorator_child_mismatch_and_set_element() -> None:
-    from pydantic_versions._wire import _set_element_wire_model
+    from pydantic_versions._wire import _set_element_wire_model, _WireCompilationContext
 
     class FrozenModel(BaseModel):
         model_config = ConfigDict(frozen=True)
         val: int
 
-    assert _set_element_wire_model(FrozenModel) is FrozenModel
+    assert (
+        _set_element_wire_model(FrozenModel, compilation=_WireCompilationContext()) is FrozenModel
+    )


### PR DESCRIPTION
## Summary

- replace the process-global strong hashable-model cache with one compilation-local cache, preserving identity only inside the owning compiled family
- lazily cache the current-wire `SchemaValidator` behind a per-family lock and publish only successful builds
- snapshot authoritative CoreSchema identity and fail closed after forced rebuilds, including transitive nested/decorator dependencies
- document rebuild recovery, concurrency boundaries, and family-owned cache lifetimes

## Evidence

### Retention

- Baseline from #99: 25 discarded nested-set families left 25/25 generated wrappers alive after garbage collection.
- Patched two-batch probe: Python's bounded typing cache initially retained 64/128 recent wrappers; after a second 128-family churn batch, 0/128 wrappers and child wire models from the first batch remained alive.

### Timing

Windows / Python 3.12 / Pydantic 2.13.4, median of five runs on a small current-wire model:

- adapter build: 28.72 us
- cached lookup: 0.23 us
- validation with existing adapter: 0.57 us
- complete dump with forced rebuild per call: 64.62 us
- complete dump with family cache: 34.21 us (47.1% faster)

### Validation

- `uv run make ci`: 624 passed, 95.10% statement coverage
- lifecycle regression suite: Python 3.12, 3.13, and 3.14
- focused lower-bound run: Pydantic 2.12.3
- `uv run make docs-build-strict`
- `uv run python tests/compatibility/v0_3_0_contract.py --check`
- `uv build`
- `uv run twine check --strict dist/*`
- independent review found no remaining code or lifecycle blocker

Closes #99