### PR TITLE
fix: enforce explicit nested representation contracts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,10 +67,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nested metadata envelopes, preflight declared attribute input, and reject
   output-name collisions from allowed extras.
 - Preserved structurally divergent explicit nested representations by selecting
-  the validated runtime arm of heterogeneous and same-origin generic unions.
-  Scalar arms remain scalar, while BaseModel, dataclass, TypedDict, and mapping
-  output has child-owned metadata pruned; object serializers that relocate a
-  managed child still fail closed.
+  recoverable validated union arms, including bound generic TypedDict shapes.
+  Scalar arms remain scalar, while statically owned BaseModel, structural
+  dataclass, TypedDict, and exact built-in-container outputs have child metadata
+  pruned. Alias-wrapped containers follow the same pruning contract, while
+  unambiguous object-shaped scalar output, including mapping-valued enums,
+  retains scalar-owned data. Empty tuples and both supported TypedDict providers
+  follow the same explicit contract.
+- Rejected broad or abstract carriers, serializers affecting managed routes,
+  alternate output at an omitted managed route, and runtime-unrecoverable union
+  arms. Mapping-enum/structural arms and distinct specializations of one
+  runtime-erased generic dataclass origin now fail at compilation when they
+  occupy overlapping reachable positions. Serialization exclusions on a
+  declared explicit managed route use the effective historical field contract
+  and also fail at compilation. This does not change automatic omission of
+  current-model `Field(exclude=True)` or `exclude_if` fields.
+- Preflighted raw family metadata through every structurally viable arm before
+  source-body validators execute. Source validator shape violations now fail
+  before migration; target and nested-target violations fail before metadata
+  pruning or serialization, with payload-safe diagnostics.
 - Rejected foreign model instances returned by explicit wire model validators
   before document-adapter construction, preventing validated user data from
   being replaced by facade defaults during validation or rendering.

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -28,17 +28,135 @@ Pydantic's declarative handling of that shape:
 | Omitted | Server-internal fields marked with `Field(exclude=True)` or `Field(exclude_if=...)` | The field is absent from every generated wire projection; it remains available on the authoritative application model. |
 | Rejected | Callable discriminators and unknown behavior-changing model or field settings | The automatic compiler fails closed instead of silently changing the wire document. |
 | Rejected at registration | Pydantic v1 compatibility models | The family raises `SchemaVersionError` before automatic projection; wire models must inherit from Pydantic v2's `BaseModel`. |
-| Rejected | A `NestedFamily` path through a mapping, a heterogeneous union or collection, or a field owned by a different model than the declared child family | Runtime conversion cannot dispatch those shapes unambiguously, so compilation raises `UnsupportedWireModelError`. |
+| Rejected | An authoritative current-model `NestedFamily` path through a mapping, a heterogeneous union or collection, or a field owned by a different model than the declared child family | Runtime conversion cannot dispatch those shapes unambiguously, so compilation raises `UnsupportedWireModelError`. |
 
 Historical patches are applied to this preserved declaration state. A removed
 field is absent, a renamed field uses its historical Python name, and a default
 patch replaces the projected field's required/default/factory state.
 
-Explicit `NestedFamily` declarations support direct and optional child models,
-plus homogeneous `list`, `tuple`, `set`, and `frozenset` boundaries. The same
-boundaries can appear while traversing a multi-segment path. Mapping values and
-heterogeneous branches are intentionally rejected during compilation rather
-than accepted with payload-dependent behavior.
+For the authoritative current model, an explicit `NestedFamily` route supports
+direct and optional child models plus homogeneous `list`, `tuple`, `set`, and
+`frozenset` boundaries. The same boundaries may appear in a multi-segment
+route. Mapping traversal and heterogeneous union or collection traversal are
+rejected for that current-model contract. An explicit historical `wire_model`
+follows the separate grammar below.
+
+### Explicit Historical Nested Shapes
+
+An explicit historical `wire_model` may omit a declared nested route or
+represent it differently from the current child. A migration can, for example,
+replace a current child model with a historical string. The historical
+annotation must nevertheless make ownership of every value at that managed
+route identifiable before a payload is seen. This lets the family distinguish
+child-owned metadata from unrelated application data and prevents metadata
+pruning from interpreting an opaque mapping as a child document.
+
+The supported historical annotation grammar is:
+
+- `Annotated`, PEP 695 type aliases, `NewType`, and bounded, constrained, or
+  defaulted type variables are unwrapped before inspection. An unresolved or
+  broad type variable is rejected.
+- Optionals and unions are inspected recursively. Every possible branch must
+  itself have a supported shape. `Literal` and concrete scalar classes are
+  supported historical subtree or leaf replacements.
+- A concrete scalar branch may replace the remainder of a route. It represents
+  no historical child occurrence; the parent transition is responsible for
+  converting that scalar to or from the current nested structure. The scalar
+  still owns its serialized form when that form is object-shaped, such as the
+  value of a mapping-valued enum, provided its runtime branch remains
+  recoverable; child metadata is not pruned from that scalar-owned output.
+- Traversal before the managed leaf may use Pydantic `BaseModel` fields and
+  exact built-in `list`, `tuple`, `set`, and `frozenset` containers. A scalar
+  branch may also terminate the route early. Dataclasses and `TypedDict` are
+  supported as managed leaves, not as intermediate path traversal objects.
+- A managed leaf may be a concrete scalar, a Pydantic `BaseModel`, a structural
+  dataclass, a `TypedDict`, or a recursively composed exact built-in container
+  of supported shapes. Built-in containers must declare their element shapes;
+  fixed, empty, and variadic tuple annotations remain distinct declared
+  contracts. Both standard-library and `typing_extensions` TypedDicts,
+  including bound generic fields and their field qualifiers, are supported
+  when their annotations are resolvable at compilation.
+
+Use a `TypedDict`, Pydantic model, or dataclass for a mapping-shaped historical
+leaf. Those declarations identify the owned fields, including any historical
+child discriminator, without requiring the runtime payload to decide what the
+mapping means. When that representation stands in for a child family with its
+own nested routes, the compiler and runtime apply the same checks recursively
+to those routes before removing child-owned metadata.
+
+Broad or opaque carriers are rejected at compilation. This includes `Any`,
+`object`, bare and parameterized `dict`, abstract `Mapping`, `Sequence`,
+`Collection`, and `Iterable` annotations, custom container origins, and custom
+annotation schema hooks. Custom hooks are deliberately unsupported at this
+boundary because the compiler cannot prove their complete validation,
+serialization, and schema behavior. A broad arm also makes a union unsupported.
+Exact built-in containers are supported because their traversal semantics are
+bounded; an abstract or custom carrier could produce a shape that cannot be
+assigned to the declared child safely.
+
+`TypedDict` declarations that preserve undeclared items through
+`ConfigDict(extra="allow")` or a declared `extra_items` type are rejected
+because those keys have no statically owned shape. Recoverable unions may
+combine model, scalar, and structurally matched `TypedDict` arms. A
+mapping-valued `Enum` branch, including a `Literal` enum member, may not compete
+with a structural `BaseModel`, dataclass, or `TypedDict` branch at an
+overlapping reachable position. Homogeneous built-in collection item positions
+overlap one another and every fixed tuple index; two fixed tuple positions
+overlap only when their indices match. Distinct specializations of one
+runtime-erased generic dataclass origin are likewise rejected at overlapping
+positions, including through aliases, type variables, `NewType`, exact
+containers, and identity-erased `TypedDict` fields. These declarations fail
+compilation because validated runtime values cannot identify the authoritative
+arm.
+
+These restrictions apply only to fields encountered along the managed path in
+an explicit historical model. An unrelated `Any` or mapping field elsewhere in
+that model remains valid, and an explicit model may omit the route entirely.
+An omitted route is reserved: another field alias, computed output, or allowed
+extra cannot repopulate that location. Declared collisions fail compilation;
+dynamic extra output fails before metadata pruning.
+
+Field and annotation serializers on a managed route, including serializers
+hidden inside an alias, and model serializers on an object-shaped managed leaf
+are rejected because they can relocate the owned document. Serializers on
+unrelated fields remain supported. Ownership checks use Pydantic's effective
+validation and serialization names, including merged `Annotated` field
+metadata, stdlib-dataclass metadata and assigned `Field()` precedence, explicit
+empty aliases, and an explicitly cleared `serialization_alias`. An alias
+generator on a plain dataclass or `TypedDict` is rejected when Pydantic has not
+materialized its result, because invoking an application callback again would
+break once-only behavior. Type aliases, `NewType`, and type variables are
+normalized the same way during compilation, runtime checking, traversal, and
+metadata pruning.
+
+The exclusion rule for an explicit historical model is deliberately different
+from automatic projection. An authoritative current-model field marked with
+`Field(exclude=True)` or `exclude_if` is still omitted from every generated wire
+projection. If an explicit historical model declares such an excluded field on
+a managed nested route and its effective Pydantic field contract sets
+`exclude=True` or a non-`None` `exclude_if`, compilation fails: validation can
+populate the field while serialization removes it unconditionally or
+conditionally. Omit the field from that historical model when the route is
+intentionally absent.
+
+Before explicit source-body validators execute, family-owned metadata is
+preflighted through every structurally viable declared arm and its effective
+validation aliases. After validation, the selected managed value must still
+conform to a declared branch.
+
+Validators on an explicit historical wire model still run normally, but their
+result at every managed route must conform to one branch of the declared
+annotation. The family checks this immediately after historical source or
+target validation, including target-default construction and nested explicit
+source validation. Target checks recurse through instantiated nested family
+documents, including those owned by generated parent adapters. A
+shape-preserving validator remains supported. A validator that annotates a
+managed value as `str` but returns a mapping instead fails with a contextual,
+payload-free `ValueError`. Source checks run before migrations; target checks
+run before metadata pruning or serialization can consume the invalid value.
+Family-owned metadata found inside a structural child is verified against that
+child family before it is pruned; a wrong label or a metadata envelope with
+missing or sibling keys fails without echoing payload data.
 
 The `@versioned_schema` compatibility decorator also discovers child models
 that have their own decorator-created family with the exact same labels. These

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -130,11 +130,56 @@ would not have once-only semantics. Annotation or decorator serializers that
 can relocate a declared nested-family path are rejected for the same reason,
 as are custom model schema hooks and legacy `json_encoders` on that path.
 
+Explicit historical bodies may reshape a managed nested-family value only
+within the [declared historical annotation
+grammar](generated-wire-contracts.md#explicit-historical-nested-shapes). Use a
+`TypedDict`, Pydantic model, or structural dataclass when that historical leaf is
+mapping-shaped; a broad `dict`, `Mapping`, `Any`, abstract container, or custom
+carrier cannot establish static ownership and is rejected during compilation.
+Only exact built-in `list`, `tuple`, `set`, and `frozenset` containers with
+supported element annotations compose managed values.
+
+A concrete scalar replacement owns whatever JSON shape its normal Pydantic
+serialization produces. In particular, an object-shaped enum value is not
+reinterpreted as a child document merely because it contains a key named like
+the child version field. Conversely, omitting a managed route reserves that
+output location; aliases, computed fields, model serializers, and extras cannot
+reintroduce it through another channel.
+
+A mapping-valued enum cannot share an overlapping union position with a
+structural model, dataclass, or `TypedDict` arm. Pydantic's collection coercion
+and smart-union selection make that branch identity unrecoverable, so the
+declaration fails compilation.
+
+Current-model `Field(exclude=True)` and `exclude_if` declarations remain
+application-only state and are omitted from generated wire projections. An
+explicit historical body must instead leave an intentionally absent managed
+route undeclared. Declaring the route and attaching a serialization exclusion
+is rejected because validation would retain a value that serialization removes
+unconditionally or conditionally.
+
+Before explicit source-body validators execute, family-owned metadata is
+preflighted through every structurally viable declared arm and its effective
+validation aliases. After validation, the selected managed value must still
+conform to a declared branch.
+
+After an explicit target model validates data or constructs defaults, the
+family verifies that every managed value still conforms to its declared
+annotation before pruning child-owned metadata and serializing the target. The
+same check descends through generated parent adapters into instantiated
+explicit child targets and independently declared model, dataclass, and
+TypedDict representations of those children. Any family-owned metadata inside
+those structural representations is verified before removal.
+Explicit-source validation applies the same check before migration. Validators
+may normalize a value while preserving a declared branch, but a field or model
+validator that returns an out-of-contract shape fails with a contextual,
+payload-free `ValueError`. Pydantic accepting such an after-validator result is
+therefore not permission to change the managed wire shape silently.
+
 Attribute input is available only when the explicit body sets
-`ConfigDict(from_attributes=True)`. The adapter preflights family-owned metadata
-before executing body validators. Per-call `from_attributes=True` cannot enable
-attribute input for a body that did not declare it; use a mapping or an exact
-body instance instead. Allowed extras remain available, but an extra that
+`ConfigDict(from_attributes=True)`. Per-call `from_attributes=True` cannot
+enable attribute input for a body that did not declare it; use a mapping or an
+exact body instance instead. Allowed extras remain available, but an extra that
 overwrites an active field or computed-field serialization name fails closed.
 The facade exposes the declared Pydantic state and standard model operations;
 it does not proxy arbitrary body methods. Self-references created inside

--- a/docs/reference/stability-policy.md
+++ b/docs/reference/stability-policy.md
@@ -52,6 +52,19 @@ Generated model object identity is stable within one compiled family. Private
 attributes and implementation class names are not a cross-release contract.
 The supported JSON Schema and serialized payload behavior is the contract.
 
+The [explicit historical nested-shape
+grammar](../guide/generated-wire-contracts.md#explicit-historical-nested-shapes)
+is part of the supported declaration contract. Compatible 1.x releases preserve
+its statically owned scalar, model, dataclass, `TypedDict`, union, and exact
+built-in-container behavior, including the post-validation requirement that a
+managed value still conform to its annotation. Effective alias normalization,
+family-owned metadata preflight and envelope verification, reserved
+omitted-route output locations, scalar ownership of recoverable scalar output,
+and fail-closed rejection of runtime-unrecoverable overlapping union arms are
+part of that boundary. Broad mappings, abstract or custom containers, and other
+opaque carriers remain unsupported declarations; support for a new, statically
+identifiable shape may be added in a compatible minor release.
+
 ## Inventories and plans
 
 Exported inventory and plan records, their frozen fields, `to_dict()` keys and

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, is_dataclass
+from dataclasses import fields as dataclass_fields
 from functools import partial
 from types import NoneType, UnionType
 from typing import (
@@ -11,10 +12,16 @@ from typing import (
     Any,
     Literal,
     NoReturn,
+    TypeVar,
     Union,
     cast,
     get_args,
     get_origin,
+    get_type_hints,
+)
+from typing import TypeAliasType as StdlibTypeAliasType
+from typing import (
+    is_typeddict as stdlib_is_typeddict,
 )
 
 from pydantic import (
@@ -25,6 +32,10 @@ from pydantic import (
     create_model,
 )
 from pydantic_core import SchemaValidator, core_schema, to_jsonable_python
+from typing_extensions import (  # noqa: UP035
+    TypeAliasType as ExtensionsTypeAliasType,
+)
+from typing_extensions import is_typeddict as extensions_is_typeddict
 
 from pydantic_versions._compiler import (
     _CompiledDecoratorNestedFamily,
@@ -80,6 +91,7 @@ _SUPPORTED_MODEL_DUMP_OPTIONS = frozenset(
     }
 )
 _MISSING = object()
+_TYPE_ALIAS_TYPES = (StdlibTypeAliasType, ExtensionsTypeAliasType)
 
 
 def _runtime_label(value: object, *, family_name: str) -> str:
@@ -159,11 +171,21 @@ def _extract_declared_value(
 def _matching_declared_annotation(annotation: Any, value: Any) -> Any:
     if annotation is None:
         return None
-    normalized = _strip_annotated(annotation)
+    normalized = _runtime_annotation_value(annotation)
     origin = get_origin(normalized)
-    if origin not in (Union, UnionType):
+    if isinstance(normalized, TypeVar):
+        candidates = tuple(
+            _runtime_annotation_value(candidate)
+            for candidate in _runtime_type_parameter_values(normalized)
+        )
+    elif origin in (Union, UnionType):
+        candidates = tuple(
+            _runtime_annotation_value(candidate) for candidate in get_args(normalized)
+        )
+    else:
         return normalized
-    candidates = tuple(_strip_annotated(candidate) for candidate in get_args(normalized))
+    if not candidates:
+        return normalized
     for candidate in candidates:
         if isinstance(candidate, type) and type(value) is candidate:
             return candidate
@@ -186,11 +208,11 @@ def _matching_declared_annotation(annotation: Any, value: Any) -> Any:
             except TypeError:
                 continue
     shape_matches = tuple(
-        candidate
-        for candidate in generic_matches
-        if _runtime_value_matches_annotation(value, candidate)
+        candidate for candidate in candidates if _runtime_value_matches_annotation(value, candidate)
     )
     if len(shape_matches) == 1:
+        return shape_matches[0]
+    if shape_matches:
         return shape_matches[0]
     if generic_matches:
         return generic_matches[0]
@@ -206,10 +228,26 @@ def _safe_annotation_instance(value: Any, annotation: Any) -> bool:
         return False
 
 
+def _is_runtime_base_model_type(annotation: Any) -> bool:
+    if not isinstance(annotation, type):
+        return False
+    try:
+        return issubclass(annotation, BaseModel)
+    except TypeError:
+        return False
+
+
 def _runtime_value_matches_annotation(value: Any, annotation: Any) -> bool:
-    normalized = _strip_annotated(annotation)
+    normalized = _runtime_annotation_value(annotation)
     if normalized is Any:
         return True
+    if isinstance(normalized, TypeVar):
+        candidates = _runtime_type_parameter_values(normalized)
+        return not candidates or any(
+            _runtime_value_matches_annotation(value, candidate) for candidate in candidates
+        )
+    if _is_typed_dict(normalized):
+        return _runtime_value_matches_typed_dict(value, normalized)
     origin = get_origin(normalized)
     arguments = get_args(normalized)
     if origin in (Union, UnionType):
@@ -226,7 +264,7 @@ def _runtime_value_matches_annotation(value: Any, annotation: Any) -> bool:
         if not isinstance(value, tuple):
             return False
         if not arguments:
-            return True
+            return not value
         if arguments[-1] is Ellipsis:
             return all(_runtime_value_matches_annotation(item, arguments[0]) for item in value)
         return len(value) == len(arguments) and all(
@@ -246,6 +284,487 @@ def _runtime_value_matches_annotation(value: Any, annotation: Any) -> bool:
         )
     runtime_type = origin if isinstance(origin, type) else normalized
     return isinstance(runtime_type, type) and _safe_annotation_instance(value, runtime_type)
+
+
+def _is_typed_dict(annotation: Any) -> bool:
+    if stdlib_is_typeddict(annotation) or extensions_is_typeddict(annotation):
+        return True
+    origin = get_origin(annotation)
+    return origin is not None and (stdlib_is_typeddict(origin) or extensions_is_typeddict(origin))
+
+
+def _runtime_annotation_value(annotation: Any) -> Any:
+    normalized = annotation
+    while True:
+        stripped = _strip_annotated(normalized)
+        if stripped is not normalized:
+            normalized = stripped
+            continue
+        if isinstance(normalized, _TYPE_ALIAS_TYPES):
+            normalized = normalized.__value__
+            continue
+        origin = get_origin(normalized)
+        if isinstance(origin, _TYPE_ALIAS_TYPES):
+            arguments = get_args(normalized)
+            replacements = list(zip(origin.__type_params__, arguments, strict=False))
+            for parameter in origin.__type_params__[len(arguments) :]:
+                default = _runtime_type_parameter_default(parameter)
+                if default is not _MISSING:
+                    replacements.append((parameter, default))
+            normalized = _replace_runtime_type_parameters(
+                origin.__value__,
+                replacements=tuple(replacements),
+            )
+            continue
+        supertype = getattr(normalized, "__supertype__", None)
+        if supertype is not None and supertype is not normalized:
+            normalized = supertype
+            continue
+        return normalized
+
+
+def _replace_runtime_type_parameters(
+    annotation: Any,
+    *,
+    replacements: tuple[tuple[Any, Any], ...],
+) -> Any:
+    replacement = next(
+        (value for parameter, value in replacements if annotation is parameter),
+        _MISSING,
+    )
+    if replacement is not _MISSING:
+        return replacement
+    origin = get_origin(annotation)
+    arguments = get_args(annotation)
+    if origin is None or not arguments or origin is Literal:
+        return annotation
+    rewritten = tuple(
+        _replace_runtime_type_parameters(argument, replacements=replacements)
+        if argument is not Ellipsis
+        else argument
+        for argument in arguments
+    )
+    if rewritten == arguments:
+        return annotation
+    if origin in (Union, UnionType):
+        rewritten_union: Any = rewritten[0]
+        for argument in rewritten[1:]:
+            rewritten_union |= argument
+        return rewritten_union
+    if origin is Annotated:
+        return Annotated[rewritten[0], *rewritten[1:]]
+    parameters: Any = rewritten[0] if len(rewritten) == 1 else rewritten
+    return origin[parameters]
+
+
+def _runtime_type_parameter_values(parameter: TypeVar) -> tuple[Any, ...]:
+    values = list(parameter.__constraints__)
+    if parameter.__bound__ is not None:
+        values.append(parameter.__bound__)
+    default = _runtime_type_parameter_default(parameter)
+    if default is not _MISSING:
+        values.append(default)
+    return tuple(values)
+
+
+def _runtime_type_parameter_default(parameter: Any) -> Any:
+    default = getattr(parameter, "__default__", _MISSING)
+    default_is_sentinel = "NoDefault" in type(default).__name__ and repr(default) in (
+        "typing.NoDefault",
+        "typing_extensions.NoDefault",
+    )
+    if default is not _MISSING and not default_is_sentinel:
+        return default
+    return _MISSING
+
+
+def _runtime_value_matches_typed_dict(value: Any, annotation: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    origin = _runtime_typed_dict_origin(annotation)
+    assert origin is not None
+    fields = _runtime_typed_dict_fields(annotation, origin=origin)
+    required_keys = cast(frozenset[str], origin.__required_keys__)
+    if not required_keys.issubset(value):
+        return False
+    if any(key not in fields for key in value):
+        return False
+    return all(
+        key not in value or _runtime_value_matches_annotation(value[key], field_annotation)
+        for key, field_annotation in fields.items()
+    )
+
+
+def _runtime_typed_dict_origin(annotation: Any) -> type[Any] | None:
+    normalized = _runtime_annotation_value(annotation)
+    if stdlib_is_typeddict(normalized) or extensions_is_typeddict(normalized):
+        return normalized
+    origin = get_origin(normalized)
+    if stdlib_is_typeddict(origin) or extensions_is_typeddict(origin):
+        return cast(type[Any], origin)
+    return None
+
+
+def _runtime_typed_dict_fields(
+    annotation: Any,
+    *,
+    origin: type[Any],
+) -> dict[str, Any]:
+    try:
+        fields = get_type_hints(origin, include_extras=True)
+    except (NameError, TypeError):
+        # Explicit wire-model compilation has already rejected unresolved
+        # managed annotations. Keep this structural fallback for annotations
+        # whose local namespace is no longer available to get_type_hints().
+        fields = origin.__annotations__
+    replacements = _runtime_generic_replacements(annotation, origin=origin)
+    return {
+        key: _runtime_typed_dict_field_annotation(
+            _replace_runtime_type_parameters(field_annotation, replacements=replacements),
+        )
+        for key, field_annotation in fields.items()
+    }
+
+
+def _runtime_generic_replacements(
+    annotation: Any,
+    *,
+    origin: type[Any],
+) -> tuple[tuple[Any, Any], ...]:
+    parameters = tuple(getattr(origin, "__type_params__", ())) or tuple(
+        getattr(origin, "__parameters__", ()),
+    )
+    arguments = get_args(_runtime_annotation_value(annotation))
+    replacements = list(zip(parameters, arguments, strict=False))
+    for parameter in parameters[len(arguments) :]:
+        default = _runtime_type_parameter_default(parameter)
+        if default is not _MISSING:
+            replacements.append((parameter, default))
+    return tuple(replacements)
+
+
+def _runtime_typed_dict_field_annotation(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if _is_typed_dict_field_qualifier(origin):
+        arguments = get_args(annotation)
+        return arguments[0] if arguments else Any
+    return annotation
+
+
+def _is_typed_dict_field_qualifier(origin: Any) -> bool:
+    return getattr(origin, "__module__", None) in ("typing", "typing_extensions") and getattr(
+        origin,
+        "_name",
+        None,
+    ) in ("NotRequired", "ReadOnly", "Required")
+
+
+def _validate_explicit_nested_runtime_shapes(
+    value: Any,
+    *,
+    compiled: _CompiledFamily,
+    version: _CompiledVersion,
+    label: str,
+    recurse_nested_targets: bool = False,
+) -> None:
+    root_value = value
+    root_annotation: Any = version.model
+    if version.wire_model_kind == "explicit":
+        explicit_model = _explicit_runtime_body_model(version.model)
+        explicit_value = _explicit_runtime_body(value, model=explicit_model)
+        root_value = explicit_value
+        root_annotation = explicit_model
+        for nested in compiled.nested:
+            target_path = _target_nested_path(version, nested.path)
+            if (
+                _declared_runtime_values_at_path(
+                    explicit_value,
+                    annotation=explicit_model,
+                    path=target_path,
+                )
+                is not None
+            ):
+                continue
+            _raise_explicit_nested_runtime_shape(compiled, label=label, path=nested.path)
+    if recurse_nested_targets:
+        _validate_nested_target_runtime_shapes(
+            root_value,
+            annotation=root_annotation,
+            compiled=compiled,
+            version=version,
+            label=label,
+        )
+
+
+def _validate_nested_target_runtime_shapes(
+    value: Any,
+    *,
+    annotation: Any,
+    compiled: _CompiledFamily,
+    version: _CompiledVersion,
+    label: str,
+) -> None:
+    for nested in compiled.nested:
+        child_label = nested.child_label(label)
+        child_compiled = nested.family._compiled_family()
+        child_version = child_compiled.version(child_label)
+        child_model = _explicit_runtime_body_model(child_version.model)
+        target_path = _target_nested_path(version, nested.path)
+        route_values = _declared_runtime_values_at_path(
+            value,
+            annotation=annotation,
+            path=target_path,
+        )
+        if route_values is None:
+            _raise_explicit_nested_runtime_shape(compiled, label=label, path=nested.path)
+        for route_value, route_annotation in route_values:
+            for child_value, child_annotation in _runtime_nested_structural_occurrences(
+                route_value,
+                annotation=route_annotation,
+                model=child_model,
+            ):
+                _validate_nested_target_runtime_shapes(
+                    child_value,
+                    annotation=child_annotation,
+                    compiled=child_compiled,
+                    version=child_version,
+                    label=child_label,
+                )
+
+
+def _raise_explicit_nested_runtime_shape(
+    compiled: _CompiledFamily,
+    *,
+    label: str,
+    path: tuple[str, ...],
+) -> NoReturn:
+    msg = (
+        f"Explicit wire model for schema family {compiled.name!r} and version "
+        f"{label!r} returned a value outside its declared annotation at "
+        f"nested path {path!r}"
+    )
+    raise ValueError(msg)
+
+
+def _runtime_nested_structural_occurrences(
+    value: Any,
+    *,
+    annotation: Any,
+    model: type[BaseModel],
+    conservative_structural_unions: bool = False,
+) -> tuple[tuple[Any, Any], ...]:
+    if isinstance(value, model):
+        return ((value, model),)
+    document_body = _explicit_runtime_body(value, model=model)
+    if document_body is not value:
+        return ((document_body, model),)
+    declared = _runtime_annotation_value(annotation)
+    declared_origin = get_origin(declared)
+    if conservative_structural_unions and (
+        isinstance(declared, TypeVar) or declared_origin in (Union, UnionType)
+    ):
+        candidates = (
+            _runtime_type_parameter_values(declared)
+            if isinstance(declared, TypeVar)
+            else tuple(candidate for candidate in get_args(declared) if candidate is not NoneType)
+        )
+        return tuple(
+            occurrence
+            for candidate in candidates
+            for occurrence in _runtime_nested_structural_occurrences(
+                value,
+                annotation=candidate,
+                model=model,
+                conservative_structural_unions=True,
+            )
+        )
+    selected = _runtime_annotation_value(_matching_declared_annotation(annotation, value))
+    items = _declared_collection_items(value, annotation=selected)
+    if items is not None:
+        return tuple(
+            occurrence
+            for item, item_annotation in items
+            for occurrence in _runtime_nested_structural_occurrences(
+                item,
+                annotation=item_annotation,
+                model=model,
+                conservative_structural_unions=conservative_structural_unions,
+            )
+        )
+    if _runtime_structural_fields(selected) is None:
+        return ()
+    return ((value, selected),)
+
+
+def _explicit_runtime_body_model(model: type[BaseModel]) -> type[BaseModel]:
+    body_model = getattr(model, "_document_body_model", None)
+    return cast(type[BaseModel], body_model) if _is_runtime_base_model_type(body_model) else model
+
+
+def _explicit_runtime_body(value: Any, *, model: type[BaseModel]) -> Any:
+    if isinstance(value, model):
+        return value
+    if getattr(type(value), "_document_body_model", None) is not model:
+        return value
+    try:
+        body = object.__getattribute__(
+            value,
+            "_FamilyDocumentAdapterBase__document_body",
+        )
+    except AttributeError:
+        return value
+    return body if isinstance(body, model) else value
+
+
+def _declared_runtime_values_at_path(
+    value: Any,
+    *,
+    annotation: Any,
+    path: tuple[str, ...],
+) -> tuple[tuple[Any, Any], ...] | None:
+    selected = _runtime_annotation_value(_matching_declared_annotation(annotation, value))
+    if isinstance(selected, TypeVar) or get_origin(selected) in (Union, UnionType):
+        return None
+    if not _runtime_value_matches_annotation(value, selected):
+        return None
+    if not path:
+        return ((value, selected),)
+
+    items = _declared_collection_items(value, annotation=selected)
+    if items is not None:
+        occurrences: list[tuple[Any, Any]] = []
+        for item, item_annotation in items:
+            nested = _declared_runtime_values_at_path(
+                item,
+                annotation=item_annotation,
+                path=path,
+            )
+            if nested is None:
+                return None
+            occurrences.extend(nested)
+        return tuple(occurrences)
+
+    structure = _runtime_structural_fields(selected)
+    if structure is None:
+        # A concrete historical scalar may intentionally replace the rest of
+        # a current nested route.
+        return ()
+    kind, _owner, field_annotations, required_keys = structure
+    field_name, *remaining = path
+    field_annotation = field_annotations.get(field_name, _MISSING)
+    if field_annotation is _MISSING:
+        return (
+            None
+            if _runtime_undeclared_field_is_present(
+                value,
+                kind=kind,
+                field_name=field_name,
+            )
+            else ()
+        )
+    present, field_value = _runtime_structural_field_value(
+        value,
+        kind=kind,
+        field_name=field_name,
+    )
+    if not present:
+        return () if kind == "typed_dict" and field_name not in required_keys else None
+    if not _runtime_value_matches_annotation(field_value, field_annotation):
+        return None
+    if not remaining:
+        return ((field_value, field_annotation),)
+    return _declared_runtime_values_at_path(
+        field_value,
+        annotation=field_annotation,
+        path=tuple(remaining),
+    )
+
+
+def _runtime_structural_fields(
+    annotation: Any,
+) -> (
+    tuple[
+        Literal["model", "dataclass", "typed_dict"],
+        type[Any],
+        dict[str, Any],
+        frozenset[str],
+    ]
+    | None
+):
+    normalized = _runtime_annotation_value(annotation)
+    if _is_runtime_base_model_type(normalized):
+        fields = {name: field.annotation for name, field in normalized.model_fields.items()}
+        return "model", normalized, fields, frozenset(fields)
+
+    typed_dict_origin = _runtime_typed_dict_origin(normalized)
+    if typed_dict_origin is not None:
+        fields = _runtime_typed_dict_fields(normalized, origin=typed_dict_origin)
+        required = cast(frozenset[str], typed_dict_origin.__required_keys__)
+        return "typed_dict", typed_dict_origin, fields, required
+
+    origin = get_origin(normalized)
+    dataclass_type = origin if isinstance(origin, type) and is_dataclass(origin) else normalized
+    if not isinstance(dataclass_type, type) or not is_dataclass(dataclass_type):
+        return None
+    pydantic_fields = getattr(dataclass_type, "__pydantic_fields__", None)
+    if isinstance(pydantic_fields, Mapping):
+        fields = {name: field.annotation for name, field in pydantic_fields.items()}
+    else:
+        try:
+            resolved = get_type_hints(dataclass_type, include_extras=True)
+        except (NameError, TypeError):
+            resolved = dict(getattr(dataclass_type, "__annotations__", {}))
+        declared_names = {field.name for field in dataclass_fields(dataclass_type)}
+        fields = {name: resolved[name] for name in declared_names if name in resolved}
+    replacements = _runtime_generic_replacements(normalized, origin=dataclass_type)
+    fields = {
+        name: _replace_runtime_type_parameters(field_annotation, replacements=replacements)
+        for name, field_annotation in fields.items()
+    }
+    return "dataclass", dataclass_type, fields, frozenset(fields)
+
+
+def _runtime_structural_field_value(
+    value: Any,
+    *,
+    kind: Literal["model", "dataclass", "typed_dict"],
+    field_name: str,
+) -> tuple[bool, Any]:
+    if kind == "typed_dict":
+        if not isinstance(value, Mapping) or field_name not in value:
+            return False, None
+        return True, value[field_name]
+    if kind == "model":
+        if isinstance(value, BaseModel):
+            if field_name not in value.__dict__:
+                return False, None
+            return True, value.__dict__[field_name]
+        if isinstance(value, Mapping) and field_name in value:
+            return True, value[field_name]
+        return False, None
+    if isinstance(value, Mapping):
+        if field_name not in value:
+            return False, None
+        return True, value[field_name]
+    try:
+        return True, object.__getattribute__(value, field_name)
+    except AttributeError:
+        return False, None
+
+
+def _runtime_undeclared_field_is_present(
+    value: Any,
+    *,
+    kind: Literal["model", "dataclass", "typed_dict"],
+    field_name: str,
+) -> bool:
+    if kind == "typed_dict":
+        return isinstance(value, Mapping) and field_name in value
+    storage = getattr(value, "__dict__", None)
+    if kind == "model":
+        extras = getattr(value, "__pydantic_extra__", None)
+        return isinstance(extras, Mapping) and field_name in extras
+    return isinstance(storage, Mapping) and field_name in storage
 
 
 def _select_decorator_routes(
@@ -553,6 +1072,23 @@ def _validate_family[T: BaseModel](
     )
     source = compiled.version(source_version)
     source_model = source.model.model_validate(data)
+    _validate_explicit_nested_runtime_shapes(
+        source_model,
+        compiled=compiled,
+        version=source,
+        label=source_version,
+        recurse_nested_targets=True,
+    )
+    _verify_validated_family_version_metadata(
+        value=source_model,
+        compiled=compiled,
+        label=source_version,
+    )
+    _preflight_nested_version_metadata(
+        payload=source_model,
+        compiled=compiled,
+        parent_label=source_version,
+    )
     decorator_selections = _select_decorator_routes(
         source_model,
         compiled=compiled,
@@ -770,6 +1306,13 @@ def _dump_family[T: BaseModel](
 
     target_payload = _to_version_names(target, payload)
     target_model = target.model.model_validate(target_payload, by_name=True)
+    _validate_explicit_nested_runtime_shapes(
+        target_model,
+        compiled=compiled,
+        version=target,
+        label=requested,
+        recurse_nested_targets=True,
+    )
     _validate_nested_collection_cardinality(
         input_payload=target_payload,
         validated_model=target_model,
@@ -797,7 +1340,15 @@ def _defaults_family[T: BaseModel](
     compiled = family._compiled_family()
     _validate_include_version_mode(compiled, include_version)
     requested = _runtime_label(version, family_name=family.name)
-    target_model = compiled.version(requested).model.model_validate({})
+    target = compiled.version(requested)
+    target_model = target.model.model_validate({})
+    _validate_explicit_nested_runtime_shapes(
+        target_model,
+        compiled=compiled,
+        version=target,
+        label=requested,
+        recurse_nested_targets=True,
+    )
     return _serialize_target_model(
         compiled=compiled,
         requested=requested,
@@ -1029,10 +1580,11 @@ def _verify_serialized_model_metadata(
             f"{requested!r} omitted model-owned version metadata {output_key!r}"
         )
         raise ValueError(msg)
-    if value != requested:
+    if not _matches_version_label(value, requested):
+        value_display = _safe_nested_version_display(value, compiled=compiled)
         msg = (
             f"Target wire model for family {compiled.name!r} serialized version "
-            f"metadata {output_key!r} as {value!r}, expected {requested!r}"
+            f"metadata {output_key!r} as {value_display}, expected {requested!r}"
         )
         raise ValueError(msg)
     duplicate_keys = tuple(key for key in candidate_keys if key != output_key and key in dumped)
@@ -1112,8 +1664,6 @@ def _serialized_field_name(
     field_info = model.model_fields[field_name]
     if use_alias:
         output_alias = field_info.serialization_alias
-        if output_alias is None:
-            output_alias = field_info.alias
         if isinstance(output_alias, str):
             return output_alias
     return field_name
@@ -1711,7 +2261,12 @@ def _validate_current_render_metadata(
         field_info = compiled.model.model_fields[field_name]
         locations.append((field_name,))
         if compiled.model.model_config.get("validate_by_alias", True) is not False:
-            locations.extend(_field_alias_paths(field_info))
+            locations.extend(
+                _alias_paths(
+                    field_info.validation_alias,
+                    fallback=field_info.alias,
+                ),
+            )
 
     checked_locations: list[tuple[Any, ...]] = []
     for location in locations:
@@ -2618,10 +3173,14 @@ def _preflight_nested_version_metadata(
     payload: Any,
     compiled: _CompiledFamily,
     parent_label: str,
+    representation_annotation: Any | None = None,
 ) -> None:
     if not compiled.nested and not compiled.decorator_nested:
         return
     parent_version = compiled.version(parent_label)
+    root_annotation = (
+        parent_version.model if representation_annotation is None else representation_annotation
+    )
     payload_is_canonical = False
     if isinstance(payload, BaseModel):
         payload_is_canonical = isinstance(payload, parent_version.model) or (
@@ -2631,43 +3190,65 @@ def _preflight_nested_version_metadata(
             payload,
             preserve_nested_models=True,
         )
-    if not isinstance(payload, Mapping):
+    if not isinstance(payload, Mapping) and _runtime_structural_fields(root_annotation) is None:
         return
 
     for nested in compiled.nested:
         source_path = _target_nested_path(parent_version, nested.path)
         expected = nested.child_label(parent_label)
         child_compiled = nested.family._compiled_family()
-        for nested_payload in _declared_payload_values_at_path(
+        child_model = _explicit_runtime_body_model(
+            child_compiled.version(expected).model,
+        )
+        route_occurrences = _declared_payload_occurrences_at_path(
             payload,
-            model=parent_version.model,
+            annotation=root_annotation,
             path=source_path,
             prefer_aliases=not payload_is_canonical,
-        ):
-            for item in _nested_payload_items(nested_payload):
-                metadata_payload = (
-                    _extract_preflight_fields(item) if isinstance(item, BaseModel) else item
+            conservative_structural_unions=True,
+        )
+        for nested_payload, nested_annotation in route_occurrences:
+            for item, item_annotation in _runtime_nested_structural_occurrences(
+                nested_payload,
+                annotation=nested_annotation,
+                model=child_model,
+                conservative_structural_unions=True,
+            ):
+                metadata_payload = _runtime_preflight_metadata_payload(
+                    item,
+                    annotation=item_annotation,
+                    family_metadata_path=(
+                        child_compiled.version_metadata.path
+                        if child_compiled.version_metadata is not None
+                        and child_compiled.version_metadata.owner == "family"
+                        else None
+                    ),
                 )
-                if not isinstance(metadata_payload, Mapping):
-                    continue
                 found, declared = _declared_nested_version_metadata(
                     payload=metadata_payload,
                     compiled=child_compiled,
                     source_label=expected,
                 )
-                if found and declared != expected:
+                if found and not _matches_version_label(declared, expected):
+                    declared_display = _safe_nested_version_display(
+                        declared,
+                        compiled=child_compiled,
+                    )
                     msg = (
                         f"Nested family {nested.family.name!r} at path {nested.path!r} "
                         f"expects version {expected!r} for parent label {parent_label!r}, "
-                        f"but the payload declares {declared!r}"
+                        f"but the payload declares {declared_display}"
                     )
                     raise SchemaVersionError(msg)
                 _preflight_nested_version_metadata(
                     payload=item,
                     compiled=child_compiled,
                     parent_label=expected,
+                    representation_annotation=item_annotation,
                 )
 
+    if not isinstance(payload, Mapping):
+        return
     root_names = {
         route.path[0]: parent_version.projection.field(route.path[0]).version_name
         for route in compiled.decorator_nested
@@ -2690,11 +3271,15 @@ def _preflight_nested_version_metadata(
                 compiled=child_compiled,
                 source_label=expected,
             )
-            if found and declared != expected:
+            if found and not _matches_version_label(declared, expected):
+                declared_display = _safe_nested_version_display(
+                    declared,
+                    compiled=child_compiled,
+                )
                 msg = (
                     f"Decorator nested family {route.family.name!r} at path {route.path!r} "
                     f"expects version {expected!r} for parent label {parent_label!r}, "
-                    f"but the payload declares {declared!r}"
+                    f"but the payload declares {declared_display}"
                 )
                 raise SchemaVersionError(msg)
             _preflight_nested_version_metadata(
@@ -2702,6 +3287,94 @@ def _preflight_nested_version_metadata(
                 compiled=child_compiled,
                 parent_label=expected,
             )
+
+
+def _runtime_preflight_metadata_payload(
+    value: Any,
+    *,
+    annotation: Any,
+    family_metadata_path: VersionPath | None,
+) -> dict[Any, Any]:
+    structure = _runtime_structural_fields(annotation)
+    assert structure is not None
+    kind, owner, field_annotations, _required_keys = structure
+    extracted = (
+        {key: _copy_alias_payload_value(item) for key, item in value.items()}
+        if isinstance(value, Mapping)
+        else {}
+    )
+    if isinstance(value, BaseModel):
+        extras = value.__pydantic_extra__
+        if isinstance(extras, Mapping):
+            extracted.update(
+                (key, _copy_alias_payload_value(item))
+                for key, item in extras.items()
+                if isinstance(key, str)
+            )
+    for field_name, field_annotation in field_annotations.items():
+        present, field_value = _runtime_structural_field_value(
+            value,
+            kind=kind,
+            field_name=field_name,
+        )
+        if not present:
+            continue
+        extracted.setdefault(field_name, field_value)
+        if kind == "model":
+            alias_config = cast(type[BaseModel], owner).model_config
+            model_field = cast(type[BaseModel], owner).model_fields[field_name]
+            alias_paths = _alias_paths(
+                model_field.validation_alias,
+                fallback=model_field.alias,
+            )
+        else:
+            alias_config, alias_paths = _runtime_structural_validation_alias_paths(
+                kind=kind,
+                owner=owner,
+                field_name=field_name,
+                field_annotation=field_annotation,
+            )
+        if alias_config.get("validate_by_alias", True) is False:
+            continue
+        for alias_path in alias_paths:
+            if family_metadata_path is not None:
+                expected_path = (
+                    (family_metadata_path,)
+                    if isinstance(family_metadata_path, str)
+                    else family_metadata_path
+                )
+                if alias_path != expected_path:
+                    continue
+            _set_preflight_alias_payload_value(
+                extracted,
+                path=alias_path,
+                value=field_value,
+            )
+    return extracted
+
+
+def _set_preflight_alias_payload_value(
+    payload: dict[Any, Any],
+    *,
+    path: tuple[Any, ...],
+    value: Any,
+) -> None:
+    if not path or not all(isinstance(part, str) for part in path):
+        return
+    current = payload
+    for part in path[:-1]:
+        nested = current.get(part, _MISSING)
+        if nested is _MISSING:
+            child: dict[Any, Any] = {}
+            current[part] = child
+            current = child
+            continue
+        if not isinstance(nested, Mapping):
+            return
+        child = dict(nested)
+        current[part] = child
+        current = child
+    current.setdefault(path[-1], value)
 
 
 def _preflight_selected_decorator_version_metadata(
@@ -2735,11 +3408,15 @@ def _preflight_selected_decorator_version_metadata(
             compiled=child_compiled,
             source_label=expected,
         )
-        if found and declared != expected:
+        if found and not _matches_version_label(declared, expected):
+            declared_display = _safe_nested_version_display(
+                declared,
+                compiled=child_compiled,
+            )
             msg = (
                 f"Decorator nested family {route.family.name!r} at path {route.path!r} "
                 f"expects version {expected!r} for parent label {parent_label!r}, "
-                f"but the payload declares {declared!r}"
+                f"but the payload declares {declared_display}"
             )
             raise SchemaVersionError(msg)
         _preflight_nested_version_metadata(
@@ -2815,14 +3492,6 @@ def _extract_preflight_value(
     return value
 
 
-def _nested_payload_items(payload: Any) -> tuple[Any, ...]:
-    if isinstance(payload, list | tuple | set | frozenset):
-        return tuple(payload)
-    if payload is None:
-        return ()
-    return (payload,)
-
-
 def _declared_nested_version_metadata(
     *,
     payload: Mapping[str, Any],
@@ -2834,6 +3503,16 @@ def _declared_nested_version_metadata(
         return False, None
     if metadata.owner == "family":
         metadata_path = (metadata.path,) if isinstance(metadata.path, str) else metadata.path
+        if len(metadata_path) > 1 and metadata_path[0] in payload:
+            current: Any = payload[metadata_path[0]]
+            for part in metadata_path[1:]:
+                if not isinstance(current, Mapping) or set(current) != {part}:
+                    msg = (
+                        f"Nested family {compiled.name!r} reserves the entire version "
+                        f"metadata root {metadata_path[0]!r} without siblings"
+                    )
+                    raise SchemaVersionError(msg)
+                current = current[part]
         if not _path_has_payload(payload, metadata_path):
             return False, None
         declared = _get_version_field(payload, metadata.path)
@@ -2847,6 +3526,49 @@ def _declared_nested_version_metadata(
     return True, normalized[metadata_field]
 
 
+def _safe_nested_version_display(value: Any, *, compiled: _CompiledFamily) -> str:
+    if type(value) is str and any(
+        value == version.projection.label for version in compiled.versions
+    ):
+        return repr(value)
+    return "a different label"
+
+
+def _matches_version_label(value: Any, label: str) -> bool:
+    return type(value) is str and value == label
+
+
+def _verify_validated_family_version_metadata(
+    *,
+    value: BaseModel,
+    compiled: _CompiledFamily,
+    label: str,
+) -> None:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        return
+    metadata_payload = _extract_preflight_fields(value)
+    found, declared = _declared_nested_version_metadata(
+        payload=metadata_payload,
+        compiled=compiled,
+        source_label=label,
+    )
+    if not found:
+        msg = (
+            f"Validated source for schema family {compiled.name!r} and version {label!r} "
+            "omitted required version metadata"
+        )
+        raise SchemaVersionError(msg)
+    if _matches_version_label(declared, label):
+        return
+    declared_display = _safe_nested_version_display(declared, compiled=compiled)
+    msg = (
+        f"Validated source for schema family {compiled.name!r} and version {label!r} "
+        f"contains version metadata declaring {declared_display}"
+    )
+    raise SchemaVersionError(msg)
+
+
 def _nested_family_collection_kind(
     *,
     model: type[BaseModel],
@@ -2854,7 +3576,7 @@ def _nested_family_collection_kind(
 ) -> Literal["list", "tuple", "set", "frozenset"] | None:
     annotation: Any = model
     for index, key in enumerate(path):
-        if not isinstance(annotation, type) or not issubclass(annotation, BaseModel):
+        if not _is_runtime_base_model_type(annotation):
             return None
         field_info = annotation.model_fields.get(key)
         if field_info is None:
@@ -2865,7 +3587,7 @@ def _nested_family_collection_kind(
             return kind
         if kind is None:
             continue
-        args = get_args(annotation)
+        args = get_args(_runtime_annotation_value(annotation))
         if not args:
             return None
         annotation = _unwrap_optional_annotated(args[0])
@@ -2875,7 +3597,15 @@ def _nested_family_collection_kind(
 def _collection_kind(
     annotation: Any,
 ) -> Literal["list", "tuple", "set", "frozenset"] | None:
-    origin = get_origin(annotation)
+    normalized = _runtime_annotation_value(annotation)
+    if isinstance(normalized, TypeVar):
+        kinds = {
+            kind
+            for candidate in _runtime_type_parameter_values(normalized)
+            if (kind := _collection_kind(candidate)) is not None
+        }
+        return kinds.pop() if len(kinds) == 1 else None
+    origin = get_origin(normalized)
     if origin is list:
         return "list"
     if origin is tuple:
@@ -2897,9 +3627,15 @@ def _strip_annotated(annotation: Any) -> Any:
 def _unwrap_optional_annotated(annotation: Any) -> Any:
     current = annotation
     while True:
-        stripped = _strip_annotated(current)
-        if stripped is not current:
-            current = stripped
+        normalized = _runtime_annotation_value(current)
+        if normalized is not current:
+            current = normalized
+            continue
+        if isinstance(current, TypeVar):
+            candidates = _runtime_type_parameter_values(current)
+            if len(candidates) != 1:
+                return current
+            current = candidates[0]
             continue
         origin = get_origin(current)
         if origin not in (Union, UnionType):
@@ -2924,6 +3660,7 @@ def _prune_nested_family_metadata_payload(
     *,
     by_alias: Any = False,
     source_value: Any = _MISSING,
+    representation_annotation: Any | None = None,
 ) -> None:
     resolved_target = family.current_version if target_label is None else target_label
     if not isinstance(payload, Mapping):
@@ -2935,6 +3672,12 @@ def _prune_nested_family_metadata_payload(
     metadata = family.version_metadata
     if metadata is not None:
         if metadata.owner == "family":
+            _verify_serialized_nested_family_metadata(
+                payload,
+                metadata_path=metadata.path,
+                expected=resolved_target,
+                family_name=family.name,
+            )
             _remove_version_field(payload, metadata.path)
         else:
             _verify_serialized_model_metadata(
@@ -2949,17 +3692,55 @@ def _prune_nested_family_metadata_payload(
         return
 
     target = family.version(resolved_target)
+    root_annotation = (
+        target.model if representation_annotation is None else representation_annotation
+    )
     for child in family.nested:
         target_path = _target_nested_path(target, child.path)
-        _prune_nested_family_metadata_at_path(
-            payload=payload,
+        _prune_serialized_nested_path_through_annotation(
+            payload,
             source_payload=source_value,
-            model=target.model,
+            annotation=root_annotation,
             path=target_path,
             family=child.family._compiled_family(),
             target_label=child.child_label(resolved_target),
             by_alias=by_alias,
         )
+
+
+def _verify_serialized_nested_family_metadata(
+    payload: Mapping[Any, Any],
+    *,
+    metadata_path: VersionPath,
+    expected: str,
+    family_name: str,
+) -> None:
+    path = (metadata_path,) if isinstance(metadata_path, str) else metadata_path
+    root = path[0]
+    if root not in payload:
+        return
+    current: Any = payload[root]
+    for part in path[1:]:
+        if not isinstance(current, Mapping):
+            msg = (
+                f"Nested target wire model for family {family_name!r} serialized a "
+                f"non-object version metadata component below {root!r}"
+            )
+            raise ValueError(msg)
+        if set(current) != {part}:
+            msg = (
+                f"Nested target wire model for family {family_name!r} reserves the "
+                f"entire version metadata root {root!r} without siblings"
+            )
+            raise ValueError(msg)
+        current = current[part]
+    if not _matches_version_label(current, expected):
+        msg = (
+            f"Nested target wire model for family {family_name!r} serialized version "
+            f"metadata {_version_field_display(metadata_path)!r} that does not match "
+            f"expected label {expected!r}"
+        )
+        raise ValueError(msg)
 
 
 def _prune_nested_family_metadata_at_path(
@@ -3004,6 +3785,11 @@ def _prune_serialized_nested_path(
     field_name, *remaining = path
     field_info = model.model_fields.get(field_name)
     if field_info is None:
+        if field_name in payload:
+            msg = (
+                f"Target wire model emitted omitted nested family {family.name!r} at path {path!r}"
+            )
+            raise ValueError(msg)
         return
     found, field_payload = _serialized_nested_field_payload(
         payload,
@@ -3088,7 +3874,22 @@ def _prune_serialized_nested_path_through_annotation(
     target_label: str,
     by_alias: Any,
 ) -> None:
-    annotation = _strip_annotated(annotation)
+    runtime_value = payload if source_payload is _MISSING else source_payload
+    annotation = _runtime_annotation_value(annotation)
+    if isinstance(annotation, TypeVar):
+        selected = _matching_declared_annotation(annotation, runtime_value)
+        if isinstance(selected, TypeVar):
+            selected = next(
+                (
+                    candidate
+                    for candidate in _runtime_type_parameter_values(annotation)
+                    if _annotation_declares_path(candidate, path)
+                ),
+                None,
+            )
+        if selected is None:
+            return
+        annotation = _runtime_annotation_value(selected)
     origin = get_origin(annotation)
     if origin in (Union, UnionType):
         if (
@@ -3097,7 +3898,6 @@ def _prune_serialized_nested_path_through_annotation(
             and (source_payload is None or source_payload is _MISSING)
         ):
             return
-        runtime_value = payload if source_payload is _MISSING else source_payload
         selected = _matching_declared_annotation(annotation, runtime_value)
         if get_origin(selected) not in (Union, UnionType):
             if selected is NoneType or not _annotation_declares_path(selected, path):
@@ -3128,11 +3928,23 @@ def _prune_serialized_nested_path_through_annotation(
                 by_alias=by_alias,
             )
         return
-    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+    if _is_runtime_base_model_type(annotation):
         _prune_serialized_nested_path(
             payload,
             source_payload=source_payload,
             model=annotation,
+            path=path,
+            family=family,
+            target_label=target_label,
+            by_alias=by_alias,
+        )
+        return
+    structure = _runtime_structural_fields(annotation)
+    if structure is not None:
+        _prune_serialized_nested_structural_path(
+            payload,
+            source_payload=source_payload,
+            structure=structure,
             path=path,
             family=family,
             target_label=target_label,
@@ -3165,6 +3977,271 @@ def _prune_serialized_nested_path_through_annotation(
     )
 
 
+def _prune_serialized_nested_structural_path(
+    payload: Any,
+    *,
+    source_payload: Any,
+    structure: tuple[
+        Literal["model", "dataclass", "typed_dict"],
+        type[Any],
+        dict[str, Any],
+        frozenset[str],
+    ],
+    path: tuple[str, ...],
+    family: _CompiledFamily,
+    target_label: str,
+    by_alias: Any,
+) -> None:
+    if not isinstance(payload, Mapping):
+        msg = (
+            f"Target wire model containing nested family {family.name!r} must "
+            f"serialize declared path {path!r} through objects"
+        )
+        raise ValueError(msg)
+    kind, owner, field_annotations, required_keys = structure
+    field_name, *remaining = path
+    field_annotation = field_annotations.get(field_name, _MISSING)
+    if field_annotation is _MISSING:
+        if field_name in payload:
+            msg = (
+                f"Target wire model emitted omitted nested family {family.name!r} at path {path!r}"
+            )
+            raise ValueError(msg)
+        return
+
+    output_name = _runtime_structural_serialized_field_name(
+        kind=kind,
+        owner=owner,
+        field_name=field_name,
+        field_annotation=field_annotation,
+        by_alias=by_alias,
+    )
+    candidates = tuple(dict.fromkeys((field_name, output_name)))
+    present = tuple(candidate for candidate in candidates if candidate in payload)
+    if len(present) > 1:
+        formatted = ", ".join(repr(candidate) for candidate in present)
+        msg = (
+            f"Target wire model serialized duplicate locations for nested family "
+            f"{family.name!r}: {formatted}"
+        )
+        raise ValueError(msg)
+    if output_name not in payload:
+        source_present, _source_field = _runtime_structural_field_value(
+            source_payload,
+            kind=kind,
+            field_name=field_name,
+        )
+        if kind == "typed_dict" and field_name not in required_keys and not source_present:
+            return
+        msg = f"Target wire model omitted declared nested family {family.name!r} at path {path!r}"
+        raise ValueError(msg)
+
+    source_present, source_field = _runtime_structural_field_value(
+        source_payload,
+        kind=kind,
+        field_name=field_name,
+    )
+    if not source_present:
+        source_field = _MISSING
+    field_payload = payload[output_name]
+    if remaining:
+        _prune_serialized_nested_path_through_annotation(
+            field_payload,
+            source_payload=source_field,
+            annotation=field_annotation,
+            path=tuple(remaining),
+            family=family,
+            target_label=target_label,
+            by_alias=by_alias,
+        )
+        return
+    _prune_serialized_nested_value(
+        field_payload,
+        source_payload=source_field,
+        annotation=field_annotation,
+        family=family,
+        target_label=target_label,
+        by_alias=by_alias,
+    )
+
+
+def _runtime_structural_serialized_field_name(
+    *,
+    kind: Literal["model", "dataclass", "typed_dict"],
+    owner: type[Any],
+    field_name: str,
+    field_annotation: Any,
+    by_alias: Any,
+) -> str:
+    if kind == "model":
+        return _serialized_field_name(
+            cast(type[BaseModel], owner),
+            field_name,
+            by_alias=by_alias,
+        )
+    (
+        config,
+        resolved_field_info,
+        assigned_field_info,
+        field_metadata,
+        annotated_field_infos,
+    ) = _runtime_structural_field_sources(
+        kind=kind,
+        owner=owner,
+        field_name=field_name,
+        field_annotation=field_annotation,
+    )
+    use_alias = (
+        config.get("serialize_by_alias", False) is True if by_alias is None else by_alias is True
+    )
+    if use_alias:
+        serialization_alias = _runtime_effective_structural_field_attribute(
+            attribute="serialization_alias",
+            resolved_field_info=resolved_field_info,
+            assigned_field_info=assigned_field_info,
+            field_metadata=field_metadata,
+            annotated_field_infos=annotated_field_infos,
+        )
+        output_alias = serialization_alias
+        if serialization_alias is _MISSING:
+            output_alias = _runtime_effective_structural_field_attribute(
+                attribute="alias",
+                resolved_field_info=resolved_field_info,
+                assigned_field_info=assigned_field_info,
+                field_metadata=field_metadata,
+                annotated_field_infos=annotated_field_infos,
+            )
+        if isinstance(output_alias, str):
+            return output_alias
+    return field_name
+
+
+def _runtime_structural_field_sources(
+    *,
+    kind: Literal["dataclass", "typed_dict"],
+    owner: type[Any],
+    field_name: str,
+    field_annotation: Any,
+) -> tuple[Mapping[str, Any], Any, Any, Mapping[Any, Any], tuple[Any, ...]]:
+    fields = getattr(owner, "__pydantic_fields__", None) if kind == "dataclass" else None
+    config = getattr(owner, "__pydantic_config__", {})
+    if not isinstance(config, Mapping):
+        config = {}
+    resolved_field_info = fields.get(field_name) if isinstance(fields, Mapping) else None
+    assigned_field_info: Any = None
+    field_metadata: Mapping[Any, Any] = {}
+    if resolved_field_info is None and kind == "dataclass":
+        declared_field = next(
+            (field for field in dataclass_fields(owner) if field.name == field_name),
+            None,
+        )
+        if declared_field is not None:
+            field_metadata = declared_field.metadata
+            if hasattr(declared_field.default, "_attributes_set"):
+                assigned_field_info = declared_field.default
+    annotated_field_infos = (
+        () if resolved_field_info is not None else _runtime_annotation_field_infos(field_annotation)
+    )
+    return (
+        config,
+        resolved_field_info,
+        assigned_field_info,
+        field_metadata,
+        annotated_field_infos,
+    )
+
+
+def _runtime_effective_structural_field_attribute(
+    *,
+    attribute: str,
+    resolved_field_info: Any,
+    assigned_field_info: Any,
+    field_metadata: Mapping[Any, Any],
+    annotated_field_infos: tuple[Any, ...],
+) -> Any:
+    if resolved_field_info is not None:
+        return getattr(resolved_field_info, attribute, None)
+    selected: Any = _MISSING
+    for field_info in annotated_field_infos:
+        if attribute in getattr(field_info, "_attributes_set", {}):
+            selected = getattr(field_info, attribute, None)
+    if attribute in field_metadata:
+        selected = field_metadata[attribute]
+    if assigned_field_info is not None and attribute in getattr(
+        assigned_field_info,
+        "_attributes_set",
+        {},
+    ):
+        selected = getattr(assigned_field_info, attribute, None)
+    return selected
+
+
+def _runtime_structural_validation_alias_paths(
+    *,
+    kind: Literal["dataclass", "typed_dict"],
+    owner: type[Any],
+    field_name: str,
+    field_annotation: Any,
+) -> tuple[Mapping[str, Any], tuple[tuple[Any, ...], ...]]:
+    (
+        config,
+        resolved_field_info,
+        assigned_field_info,
+        field_metadata,
+        annotated_field_infos,
+    ) = _runtime_structural_field_sources(
+        kind=kind,
+        owner=owner,
+        field_name=field_name,
+        field_annotation=field_annotation,
+    )
+    validation_alias = _runtime_effective_structural_field_attribute(
+        attribute="validation_alias",
+        resolved_field_info=resolved_field_info,
+        assigned_field_info=assigned_field_info,
+        field_metadata=field_metadata,
+        annotated_field_infos=annotated_field_infos,
+    )
+    alias = _runtime_effective_structural_field_attribute(
+        attribute="alias",
+        resolved_field_info=resolved_field_info,
+        assigned_field_info=assigned_field_info,
+        field_metadata=field_metadata,
+        annotated_field_infos=annotated_field_infos,
+    )
+    return config, _alias_paths(validation_alias, fallback=alias)
+
+
+def _alias_paths(
+    alias: Any,
+    *,
+    fallback: Any = _MISSING,
+) -> tuple[tuple[str | int, ...], ...]:
+    if (alias is _MISSING or alias is None) and fallback is not _MISSING:
+        alias = fallback
+    if isinstance(alias, str):
+        return ((alias,),)
+    if isinstance(alias, AliasPath):
+        return (tuple(alias.path),)
+    if isinstance(alias, AliasChoices):
+        return tuple(path for choice in alias.choices for path in _alias_paths(choice))
+    return ()
+
+
+def _runtime_annotation_field_infos(annotation: Any) -> tuple[Any, ...]:
+    origin = get_origin(annotation)
+    if _is_typed_dict_field_qualifier(origin):
+        arguments = get_args(annotation)
+        return _runtime_annotation_field_infos(arguments[0]) if arguments else ()
+    if origin is Annotated:
+        return tuple(
+            metadata
+            for metadata in get_args(annotation)[1:]
+            if hasattr(metadata, "_attributes_set")
+        )
+    return ()
+
+
 def _prune_serialized_nested_value(
     payload: Any,
     *,
@@ -3174,7 +4251,23 @@ def _prune_serialized_nested_value(
     target_label: str,
     by_alias: Any,
 ) -> None:
-    annotation = _strip_annotated(annotation)
+    runtime_value = payload if source_payload is _MISSING else source_payload
+    annotation = _runtime_annotation_value(annotation)
+    if isinstance(annotation, TypeVar):
+        selected = _matching_declared_annotation(annotation, runtime_value)
+        if isinstance(selected, TypeVar):
+            child_model = _explicit_runtime_body_model(family.version(target_label).model)
+            selected = next(
+                (
+                    candidate
+                    for candidate in _runtime_type_parameter_values(annotation)
+                    if _annotation_contains_model(candidate, child_model)
+                ),
+                None,
+            )
+        if selected is None:
+            return
+        annotation = _runtime_annotation_value(selected)
     origin = get_origin(annotation)
     if origin in (Union, UnionType):
         arguments = get_args(annotation)
@@ -3188,7 +4281,7 @@ def _prune_serialized_nested_value(
         runtime_value = payload if source_payload is _MISSING else source_payload
         selected = _matching_declared_annotation(annotation, runtime_value)
         if get_origin(selected) in (Union, UnionType):
-            child_model = family.version(target_label).model
+            child_model = _explicit_runtime_body_model(family.version(target_label).model)
             selected = next(
                 (
                     argument
@@ -3229,10 +4322,20 @@ def _prune_serialized_nested_value(
             family_name=family.name,
         )
         return
-    runtime_value = payload if source_payload is _MISSING else source_payload
-    annotation_is_object = (
-        isinstance(annotation, type) and issubclass(annotation, BaseModel)
-    ) or is_dataclass(annotation)
+    annotation_is_object = _runtime_structural_fields(annotation) is not None
+    if (
+        source_payload is not _MISSING
+        and _is_concrete_runtime_scalar_annotation(annotation)
+        and _runtime_value_matches_annotation(runtime_value, annotation)
+        and not isinstance(
+            runtime_value,
+            BaseModel | Mapping | list | tuple | set | frozenset,
+        )
+    ):
+        # A conforming historical scalar owns its serialized representation.
+        # Enum values and field serializers may legitimately emit mappings that
+        # happen to contain a child family's metadata key.
+        return
     if (
         not annotation_is_object
         and not isinstance(runtime_value, BaseModel | Mapping)
@@ -3245,6 +4348,7 @@ def _prune_serialized_nested_value(
         target_label,
         by_alias=by_alias,
         source_value=source_payload,
+        representation_annotation=annotation,
     )
 
 
@@ -3273,6 +4377,10 @@ def _serialized_collection_items(
             "collection cardinality after target serialization"
         )
         raise InvalidMigrationError(msg)
+    runtime_value = payload if source_payload is _MISSING else source_payload
+    annotation = _runtime_annotation_value(
+        _matching_declared_annotation(annotation, runtime_value),
+    )
     arguments = get_args(annotation)
     if get_origin(annotation) is tuple and arguments and arguments[-1] is not Ellipsis:
         return tuple(zip(values, arguments, source_values, strict=False))
@@ -3308,37 +4416,100 @@ def _validate_serialized_set_cardinality(
         raise InvalidMigrationError(msg)
 
 
-def _annotation_declares_path(annotation: Any, path: tuple[str, ...]) -> bool:
-    annotation = _strip_annotated(annotation)
+def _is_concrete_runtime_scalar_annotation(annotation: Any) -> bool:
+    annotation = _runtime_annotation_value(annotation)
+    origin = get_origin(annotation)
+    if origin is Literal:
+        return True
+    return (
+        origin is None
+        and isinstance(annotation, type)
+        and annotation not in (Any, object)
+        and not _is_runtime_base_model_type(annotation)
+        and not is_dataclass(annotation)
+        and not _is_typed_dict(annotation)
+    )
+
+
+def _annotation_declares_path(
+    annotation: Any,
+    path: tuple[str, ...],
+    *,
+    _seen: frozenset[Any] = frozenset(),
+) -> bool:
+    annotation_key = _runtime_annotation_cycle_key(annotation)
+    if annotation_key in _seen:
+        return False
+    seen = _seen | {annotation_key}
+    annotation = _runtime_annotation_value(annotation)
+    if isinstance(annotation, TypeVar):
+        return any(
+            _annotation_declares_path(candidate, path, _seen=seen)
+            for candidate in _runtime_type_parameter_values(annotation)
+        )
     origin = get_origin(annotation)
     if origin in (Union, UnionType):
         return any(
-            argument is not NoneType and _annotation_declares_path(argument, path)
+            argument is not NoneType and _annotation_declares_path(argument, path, _seen=seen)
             for argument in get_args(annotation)
         )
-    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+    if _is_runtime_base_model_type(annotation):
         field_info = annotation.model_fields.get(path[0])
         if field_info is None:
             return False
         if len(path) == 1:
             return True
-        return _annotation_declares_path(field_info.annotation, path[1:])
+        return _annotation_declares_path(field_info.annotation, path[1:], _seen=seen)
+    structure = _runtime_structural_fields(annotation)
+    if structure is not None:
+        _kind, _owner, field_annotations, _required_keys = structure
+        field_annotation = field_annotations.get(path[0], _MISSING)
+        if field_annotation is _MISSING:
+            return False
+        if len(path) == 1:
+            return True
+        return _annotation_declares_path(field_annotation, path[1:], _seen=seen)
     if _collection_kind(annotation) is None:
         return False
     return any(
-        argument is not Ellipsis and _annotation_declares_path(argument, path)
+        argument is not Ellipsis and _annotation_declares_path(argument, path, _seen=seen)
         for argument in get_args(annotation)
     )
 
 
-def _annotation_contains_model(annotation: Any, model: type[BaseModel]) -> bool:
-    annotation = _strip_annotated(annotation)
-    if annotation is model:
+def _annotation_contains_model(
+    annotation: Any,
+    model: type[BaseModel],
+    *,
+    _seen: frozenset[Any] = frozenset(),
+) -> bool:
+    annotation_key = _runtime_annotation_cycle_key(annotation)
+    if annotation_key in _seen:
+        return False
+    seen = _seen | {annotation_key}
+    annotation = _runtime_annotation_value(annotation)
+    if annotation is model or (
+        _is_runtime_base_model_type(annotation)
+        and _explicit_runtime_body_model(annotation) is model
+    ):
         return True
+    if isinstance(annotation, TypeVar):
+        return any(
+            _annotation_contains_model(candidate, model, _seen=seen)
+            for candidate in _runtime_type_parameter_values(annotation)
+        )
     return any(
-        argument is not Ellipsis and _annotation_contains_model(argument, model)
+        argument is not Ellipsis and _annotation_contains_model(argument, model, _seen=seen)
         for argument in get_args(annotation)
     )
+
+
+def _runtime_annotation_cycle_key(annotation: Any) -> Any:
+    try:
+        hash(annotation)
+    except TypeError:
+        return ("identity", id(annotation))
+    return ("annotation", annotation)
 
 
 def _convert_nested_child_family(
@@ -3471,6 +4642,23 @@ def _convert_nested_family_payload(
     else:
         source_version = compiled.version(source_label)
         source_data = source_version.model.model_validate(payload, by_name=True)
+        _validate_explicit_nested_runtime_shapes(
+            source_data,
+            compiled=compiled,
+            version=source_version,
+            label=source_label,
+            recurse_nested_targets=True,
+        )
+        _verify_validated_family_version_metadata(
+            value=source_data,
+            compiled=compiled,
+            label=source_label,
+        )
+        _preflight_nested_version_metadata(
+            payload=source_data,
+            compiled=compiled,
+            parent_label=source_label,
+        )
         current_payload = dict(
             _to_current_names(
                 compiled,
@@ -3660,6 +4848,14 @@ def _project_nested_family_payload(
         return payload
 
     compiled = family._compiled_family()
+    metadata = compiled.version_metadata
+    if metadata is not None and metadata.owner == "family":
+        _verify_serialized_nested_family_metadata(
+            payload,
+            metadata_path=metadata.path,
+            expected=target_label,
+            family_name=compiled.name,
+        )
     projected = _project_nested_family_payloads(
         payload=dict(payload),
         compiled=compiled,
@@ -3675,7 +4871,6 @@ def _project_nested_family_payload(
         return projected
 
     target_payload = _to_version_names(compiled.version(target_label), projected)
-    metadata = compiled.version_metadata
     if metadata is not None and metadata.owner == "family":
         if collection_kind in ("set", "tuple", "frozenset"):
             _set_version_field(target_payload, metadata.path, target_label)
@@ -3695,10 +4890,13 @@ def _validate_nested_collection_cardinality(
     del selections
     if not compiled.nested and not compiled.decorator_nested:
         return
+    target = compiled.version(parent_label)
     validated_payload = _extract_declared_fields(validated_model)
     _validate_nested_collection_cardinality_payloads(
         input_payloads=(input_payload,),
         validated_payloads=(validated_payload,),
+        input_annotations=(target.model,),
+        validated_annotations=(target.model,),
         compiled=compiled,
         parent_label=parent_label,
     )
@@ -3748,30 +4946,50 @@ def _validate_nested_collection_cardinality_payloads(
     *,
     input_payloads: tuple[Any, ...],
     validated_payloads: tuple[Any, ...],
+    input_annotations: tuple[Any, ...] | None = None,
+    validated_annotations: tuple[Any, ...] | None = None,
     compiled: _CompiledFamily,
     parent_label: str,
 ) -> None:
     target = compiled.version(parent_label)
+    resolved_input_annotations = (
+        (target.model,) * len(input_payloads) if input_annotations is None else input_annotations
+    )
+    resolved_validated_annotations = (
+        (target.model,) * len(validated_payloads)
+        if validated_annotations is None
+        else validated_annotations
+    )
     for nested in compiled.nested:
         target_path = _target_nested_path(target, nested.path)
-        input_values = tuple(
-            item
-            for payload in input_payloads
-            for item in _declared_payload_values_at_path(
+        input_occurrences = tuple(
+            occurrence
+            for payload, annotation in zip(
+                input_payloads,
+                resolved_input_annotations,
+                strict=True,
+            )
+            for occurrence in _declared_payload_occurrences_at_path(
                 payload,
-                model=target.model,
+                annotation=annotation,
                 path=target_path,
             )
         )
-        validated_values = tuple(
-            item
-            for payload in validated_payloads
-            for item in _declared_payload_values_at_path(
+        validated_occurrences = tuple(
+            occurrence
+            for payload, annotation in zip(
+                validated_payloads,
+                resolved_validated_annotations,
+                strict=True,
+            )
+            for occurrence in _declared_payload_occurrences_at_path(
                 payload,
-                model=target.model,
+                annotation=annotation,
                 path=target_path,
             )
         )
+        input_values = tuple(value for value, _annotation in input_occurrences)
+        validated_values = tuple(value for value, _annotation in validated_occurrences)
         collection_kind = _nested_family_collection_kind(
             model=compiled.model,
             path=nested.path,
@@ -3798,17 +5016,43 @@ def _validate_nested_collection_cardinality_payloads(
                 )
                 raise InvalidMigrationError(msg)
 
-        child_input = tuple(item for value in input_values for item in _nested_payload_items(value))
-        child_validated = tuple(
-            item for value in validated_values for item in _nested_payload_items(value)
-        )
         child_compiled = nested.family._compiled_family()
         if child_compiled.nested or child_compiled.decorator_nested:
+            child_label = nested.child_label(parent_label)
+            child_model = _explicit_runtime_body_model(
+                child_compiled.version(child_label).model,
+            )
+            child_input_occurrences = tuple(
+                child_occurrence
+                for value, annotation in input_occurrences
+                for child_occurrence in _runtime_nested_structural_occurrences(
+                    value,
+                    annotation=annotation,
+                    model=child_model,
+                )
+            )
+            child_validated_occurrences = tuple(
+                child_occurrence
+                for value, annotation in validated_occurrences
+                for child_occurrence in _runtime_nested_structural_occurrences(
+                    value,
+                    annotation=annotation,
+                    model=child_model,
+                )
+            )
             _validate_nested_collection_cardinality_payloads(
-                input_payloads=child_input,
-                validated_payloads=child_validated,
+                input_payloads=tuple(value for value, _annotation in child_input_occurrences),
+                validated_payloads=tuple(
+                    value for value, _annotation in child_validated_occurrences
+                ),
+                input_annotations=tuple(
+                    annotation for _value, annotation in child_input_occurrences
+                ),
+                validated_annotations=tuple(
+                    annotation for _value, annotation in child_validated_occurrences
+                ),
                 compiled=child_compiled,
-                parent_label=nested.child_label(parent_label),
+                parent_label=child_label,
             )
 
     canonical_input = tuple(
@@ -3881,85 +5125,123 @@ def _target_nested_path(
     return (first, *path[1:])
 
 
-def _declared_payload_values_at_path(
-    payload: Any,
-    *,
-    model: type[BaseModel],
-    path: tuple[str, ...],
-    prefer_aliases: bool = False,
-) -> tuple[Any, ...]:
-    if not path:
-        return (payload,)
-    if isinstance(payload, BaseModel):
-        payload_is_canonical = isinstance(payload, model)
-        payload = _extract_preflight_fields(
-            payload,
-            preserve_nested_models=True,
-        )
-        # Only an instance of the model declaring this path has canonical
-        # storage. Unrelated models are structural input and must follow the
-        # declaring model's enabled validation locations.
-        if payload_is_canonical:
-            prefer_aliases = False
-    if not isinstance(payload, Mapping):
-        return ()
-
-    field_name, *remaining = path
-    field_info = model.model_fields.get(field_name)
-    if field_info is None:
-        return ()
-    found, field_value = _declared_field_payload_value(
-        payload,
-        field_name=field_name,
-        field_info=field_info,
-        model_config=model.model_config,
-        prefer_aliases=prefer_aliases,
-    )
-    if not found:
-        return ()
-    if not remaining:
-        return (field_value,)
-    return _declared_payload_values_through_annotation(
-        field_value,
-        annotation=field_info.annotation,
-        path=tuple(remaining),
-        prefer_aliases=prefer_aliases,
-    )
-
-
-def _declared_payload_values_through_annotation(
+def _declared_payload_occurrences_at_path(
     payload: Any,
     *,
     annotation: Any,
     path: tuple[str, ...],
-    prefer_aliases: bool,
-) -> tuple[Any, ...]:
-    annotation = _unwrap_optional_annotated(annotation)
-    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-        return _declared_payload_values_at_path(
-            payload,
-            model=annotation,
-            path=path,
-            prefer_aliases=prefer_aliases,
-        )
-
-    element_annotation = _declared_collection_element(annotation)
-    if element_annotation is None or not isinstance(
-        payload,
-        list | tuple | set | frozenset,
+    prefer_aliases: bool = False,
+    conservative_structural_unions: bool = False,
+) -> tuple[tuple[Any, Any], ...]:
+    declared = _runtime_annotation_value(annotation)
+    declared_origin = get_origin(declared)
+    if conservative_structural_unions and (
+        isinstance(declared, TypeVar) or declared_origin in (Union, UnionType)
     ):
-        return ()
-    values: list[Any] = []
-    for item in payload:
-        values.extend(
-            _declared_payload_values_through_annotation(
-                item,
-                annotation=element_annotation,
+        candidates = (
+            _runtime_type_parameter_values(declared)
+            if isinstance(declared, TypeVar)
+            else tuple(candidate for candidate in get_args(declared) if candidate is not NoneType)
+        )
+        return tuple(
+            occurrence
+            for candidate in candidates
+            for occurrence in _declared_payload_occurrences_at_path(
+                payload,
+                annotation=candidate,
                 path=path,
                 prefer_aliases=prefer_aliases,
-            ),
+                conservative_structural_unions=True,
+            )
         )
-    return tuple(values)
+    selected = _declared_traversal_annotation(
+        annotation,
+        payload=payload,
+        path=path,
+    )
+    if selected is None:
+        return ()
+    if not path:
+        return ((payload, selected),)
+
+    items = _declared_collection_items(payload, annotation=selected)
+    if items is not None:
+        return tuple(
+            occurrence
+            for item, item_annotation in items
+            for occurrence in _declared_payload_occurrences_at_path(
+                item,
+                annotation=item_annotation,
+                path=path,
+                prefer_aliases=prefer_aliases,
+                conservative_structural_unions=conservative_structural_unions,
+            )
+        )
+
+    structure = _runtime_structural_fields(selected)
+    if structure is None:
+        return ()
+    kind, owner, field_annotations, _required_keys = structure
+    field_name, *remaining = path
+    field_annotation = field_annotations.get(field_name, _MISSING)
+    if field_annotation is _MISSING:
+        return ()
+
+    if kind == "model":
+        model = cast(type[BaseModel], owner)
+        payload_is_canonical = isinstance(payload, model)
+        if isinstance(payload, BaseModel):
+            payload = _extract_preflight_fields(
+                payload,
+                preserve_nested_models=True,
+            )
+            if payload_is_canonical:
+                prefer_aliases = False
+        if not isinstance(payload, Mapping):
+            return ()
+        field_info = model.model_fields[field_name]
+        found, field_value = _declared_field_payload_value(
+            payload,
+            field_name=field_name,
+            field_info=field_info,
+            model_config=model.model_config,
+            prefer_aliases=prefer_aliases,
+        )
+    elif isinstance(payload, Mapping):
+        config, alias_paths = _runtime_structural_validation_alias_paths(
+            kind=kind,
+            owner=owner,
+            field_name=field_name,
+            field_annotation=field_annotation,
+        )
+        access_path = _declared_payload_path_for_aliases(
+            payload,
+            field_name=field_name,
+            alias_paths=alias_paths,
+            model_config=config,
+            prefer_aliases=prefer_aliases,
+        )
+        found = access_path is not None
+        field_value = (
+            _payload_value_at_access_path(payload, access_path) if access_path is not None else None
+        )
+    else:
+        found, field_value = _runtime_structural_field_value(
+            payload,
+            kind=kind,
+            field_name=field_name,
+        )
+    if not found:
+        return ()
+    if not remaining:
+        return ((field_value, field_annotation),)
+    return _declared_payload_occurrences_at_path(
+        field_value,
+        annotation=field_annotation,
+        path=tuple(remaining),
+        prefer_aliases=prefer_aliases,
+        conservative_structural_unions=conservative_structural_unions,
+    )
 
 
 def _transform_declared_payload_at_path(
@@ -4002,29 +5284,32 @@ def _transform_declared_payload_through_annotation(
     path: tuple[str, ...],
     transform: Callable[[Any], Any],
 ) -> Any:
-    annotation = _unwrap_optional_annotated(annotation)
-    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+    selected = _declared_traversal_annotation(
+        annotation,
+        payload=payload,
+        path=path,
+    )
+    if selected is None:
+        return payload
+    if _is_runtime_base_model_type(selected):
         return _transform_declared_payload_at_path(
             payload,
-            model=annotation,
+            model=selected,
             path=path,
             transform=transform,
         )
 
-    element_annotation = _declared_collection_element(annotation)
-    if element_annotation is None or not isinstance(
-        payload,
-        list | tuple | set | frozenset,
-    ):
+    items = _declared_collection_items(payload, annotation=selected)
+    if items is None:
         return payload
     transformed_items = [
         _transform_declared_payload_through_annotation(
             item,
-            annotation=element_annotation,
+            annotation=item_annotation,
             path=path,
             transform=transform,
         )
-        for item in payload
+        for item, item_annotation in items
     ]
     if all(
         transformed is original
@@ -4048,14 +5333,91 @@ def _transform_declared_payload_through_annotation(
     return transformed_set
 
 
-def _declared_collection_element(annotation: Any) -> Any | None:
-    annotation = _unwrap_optional_annotated(annotation)
+def _declared_traversal_annotation(
+    annotation: Any,
+    *,
+    payload: Any,
+    path: tuple[str, ...],
+) -> Any | None:
+    normalized = _runtime_annotation_value(annotation)
+    origin = get_origin(normalized)
+    if isinstance(normalized, TypeVar):
+        candidates = _runtime_type_parameter_values(normalized)
+    elif origin in (Union, UnionType):
+        candidates = tuple(
+            candidate for candidate in get_args(normalized) if candidate is not NoneType
+        )
+    else:
+        return normalized
+    if not candidates:
+        return normalized
+
+    selected = _runtime_annotation_value(
+        _matching_declared_annotation(normalized, payload),
+    )
+    if not isinstance(selected, TypeVar) and get_origin(selected) not in (
+        Union,
+        UnionType,
+    ):
+        if _runtime_value_matches_annotation(payload, selected) or _annotation_declares_path(
+            selected,
+            path,
+        ):
+            return selected
+
+    path_candidates = tuple(
+        _runtime_annotation_value(candidate)
+        for candidate in candidates
+        if _annotation_declares_path(candidate, path)
+    )
+    if not path_candidates:
+        return selected
+    runtime_matches = tuple(
+        candidate
+        for candidate in path_candidates
+        if _runtime_value_matches_annotation(payload, candidate)
+    )
+    if runtime_matches:
+        return runtime_matches[0]
+    if isinstance(payload, Mapping):
+        model_candidate = next(
+            (candidate for candidate in path_candidates if _is_runtime_base_model_type(candidate)),
+            None,
+        )
+        if model_candidate is not None:
+            return model_candidate
+    if isinstance(payload, list | tuple | set | frozenset):
+        payload_kind = type(payload).__name__
+        collection_candidate = next(
+            (
+                candidate
+                for candidate in path_candidates
+                if _collection_kind(candidate) == payload_kind
+            ),
+            None,
+        )
+        if collection_candidate is not None:
+            return collection_candidate
+        return path_candidates[0]
+    return selected
+
+
+def _declared_collection_items(
+    payload: Any,
+    *,
+    annotation: Any,
+) -> tuple[tuple[Any, Any], ...] | None:
+    if not isinstance(payload, list | tuple | set | frozenset):
+        return None
+    annotation = _runtime_annotation_value(annotation)
     if _collection_kind(annotation) is None:
         return None
-    arguments = tuple(argument for argument in get_args(annotation) if argument is not Ellipsis)
-    if not arguments:
-        return None
-    return _unwrap_optional_annotated(arguments[0])
+    values = tuple(payload)
+    arguments = get_args(annotation)
+    if get_origin(annotation) is tuple and arguments and arguments[-1] is not Ellipsis:
+        return tuple(zip(values, arguments, strict=False))
+    item_annotation = arguments[0] if arguments else Any
+    return tuple((item, item_annotation) for item in values)
 
 
 def _declared_field_payload_value(
@@ -4086,18 +5448,42 @@ def _declared_field_payload_path(
     model_config: Mapping[str, Any],
     prefer_aliases: bool,
 ) -> tuple[Any, ...] | None:
+    return _declared_payload_path_for_aliases(
+        payload,
+        field_name=field_name,
+        alias_paths=_alias_paths(
+            field_info.validation_alias,
+            fallback=field_info.alias,
+        ),
+        model_config=model_config,
+        prefer_aliases=prefer_aliases,
+    )
+
+
+def _declared_payload_path_for_aliases(
+    payload: Mapping[Any, Any],
+    *,
+    field_name: str,
+    alias_paths: tuple[tuple[Any, ...], ...],
+    model_config: Mapping[str, Any],
+    prefer_aliases: bool,
+) -> tuple[Any, ...] | None:
     if prefer_aliases:
-        validation_aliases = _field_alias_paths(field_info)
-        if not validation_aliases:
+        if not alias_paths:
             # An unaliased field is always accepted by its field name, even
             # when validate_by_name is otherwise disabled for aliased fields.
             candidates = ((field_name,),)
         else:
             aliases_enabled = model_config.get("validate_by_alias", True) is not False
-            names_enabled = model_config.get("validate_by_name", False) is True
+            configured_names = model_config.get("validate_by_name", _MISSING)
+            names_enabled = (
+                configured_names is True
+                if configured_names is not _MISSING
+                else model_config.get("populate_by_name", False) is True or not aliases_enabled
+            )
             name_candidates = ((field_name,),) if names_enabled else ()
             candidates = (
-                *(validation_aliases if aliases_enabled else ()),
+                *(alias_paths if aliases_enabled else ()),
                 *name_candidates,
             )
     else:
@@ -4283,7 +5669,10 @@ def _normalize_payload_field_aliases(
 ) -> dict[str, Any]:
     normalized = {key: _copy_alias_payload_value(value) for key, value in payload.items()}
     for name, field_info in model_cls.model_fields.items():
-        alias_paths = _field_alias_paths(field_info)
+        alias_paths = _alias_paths(
+            field_info.validation_alias,
+            fallback=field_info.alias,
+        )
         if name in normalized:
             if prefer_aliases:
                 value = normalized[name]
@@ -4321,29 +5710,11 @@ def _copy_alias_payload_value(value: Any) -> Any:
     return value
 
 
-def _field_alias_paths(field_info: Any) -> tuple[tuple[Any, ...], ...]:
-    validation_alias = field_info.validation_alias
-    if validation_alias is None:
-        return _alias_path(field_info.alias)
-    if isinstance(validation_alias, str):
-        return ((validation_alias,),)
-    if isinstance(validation_alias, AliasChoices):
-        return tuple(path for choice in validation_alias.choices for path in _alias_path(choice))
-    if isinstance(validation_alias, AliasPath):
-        return (tuple(validation_alias.path),)
-    return ()
-
-
-def _alias_path(alias: Any) -> tuple[tuple[Any, ...], ...]:
-    if isinstance(alias, str):
-        return ((alias,),)
-    if isinstance(alias, AliasPath):
-        return (tuple(alias.path),)
-    return ()
-
-
 def _next_alias_path(field_info: Any) -> tuple[Any, ...] | None:
-    paths = _field_alias_paths(field_info)
+    paths = _alias_paths(
+        field_info.validation_alias,
+        fallback=field_info.alias,
+    )
     for path in paths:
         if path:
             return path

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -6,6 +6,8 @@ from collections.abc import Iterable, Mapping, Sequence
 from copy import copy, deepcopy
 from dataclasses import dataclass, is_dataclass
 from dataclasses import field as dataclass_field
+from dataclasses import fields as dataclass_fields
+from enum import Enum
 from functools import reduce
 from operator import or_
 from types import GenericAlias, MemberDescriptorType, UnionType
@@ -16,11 +18,13 @@ from typing import (
     ClassVar,
     ForwardRef,
     Literal,
+    Never,
     TypeVar,
     Union,
     cast,
     get_args,
     get_origin,
+    get_type_hints,
     is_typeddict,
 )
 from typing import (
@@ -41,6 +45,7 @@ from pydantic import (
     WithJsonSchema,
     create_model,
 )
+from pydantic.fields import FieldInfo
 from pydantic.functional_serializers import PlainSerializer, SerializeAsAny, WrapSerializer
 from pydantic.functional_validators import (
     AfterValidator,
@@ -49,7 +54,9 @@ from pydantic.functional_validators import (
     WrapValidator,
 )
 from pydantic_core import CoreSchema, PydanticUndefined, core_schema
+from typing_extensions import NoExtraItems
 from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
+from typing_extensions import is_typeddict as extensions_is_typeddict
 
 from pydantic_versions._compiler import (
     _CompiledDecoratorNestedFamily,
@@ -77,6 +84,23 @@ _SCHEMA_HOOK_NAMES = (
 _MISSING = object()
 _DOCUMENT_BODY_SLOT = "_FamilyDocumentAdapterBase__document_body"
 _SERIALIZE_AS_ANY_METADATA_TYPE = type(cast(Any, SerializeAsAny)())
+_MANAGED_FIELD_CONTRACT_ATTRIBUTES = (
+    "alias",
+    "exclude",
+    "exclude_if",
+    "validation_alias",
+    "serialization_alias",
+)
+_HOMOGENEOUS_COLLECTION_POSITIONS = frozenset(
+    {"frozenset:item", "list:item", "set:item", "tuple:item"},
+)
+
+type _DataclassManagedShape = tuple[
+    Literal["dataclass"],
+    type[Any],
+    tuple[Any, ...],
+]
+type _ManagedAnnotationShape = Literal["mapping_enum", "structural"] | _DataclassManagedShape
 
 _MODEL_SCHEMA_STRUCTURE_KEYS = frozenset(
     {
@@ -1789,12 +1813,8 @@ def _type_parameter_values(parameter: Any) -> tuple[Any, ...]:
     if bound is not None:
         values.append(bound)
     values.extend(getattr(parameter, "__constraints__", ()))
-    default = getattr(parameter, "__default__", None)
-    default_type = type(default)
-    if default is not None and not (
-        default_type.__module__ in ("typing", "typing_extensions")
-        and "NoDefault" in default_type.__name__
-    ):
+    default = _type_parameter_default(parameter)
+    if default is not _MISSING:
         values.append(default)
     return tuple(values)
 
@@ -2277,9 +2297,425 @@ def _record_core_schema_output_name(
     selected[output_name] = description
 
 
-def _model_has_model_serializer(model: type[BaseModel]) -> bool:
+def _model_has_model_serializer(model: type[Any]) -> bool:
     decorators = getattr(model, "__pydantic_decorators__", None)
-    return bool(decorators is not None and getattr(decorators, "model_serializers", None))
+    if decorators is not None and getattr(decorators, "model_serializers", None):
+        return True
+    return any(
+        _pydantic_decorator_info_kind(value) == "ModelSerializerDecoratorInfo"
+        for value in _effective_static_class_values(model)
+    )
+
+
+def _pydantic_decorator_info_kind(value: Any) -> str | None:
+    """Return the stable Pydantic decorator-info kind without importing internals."""
+    info = _instance_dict(value).get("decorator_info")
+    info_type = type(info)
+    if not info_type.__module__.startswith("pydantic."):
+        return None
+    return info_type.__name__
+
+
+def _effective_static_class_values(owner: type[Any]) -> tuple[Any, ...]:
+    return tuple(value for _name, value in _effective_static_class_items(owner))
+
+
+def _effective_static_class_items(owner: type[Any]) -> tuple[tuple[str, Any], ...]:
+    selected: dict[str, Any] = {}
+    for candidate in _static_mro(owner):
+        for name, value in _instance_dict(candidate).items():
+            selected.setdefault(name, value)
+    return tuple(selected.items())
+
+
+def _is_typed_dict(annotation: Any) -> bool:
+    return is_typeddict(annotation) or extensions_is_typeddict(annotation)
+
+
+def _typed_dict_origin(annotation: Any) -> type[Any] | None:
+    if _is_typed_dict(annotation):
+        return cast(type[Any], annotation)
+    origin = get_origin(annotation)
+    if _is_typed_dict(origin):
+        return cast(type[Any], origin)
+    return None
+
+
+def _annotation_type_parameters(annotation: Any) -> tuple[Any, ...]:
+    parameters = getattr(annotation, "__type_params__", None)
+    if not parameters:
+        parameters = getattr(annotation, "__parameters__", ())
+    return tuple(parameters)
+
+
+def _type_parameter_default(parameter: Any) -> Any:
+    default = getattr(parameter, "__default__", _MISSING)
+    default_type = type(default)
+    no_default = "NoDefault" in default_type.__name__ and repr(default) in (
+        "typing.NoDefault",
+        "typing_extensions.NoDefault",
+    )
+    if default is not _MISSING and not no_default:
+        return default
+    return _MISSING
+
+
+def _is_typed_dict_field_qualifier(origin: Any) -> bool:
+    return getattr(origin, "__module__", None) in ("typing", "typing_extensions") and getattr(
+        origin, "_name", None
+    ) in ("NotRequired", "ReadOnly", "Required")
+
+
+def _is_no_extra_items(value: Any) -> bool:
+    if value is NoExtraItems:
+        return True
+    value_type = type(value)
+    return (
+        value_type.__module__ in ("typing", "typing_extensions")
+        and value_type.__name__.lstrip("_") == "NoExtraItemsType"
+    )
+
+
+def _bound_annotation_parameters(
+    annotation: Any,
+    *,
+    inherited: Mapping[Any, Any],
+) -> dict[Any, Any]:
+    origin = get_origin(annotation)
+    target = annotation if origin is None else origin
+    parameters = _annotation_type_parameters(target)
+    arguments = get_args(annotation)
+    bindings = {
+        **inherited,
+        **dict(zip(parameters, arguments, strict=False)),
+    }
+    for parameter in parameters[len(arguments) :]:
+        default = _type_parameter_default(parameter)
+        if default is not _MISSING:
+            bindings[parameter] = default
+    return bindings
+
+
+def _managed_alternative_shape_positions(
+    annotations: tuple[Any, ...],
+    *,
+    type_parameters: Mapping[Any, Any],
+) -> dict[tuple[str, ...], list[_ManagedAnnotationShape]]:
+    return _merge_managed_shape_positions(
+        *(
+            _managed_annotation_shape_positions(
+                annotation,
+                type_parameters=type_parameters,
+                path=(),
+                seen=set(),
+            )
+            for annotation in annotations
+        ),
+    )
+
+
+def _mapping_enum_structural_ambiguity(
+    shapes_by_position: Mapping[tuple[str, ...], Sequence[_ManagedAnnotationShape]],
+) -> bool:
+    enum_positions: set[tuple[str, ...]] = set()
+    structural_positions: set[tuple[str, ...]] = set()
+    for position, shapes in shapes_by_position.items():
+        if "mapping_enum" in shapes:
+            enum_positions.add(position)
+        if "structural" in shapes:
+            structural_positions.add(position)
+    return any(
+        _managed_shape_positions_overlap(enum_position, structural_position)
+        for enum_position in enum_positions
+        for structural_position in structural_positions
+    )
+
+
+def _dataclass_parameterization_ambiguity(
+    shapes_by_position: Mapping[tuple[str, ...], Sequence[_ManagedAnnotationShape]],
+) -> bool:
+    parameterizations: list[tuple[tuple[str, ...], type[Any], tuple[Any, ...]]] = []
+    for position, shapes in shapes_by_position.items():
+        parameterizations.extend(
+            (position, shape[1], shape[2])
+            for shape in shapes
+            if isinstance(shape, tuple) and shape[0] == "dataclass"
+        )
+    return any(
+        left_origin is right_origin
+        and left_bindings != right_bindings
+        and _managed_shape_positions_overlap(left_position, right_position)
+        for index, (left_position, left_origin, left_bindings) in enumerate(parameterizations)
+        for right_position, right_origin, right_bindings in parameterizations[index + 1 :]
+    )
+
+
+def _managed_shape_positions_overlap(
+    left: tuple[str, ...],
+    right: tuple[str, ...],
+) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(
+        left_component == right_component
+        or _coercible_collection_item_positions(left_component, right_component)
+        for left_component, right_component in zip(left, right, strict=True)
+    )
+
+
+def _coercible_collection_item_positions(left: str, right: str) -> bool:
+    left_fixed = left.removeprefix("tuple:").isdigit()
+    right_fixed = right.removeprefix("tuple:").isdigit()
+    return not (left_fixed and right_fixed) and (
+        (left in _HOMOGENEOUS_COLLECTION_POSITIONS or left_fixed)
+        and (right in _HOMOGENEOUS_COLLECTION_POSITIONS or right_fixed)
+    )
+
+
+def _managed_annotation_shape_positions(
+    annotation: Any,
+    *,
+    type_parameters: Mapping[Any, Any],
+    path: tuple[str, ...],
+    seen: set[tuple[int, tuple[tuple[int, int], ...]]],
+) -> dict[tuple[str, ...], list[_ManagedAnnotationShape]]:
+    visit_key = (
+        id(annotation),
+        tuple(sorted((id(key), id(value)) for key, value in type_parameters.items())),
+    )
+    if visit_key in seen:
+        return {}
+    seen = {*seen, visit_key}
+
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        return _managed_annotation_shape_positions(
+            annotation.__value__,
+            type_parameters=type_parameters,
+            path=path,
+            seen=seen,
+        )
+    if isinstance(annotation, TypeVar):
+        resolved = type_parameters.get(annotation, _MISSING)
+        values = _type_parameter_values(annotation) if resolved is _MISSING else (resolved,)
+        return _merge_managed_shape_positions(
+            *(
+                _managed_annotation_shape_positions(
+                    value,
+                    type_parameters=type_parameters,
+                    path=path,
+                    seen=seen,
+                )
+                for value in values
+            ),
+        )
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        return _managed_annotation_shape_positions(
+            supertype,
+            type_parameters=type_parameters,
+            path=path,
+            seen=seen,
+        )
+
+    origin = get_origin(annotation)
+    arguments = get_args(annotation)
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        return _managed_annotation_shape_positions(
+            origin.__value__,
+            type_parameters=_bound_annotation_parameters(
+                annotation,
+                inherited=type_parameters,
+            ),
+            path=path,
+            seen=seen,
+        )
+    if origin is Annotated or _is_typed_dict_field_qualifier(origin):
+        return _managed_annotation_shape_positions(
+            arguments[0],
+            type_parameters=type_parameters,
+            path=path,
+            seen=seen,
+        )
+    if origin in (Union, UnionType):
+        return _merge_managed_shape_positions(
+            *(
+                _managed_annotation_shape_positions(
+                    argument,
+                    type_parameters=type_parameters,
+                    path=path,
+                    seen=seen,
+                )
+                for argument in arguments
+            ),
+        )
+    if origin in (list, set, frozenset) and arguments:
+        return _managed_annotation_shape_positions(
+            arguments[0],
+            type_parameters=type_parameters,
+            path=(*path, f"{origin.__name__}:item"),
+            seen=seen,
+        )
+    if origin is tuple and arguments:
+        if arguments[-1] is Ellipsis:
+            tuple_items = (("tuple:item", arguments[0]),)
+        else:
+            tuple_items = tuple(
+                (f"tuple:{index}", argument) for index, argument in enumerate(arguments)
+            )
+        return _merge_managed_shape_positions(
+            *(
+                _managed_annotation_shape_positions(
+                    argument,
+                    type_parameters=type_parameters,
+                    path=(*path, component),
+                    seen=seen,
+                )
+                for component, argument in tuple_items
+            ),
+        )
+
+    if origin is Literal:
+        if any(
+            isinstance(value, Enum) and isinstance(getattr(value, "_value_", None), Mapping)
+            for value in arguments
+        ):
+            return {path: ["mapping_enum"]}
+        return {}
+    runtime_type = origin if isinstance(origin, type) else annotation
+    if _is_mapping_valued_enum(runtime_type):
+        return {path: ["mapping_enum"]}
+    typed_dict_target = _typed_dict_origin(annotation)
+    if typed_dict_target is not None:
+        try:
+            typed_dict_fields = get_type_hints(typed_dict_target, include_extras=True)
+        except (AttributeError, NameError, TypeError):
+            return {path: ["structural"]}
+        bindings = _bound_annotation_parameters(
+            annotation,
+            inherited=type_parameters,
+        )
+        return _merge_managed_shape_positions(
+            {path: ["structural"]},
+            *(
+                _managed_annotation_shape_positions(
+                    field_annotation,
+                    type_parameters=bindings,
+                    path=(*path, f"typed_dict:{field_name}"),
+                    seen=seen,
+                )
+                for field_name, field_annotation in typed_dict_fields.items()
+            ),
+        )
+    if isinstance(runtime_type, type) and is_dataclass(runtime_type):
+        bindings = _bound_annotation_parameters(
+            annotation,
+            inherited=type_parameters,
+        )
+        parameterization = tuple(
+            _managed_binding_identity(
+                bindings.get(parameter, parameter),
+                type_parameters=bindings,
+                seen=set(),
+            )
+            for parameter in _annotation_type_parameters(runtime_type)
+        )
+        return {
+            path: [
+                "structural",
+                ("dataclass", runtime_type, parameterization),
+            ],
+        }
+    if isinstance(runtime_type, type) and issubclass(runtime_type, BaseModel):
+        return {path: ["structural"]}
+    return {}
+
+
+def _managed_binding_identity(
+    annotation: Any,
+    *,
+    type_parameters: Mapping[Any, Any],
+    seen: set[int],
+) -> Any:
+    annotation_id = id(annotation)
+    if annotation_id in seen:
+        return annotation
+    visited = {*seen, annotation_id}
+
+    if isinstance(annotation, TypeVar):
+        resolved = type_parameters.get(annotation, _MISSING)
+        if resolved is _MISSING or resolved is annotation:
+            return annotation
+        return _managed_binding_identity(
+            resolved,
+            type_parameters=type_parameters,
+            seen=visited,
+        )
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        return _managed_binding_identity(
+            annotation.__value__,
+            type_parameters=type_parameters,
+            seen=visited,
+        )
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        return _managed_binding_identity(
+            supertype,
+            type_parameters=type_parameters,
+            seen=visited,
+        )
+
+    origin = get_origin(annotation)
+    arguments = get_args(annotation)
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        return _managed_binding_identity(
+            origin.__value__,
+            type_parameters=_bound_annotation_parameters(
+                annotation,
+                inherited=type_parameters,
+            ),
+            seen=visited,
+        )
+    if origin is Annotated or _is_typed_dict_field_qualifier(origin):
+        return _managed_binding_identity(
+            arguments[0],
+            type_parameters=type_parameters,
+            seen=visited,
+        )
+    if origin is None or not arguments or origin is Literal:
+        return annotation
+    return (
+        origin,
+        tuple(
+            argument
+            if argument is Ellipsis
+            else _managed_binding_identity(
+                argument,
+                type_parameters=type_parameters,
+                seen=visited,
+            )
+            for argument in arguments
+        ),
+    )
+
+
+def _merge_managed_shape_positions(
+    *sources: Mapping[tuple[str, ...], Sequence[_ManagedAnnotationShape]],
+) -> dict[tuple[str, ...], list[_ManagedAnnotationShape]]:
+    merged: dict[tuple[str, ...], list[_ManagedAnnotationShape]] = {}
+    for source in sources:
+        for position, shapes in source.items():
+            selected = merged.setdefault(position, [])
+            selected.extend(shape for shape in shapes if shape not in selected)
+    return merged
+
+
+def _is_mapping_valued_enum(annotation: Any) -> bool:
+    if not isinstance(annotation, type) or not issubclass(annotation, Enum):
+        return False
+    return any(
+        isinstance(getattr(member, "_value_", None), Mapping)
+        for member in annotation.__members__.values()
+    )
 
 
 def _validate_explicit_nested_serializer_boundaries(
@@ -2325,14 +2761,29 @@ def _validate_explicit_nested_serializer_boundaries(
                     )
                 field_info = owner.model_fields.get(field_name)
                 if field_info is None:
+                    _validate_omitted_explicit_managed_path_output(
+                        family,
+                        projection,
+                        owner=owner,
+                        field_name=field_name,
+                        route_path=route.path,
+                    )
                     continue
-                if _model_has_field_serializer(owner, field_name):
+                if _owner_has_field_serializer(owner, field_name):
                     _raise_projection_unsupported(
                         family,
                         projection,
                         f"explicit wire model {_model_display(owner)!r} serializes field "
                         f"{field_name!r} along declared nested path {route.path!r}; "
                         "serializers can relocate child document paths",
+                    )
+                if _field_has_serialization_exclusion(field_info):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(owner)!r} excludes field "
+                        f"{field_name!r} along declared nested path {route.path!r}; "
+                        "managed child document paths must always be serialized",
                     )
                 if _field_has_functional_serializer(field_info):
                     _raise_projection_unsupported(
@@ -2343,30 +2794,776 @@ def _validate_explicit_nested_serializer_boundaries(
                         f"declared nested path {route.path!r}; serializers can relocate "
                         "child document paths",
                     )
+                _validate_explicit_managed_path_annotation(
+                    family,
+                    projection,
+                    owner=owner,
+                    field_name=field_name,
+                    annotation=field_info.annotation,
+                    route_path=route.path,
+                    leaf=index == len(target_path) - 1,
+                    represented_family=(route.family if index == len(target_path) - 1 else None),
+                    represented_label=(
+                        route.child_label(projection.label)
+                        if index == len(target_path) - 1
+                        else None
+                    ),
+                )
                 if index == len(target_path) - 1:
                     continue
-                _collect_immediate_base_models(
+                next_representations: list[tuple[type[Any], Mapping[Any, Any]]] = []
+                _collect_immediate_base_model_representations(
                     field_info.annotation,
+                    models=next_representations,
+                    seen=set(),
+                    type_parameters={},
+                )
+                next_owners.extend(model for model, _parameters in next_representations)
+            owners = next_owners
+
+
+def _validate_omitted_explicit_managed_path_output(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    owner: type[BaseModel],
+    field_name: str,
+    route_path: tuple[str, ...],
+) -> None:
+    for candidate_name, field_info in owner.model_fields.items():
+        if any(
+            path and path[0] == field_name
+            for path in _field_contract_paths(candidate_name, field_info)
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"explicit wire model {_model_display(owner)!r} treats declared "
+                f"nested path {route_path!r} as omitted, but field "
+                f"{candidate_name!r} occupies managed component {field_name!r} "
+                "through an alias",
+            )
+    for candidate_name, field_info in owner.model_computed_fields.items():
+        if any(
+            path and path[0] == field_name
+            for path in _computed_field_output_paths(candidate_name, field_info)
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"explicit wire model {_model_display(owner)!r} treats declared "
+                f"nested path {route_path!r} as omitted, but computed field "
+                f"{candidate_name!r} serializes at managed component "
+                f"{field_name!r}",
+            )
+
+
+def _validate_structural_representation_nested_boundaries(
+    family: SchemaFamily[Any],
+    label: str,
+    *,
+    owner: type[Any],
+    type_parameters: Mapping[Any, Any],
+) -> None:
+    compiled = family._compiled_family()
+    nested = compiled.nested
+    if not nested:
+        return
+    projection = compiled.version(label).projection
+
+    for route in nested:
+        first = cast(str, projection.field(route.path[0]).version_name)
+        target_path = (first, *route.path[1:])
+        owners: list[tuple[type[Any], Mapping[Any, Any]]] = [
+            (owner, type_parameters),
+        ]
+        for index, field_name in enumerate(target_path):
+            next_owners: list[tuple[type[Any], Mapping[Any, Any]]] = []
+            for structural_owner, parameters in owners:
+                _validate_structural_owner_serialization(
+                    family,
+                    projection,
+                    owner=structural_owner,
+                    route_path=route.path,
+                )
+                fields = _structural_field_annotations(
+                    family,
+                    projection,
+                    owner=structural_owner,
+                    route_path=route.path,
+                )
+                field = fields.get(field_name)
+                if field is None:
+                    _validate_omitted_structural_managed_path_output(
+                        family,
+                        projection,
+                        owner=structural_owner,
+                        fields=fields,
+                        field_name=field_name,
+                        route_path=route.path,
+                    )
+                    continue
+                annotation, field_info = field
+                if _owner_has_field_serializer(structural_owner, field_name):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(structural_owner)!r} "
+                        f"serializes field {field_name!r} along declared nested path "
+                        f"{route.path!r}; serializers can relocate child document paths",
+                    )
+                if _field_has_serialization_exclusion(field_info):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(structural_owner)!r} "
+                        f"excludes field {field_name!r} along declared nested path "
+                        f"{route.path!r}; managed child document paths must always "
+                        "be serialized",
+                    )
+                if _annotation_has_functional_serializer(
+                    annotation,
+                    seen=set(),
+                    type_parameters=parameters,
+                ) or (
+                    field_info is not None
+                    and any(
+                        _metadata_has_unsafe_nested_serialization(item)
+                        for item in getattr(field_info, "metadata", ())
+                    )
+                ):
+                    _raise_projection_unsupported(
+                        family,
+                        projection,
+                        f"explicit wire model {_model_display(structural_owner)!r} uses "
+                        f"an annotation-level serializer on field {field_name!r} along "
+                        f"declared nested path {route.path!r}; serializers can relocate "
+                        "child document paths",
+                    )
+                leaf = index == len(target_path) - 1
+                _validate_explicit_managed_path_annotation(
+                    family,
+                    projection,
+                    owner=structural_owner,
+                    field_name=field_name,
+                    annotation=annotation,
+                    route_path=route.path,
+                    leaf=leaf,
+                    represented_family=route.family if leaf else None,
+                    represented_label=route.child_label(label) if leaf else None,
+                    type_parameters=parameters,
+                )
+                if leaf:
+                    continue
+                _collect_immediate_base_model_representations(
+                    annotation,
                     models=next_owners,
                     seen=set(),
+                    type_parameters=parameters,
                 )
             owners = next_owners
 
 
-def _annotation_has_functional_serializer(annotation: Any, *, seen: set[int]) -> bool:
-    if id(annotation) in seen:
-        return False
-    seen.add(id(annotation))
+def _validate_structural_owner_serialization(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    owner: type[Any],
+    route_path: tuple[str, ...],
+) -> None:
+    config = getattr(owner, "model_config", None)
+    if not isinstance(config, Mapping):
+        config = getattr(owner, "__pydantic_config__", None)
+    if isinstance(config, Mapping) and config.get("json_encoders"):
+        _raise_projection_unsupported(
+            family,
+            projection,
+            f"explicit wire model {_model_display(owner)!r} configures json_encoders "
+            f"along declared nested path {route_path!r}; custom encoders can replace "
+            "child document values",
+        )
+    if (
+        isinstance(config, Mapping)
+        and config.get("alias_generator") is not None
+        and not isinstance(getattr(owner, "__pydantic_fields__", None), Mapping)
+    ):
+        _raise_projection_unsupported(
+            family,
+            projection,
+            f"explicit wire model {_model_display(owner)!r} configures an "
+            f"unmaterialized alias_generator along declared nested path "
+            f"{route_path!r}; generated aliases cannot be inspected without "
+            "executing user code again",
+        )
+
+
+def _structural_field_annotations(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    owner: type[Any],
+    route_path: tuple[str, ...],
+) -> dict[str, tuple[Any, Any | None]]:
+    if isinstance(owner, type) and issubclass(owner, BaseModel):
+        return {
+            name: (field_info.annotation, field_info)
+            for name, field_info in owner.model_fields.items()
+        }
+    try:
+        hints = get_type_hints(owner, include_extras=True)
+    except (AttributeError, NameError, TypeError):
+        _raise_projection_unsupported(
+            family,
+            projection,
+            f"explicit wire model {_model_display(owner)!r} has unresolved field "
+            f"annotations along declared nested path {route_path!r}",
+        )
+    pydantic_fields = getattr(owner, "__pydantic_fields__", None)
+    stdlib_dataclass_fields = (
+        {field.name: field for field in dataclass_fields(owner)} if is_dataclass(owner) else {}
+    )
+    return {
+        name: (
+            annotation,
+            (
+                pydantic_fields.get(name)
+                if isinstance(pydantic_fields, Mapping)
+                else _stdlib_dataclass_field_info(
+                    stdlib_dataclass_fields.get(name),
+                    annotation=annotation,
+                )
+            ),
+        )
+        for name, annotation in hints.items()
+    }
+
+
+def _stdlib_dataclass_field_info(field: Any, *, annotation: Any) -> Any | None:
+    metadata = getattr(field, "metadata", {}) or {}
+    metadata_values = {
+        attribute: metadata[attribute]
+        for attribute in _MANAGED_FIELD_CONTRACT_ATTRIBUTES
+        if attribute in metadata
+    }
+    candidates = [
+        _annotation_field_info(annotation),
+        Field(**metadata_values) if metadata_values else None,
+        None if field is None else field.default,
+    ]
+    return _merge_contract_field_infos(*candidates)
+
+
+def _annotation_field_info(annotation: Any) -> Any | None:
+    origin = get_origin(annotation)
+    if _is_typed_dict_field_qualifier(origin):
+        return _annotation_field_info(get_args(annotation)[0])
+    if origin is not Annotated:
+        return None
+    return _merge_contract_field_infos(*get_args(annotation)[1:])
+
+
+def _merge_contract_field_infos(*candidates: Any) -> FieldInfo | None:
+    selected: dict[str, Any] = {}
+    for candidate in candidates:
+        if not isinstance(candidate, FieldInfo):
+            continue
+        explicit = getattr(candidate, "_attributes_set", {})
+        for attribute in _MANAGED_FIELD_CONTRACT_ATTRIBUTES:
+            if attribute in explicit:
+                selected[attribute] = getattr(candidate, attribute)
+    if not selected:
+        return None
+    return Field(**selected)
+
+
+def _validate_omitted_structural_managed_path_output(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    owner: type[Any],
+    fields: Mapping[str, tuple[Any, Any | None]],
+    field_name: str,
+    route_path: tuple[str, ...],
+) -> None:
+    for candidate_name, (_annotation, field_info) in fields.items():
+        paths = (
+            ((candidate_name,),)
+            if field_info is None
+            else _field_contract_paths(candidate_name, field_info)
+        )
+        if any(path and path[0] == field_name for path in paths):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"explicit wire model {_model_display(owner)!r} treats declared "
+                f"nested path {route_path!r} as omitted, but field "
+                f"{candidate_name!r} occupies managed component {field_name!r} "
+                "through an alias",
+            )
+    for candidate_name, field_info in _structured_computed_fields(owner).items():
+        if any(
+            path and path[0] == field_name
+            for path in _computed_field_output_paths(candidate_name, field_info)
+        ):
+            _raise_projection_unsupported(
+                family,
+                projection,
+                f"explicit wire model {_model_display(owner)!r} treats declared "
+                f"nested path {route_path!r} as omitted, but computed field "
+                f"{candidate_name!r} serializes at managed component "
+                f"{field_name!r}",
+            )
+
+
+def _structured_computed_fields(owner: type[Any]) -> dict[str, Any]:
+    computed = getattr(owner, "model_computed_fields", None)
+    if isinstance(computed, Mapping):
+        return dict(computed)
+    decorators = getattr(owner, "__pydantic_decorators__", None)
+    decorated = None if decorators is None else getattr(decorators, "computed_fields", None)
+    if isinstance(decorated, Mapping):
+        return {name: decorator.info for name, decorator in decorated.items()}
+    return {
+        name: _instance_dict(value)["decorator_info"]
+        for name, value in _effective_static_class_items(owner)
+        if _pydantic_decorator_info_kind(value) == "ComputedFieldInfo"
+    }
+
+
+def _validate_explicit_managed_path_annotation(
+    family: SchemaFamily[Any],
+    projection: _VersionProjection,
+    *,
+    owner: type[Any],
+    field_name: str,
+    annotation: Any,
+    route_path: tuple[str, ...],
+    leaf: bool,
+    represented_family: SchemaFamily[Any] | None = None,
+    represented_label: str | None = None,
+    type_parameters: Mapping[Any, Any] | None = None,
+    seen: set[tuple[int, bool, tuple[tuple[int, int], ...]]] | None = None,
+) -> None:
+    parameters = {} if type_parameters is None else type_parameters
+    visit_key = (
+        id(annotation),
+        leaf,
+        tuple(sorted((id(key), id(value)) for key, value in parameters.items())),
+    )
+    visited = set() if seen is None else seen
+    if visit_key in visited:
+        return
+    visited.add(visit_key)
+
+    def reject(detail: str) -> None:
+        _raise_projection_unsupported(
+            family,
+            projection,
+            f"explicit wire model {_model_display(owner)!r} field {field_name!r} "
+            f"along declared nested path {route_path!r} {detail}",
+        )
+
+    if annotation is Any or annotation is object:
+        reject(
+            "uses a broad annotation; explicit managed paths require a shape-preserving annotation",
+        )
+
+    if isinstance(annotation, str | ForwardRef):
+        reject("has an unresolved annotation")
+
     if isinstance(annotation, _TYPE_ALIAS_TYPES):
-        return _annotation_has_functional_serializer(annotation.__value__, seen=seen)
+        _validate_explicit_managed_path_annotation(
+            family,
+            projection,
+            owner=owner,
+            field_name=field_name,
+            annotation=annotation.__value__,
+            route_path=route_path,
+            leaf=leaf,
+            represented_family=represented_family,
+            represented_label=represented_label,
+            type_parameters=parameters,
+            seen=visited,
+        )
+        return
+
+    if isinstance(annotation, TypeVar):
+        resolved = parameters.get(annotation, _MISSING)
+        if resolved is not _MISSING:
+            _validate_explicit_managed_path_annotation(
+                family,
+                projection,
+                owner=owner,
+                field_name=field_name,
+                annotation=resolved,
+                route_path=route_path,
+                leaf=leaf,
+                represented_family=represented_family,
+                represented_label=represented_label,
+                type_parameters=parameters,
+                seen=visited,
+            )
+            return
+        values = _type_parameter_values(annotation)
+        if not values:
+            reject("uses an unresolved type parameter")
+        alternative_shapes = _managed_alternative_shape_positions(
+            values,
+            type_parameters=parameters,
+        )
+        if _mapping_enum_structural_ambiguity(alternative_shapes):
+            reject(
+                "combines an object-shaped Enum scalar with a structural "
+                "representation at the same traversal position; runtime "
+                "validation cannot identify the authoritative branch",
+            )
+        if _dataclass_parameterization_ambiguity(alternative_shapes):
+            reject(
+                "uses multiple parameterizations of the same dataclass origin "
+                "at overlapping traversal positions; runtime values cannot "
+                "identify the authoritative branch",
+            )
+        for value in values:
+            _validate_explicit_managed_path_annotation(
+                family,
+                projection,
+                owner=owner,
+                field_name=field_name,
+                annotation=value,
+                route_path=route_path,
+                leaf=leaf,
+                represented_family=represented_family,
+                represented_label=represented_label,
+                type_parameters=parameters,
+                seen=visited,
+            )
+        return
+
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        _validate_explicit_managed_path_annotation(
+            family,
+            projection,
+            owner=owner,
+            field_name=field_name,
+            annotation=supertype,
+            route_path=route_path,
+            leaf=leaf,
+            represented_family=represented_family,
+            represented_label=represented_label,
+            type_parameters=parameters,
+            seen=visited,
+        )
+        return
+
+    origin = get_origin(annotation)
     arguments = get_args(annotation)
-    if get_origin(annotation) is Annotated:
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        bindings = _bound_annotation_parameters(
+            annotation,
+            inherited=parameters,
+        )
+        _validate_explicit_managed_path_annotation(
+            family,
+            projection,
+            owner=owner,
+            field_name=field_name,
+            annotation=origin.__value__,
+            route_path=route_path,
+            leaf=leaf,
+            represented_family=represented_family,
+            represented_label=represented_label,
+            type_parameters=bindings,
+            seen=visited,
+        )
+        return
+
+    if origin is Annotated:
+        _validate_explicit_managed_path_annotation(
+            family,
+            projection,
+            owner=owner,
+            field_name=field_name,
+            annotation=arguments[0],
+            route_path=route_path,
+            leaf=leaf,
+            represented_family=represented_family,
+            represented_label=represented_label,
+            type_parameters=parameters,
+            seen=visited,
+        )
+        return
+
+    if _is_typed_dict_field_qualifier(origin):
+        _validate_explicit_managed_path_annotation(
+            family,
+            projection,
+            owner=owner,
+            field_name=field_name,
+            annotation=arguments[0],
+            route_path=route_path,
+            leaf=leaf,
+            represented_family=represented_family,
+            represented_label=represented_label,
+            type_parameters=parameters,
+            seen=visited,
+        )
+        return
+
+    if origin in (Union, UnionType):
+        alternative_shapes = _managed_alternative_shape_positions(
+            arguments,
+            type_parameters=parameters,
+        )
+        if _mapping_enum_structural_ambiguity(alternative_shapes):
+            reject(
+                "combines an object-shaped Enum scalar with a structural "
+                "representation in a union at the same traversal position; "
+                "runtime validation cannot identify the authoritative arm",
+            )
+        if _dataclass_parameterization_ambiguity(alternative_shapes):
+            reject(
+                "uses multiple parameterizations of the same dataclass origin "
+                "at overlapping traversal positions in a union; runtime values "
+                "cannot identify the authoritative arm",
+            )
+        for argument in arguments:
+            _validate_explicit_managed_path_annotation(
+                family,
+                projection,
+                owner=owner,
+                field_name=field_name,
+                annotation=argument,
+                route_path=route_path,
+                leaf=leaf,
+                represented_family=represented_family,
+                represented_label=represented_label,
+                type_parameters=parameters,
+                seen=visited,
+            )
+        return
+
+    if origin is Literal:
+        return
+
+    if origin in (list, tuple, set, frozenset):
+        if not arguments:
+            if origin is tuple and getattr(annotation, "__args__", _MISSING) == ():
+                return
+            reject("uses an unparameterized collection")
+        if origin is tuple:
+            if arguments[-1] is Ellipsis:
+                item_annotations = arguments[:1]
+            else:
+                item_annotations = arguments
+        else:
+            item_annotations = arguments
+        for argument in item_annotations:
+            _validate_explicit_managed_path_annotation(
+                family,
+                projection,
+                owner=owner,
+                field_name=field_name,
+                annotation=argument,
+                route_path=route_path,
+                leaf=leaf,
+                represented_family=represented_family,
+                represented_label=represented_label,
+                type_parameters=parameters,
+                seen=visited,
+            )
+        return
+
+    if annotation in (list, tuple, set, frozenset):
+        reject("uses an unparameterized collection")
+
+    if origin is dict or annotation is dict:
+        reject("uses a mapping container")
+
+    typed_dict_target = _typed_dict_origin(annotation)
+    if typed_dict_target is not None:
+        if not leaf:
+            reject("uses a TypedDict at an intermediate path component")
+        typed_dict_parameters = _annotation_type_parameters(typed_dict_target)
+        typed_dict_bindings = _bound_annotation_parameters(
+            annotation,
+            inherited=parameters,
+        )
+        if any(parameter not in typed_dict_bindings for parameter in typed_dict_parameters):
+            reject("uses an unparameterized generic TypedDict")
+        try:
+            get_type_hints(typed_dict_target, include_extras=True)
+        except (AttributeError, NameError, TypeError):
+            reject("uses a TypedDict with unresolved field annotations")
+        config = getattr(typed_dict_target, "__pydantic_config__", None)
+        if isinstance(config, Mapping) and config.get("extra") == "allow":
+            reject(
+                "uses a TypedDict with extra='allow'; managed object fields "
+                "must have deterministic ownership",
+            )
+        extra_items = getattr(typed_dict_target, "__extra_items__", NoExtraItems)
+        if not _is_no_extra_items(extra_items):
+            reject(
+                "uses a TypedDict with extra_items; managed object fields must "
+                "have deterministic ownership",
+            )
+        if represented_family is not None and represented_label is not None:
+            _validate_structural_representation_nested_boundaries(
+                represented_family,
+                represented_label,
+                owner=typed_dict_target,
+                type_parameters=typed_dict_bindings,
+            )
+        return
+
+    structured_dataclass = is_dataclass(annotation) or (origin is not None and is_dataclass(origin))
+    if structured_dataclass:
+        if not leaf:
+            reject("uses a dataclass at an intermediate path component")
+        schema_target = annotation if origin is None else origin
+        if _model_has_model_serializer(schema_target):
+            reject(
+                "uses a model-level serializer on a managed dataclass leaf; "
+                "serializers can relocate child document paths",
+            )
+        if _has_custom_annotation_schema_hook(schema_target):
+            reject("uses an unsupported custom annotation schema hook")
+        if represented_family is not None and represented_label is not None:
+            _validate_structural_representation_nested_boundaries(
+                represented_family,
+                represented_label,
+                owner=schema_target,
+                type_parameters=_bound_annotation_parameters(
+                    annotation,
+                    inherited=parameters,
+                ),
+            )
+        return
+
+    runtime_type = origin if isinstance(origin, type) else annotation
+    if isinstance(runtime_type, type) and issubclass(runtime_type, BaseModel):
+        if getattr(runtime_type, "__pydantic_root_model__", False):
+            reject("uses a RootModel that is not object-shaped")
+        if not getattr(runtime_type, "__pydantic_complete__", False):
+            reject(
+                "uses an incomplete model; resolve forward references and call "
+                "model_rebuild() before compilation",
+            )
+        generic_metadata = getattr(runtime_type, "__pydantic_generic_metadata__", None)
+        if isinstance(generic_metadata, Mapping) and generic_metadata.get("parameters"):
+            reject("uses an unparameterized generic model")
+        if _model_has_model_serializer(runtime_type):
+            reject(
+                "uses a model-level serializer on a managed model leaf; "
+                "serializers can relocate child document paths",
+            )
+        if _has_custom_annotation_schema_hook(runtime_type):
+            reject("uses an unsupported custom annotation schema hook")
+        if represented_family is not None and represented_label is not None:
+            _validate_structural_representation_nested_boundaries(
+                represented_family,
+                represented_label,
+                owner=runtime_type,
+                type_parameters=_bound_annotation_parameters(
+                    annotation,
+                    inherited=parameters,
+                ),
+            )
+        return
+
+    if origin is not None:
+        if isinstance(runtime_type, type) and (
+            _safe_runtime_subclass(runtime_type, Mapping)
+            or _safe_runtime_subclass(runtime_type, Iterable)
+        ):
+            reject("uses an unsupported abstract or custom container")
+        reject("uses an unsupported generic annotation")
+
+    if not isinstance(annotation, type):
+        reject("uses an unsupported opaque annotation")
+    if _has_custom_annotation_schema_hook(annotation):
+        reject("uses an unsupported custom annotation schema hook")
+    if _safe_runtime_subclass(annotation, Mapping):
+        reject("uses a mapping container")
+    if annotation not in (str, bytes, bytearray) and _safe_runtime_subclass(
+        annotation,
+        Iterable,
+    ):
+        reject("uses an unsupported abstract or custom container")
+
+
+def _annotation_has_functional_serializer(
+    annotation: Any,
+    *,
+    seen: set[tuple[int, tuple[tuple[int, int], ...]]],
+    type_parameters: Mapping[Any, Any] | None = None,
+) -> bool:
+    parameters = {} if type_parameters is None else type_parameters
+    visit_key = (
+        id(annotation),
+        tuple(sorted((id(key), id(value)) for key, value in parameters.items())),
+    )
+    if visit_key in seen:
+        return False
+    seen.add(visit_key)
+
+    if isinstance(annotation, _TYPE_ALIAS_TYPES):
+        return _annotation_has_functional_serializer(
+            annotation.__value__,
+            seen=seen,
+            type_parameters=parameters,
+        )
+
+    if isinstance(annotation, TypeVar):
+        resolved = parameters.get(annotation, _MISSING)
+        values = _type_parameter_values(annotation) if resolved is _MISSING else (resolved,)
+        return any(
+            value is not annotation
+            and _annotation_has_functional_serializer(
+                value,
+                seen=seen,
+                type_parameters=parameters,
+            )
+            for value in values
+        )
+
+    supertype = _instance_dict(annotation).get("__supertype__")
+    if supertype is not None and supertype is not annotation:
+        return _annotation_has_functional_serializer(
+            supertype,
+            seen=seen,
+            type_parameters=parameters,
+        )
+
+    arguments = get_args(annotation)
+    origin = get_origin(annotation)
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        bindings = _bound_annotation_parameters(
+            annotation,
+            inherited=parameters,
+        )
+        return _annotation_has_functional_serializer(
+            origin.__value__,
+            seen=seen,
+            type_parameters=bindings,
+        )
+
+    if origin is Annotated:
         base, *metadata = arguments
         if any(_metadata_has_unsafe_nested_serialization(item) for item in metadata):
             return True
-        return _annotation_has_functional_serializer(base, seen=seen)
+        return _annotation_has_functional_serializer(
+            base,
+            seen=seen,
+            type_parameters=parameters,
+        )
     return any(
-        argument is not Ellipsis and _annotation_has_functional_serializer(argument, seen=seen)
+        argument is not Ellipsis
+        and _annotation_has_functional_serializer(
+            argument,
+            seen=seen,
+            type_parameters=parameters,
+        )
         for argument in arguments
     )
 
@@ -2376,6 +3573,20 @@ def _field_has_functional_serializer(field_info: Any) -> bool:
         field_info.annotation,
         seen=set(),
     ) or any(_metadata_has_unsafe_nested_serialization(item) for item in field_info.metadata)
+
+
+def _field_has_serialization_exclusion(field_info: Any | None) -> bool:
+    if field_info is None:
+        return False
+    return (
+        getattr(field_info, "exclude", None) not in (None, False)
+        or getattr(
+            field_info,
+            "exclude_if",
+            None,
+        )
+        is not None
+    )
 
 
 def _metadata_has_unsafe_nested_serialization(item: Any) -> bool:
@@ -2389,47 +3600,111 @@ def _metadata_has_unsafe_nested_serialization(item: Any) -> bool:
     )
 
 
-def _model_has_field_serializer(model: type[BaseModel], field_name: str) -> bool:
-    decorators = getattr(model, "__pydantic_decorators__", None)
+def _owner_has_field_serializer(owner: type[Any], field_name: str) -> bool:
+    decorators = getattr(owner, "__pydantic_decorators__", None)
     serializers = None if decorators is None else getattr(decorators, "field_serializers", None)
-    if not serializers:
-        return False
-    return any(
+    if serializers and any(
         field_name in decorator.info.fields or "*" in decorator.info.fields
         for decorator in serializers.values()
-    )
+    ):
+        return True
+    for value in _effective_static_class_values(owner):
+        if _pydantic_decorator_info_kind(value) != "FieldSerializerDecoratorInfo":
+            continue
+        info = _instance_dict(value)["decorator_info"]
+        fields = getattr(info, "fields", ())
+        if field_name in fields or "*" in fields:
+            return True
+    return False
 
 
-def _collect_immediate_base_models(
+def _collect_immediate_base_model_representations(
     annotation: Any,
     *,
-    models: list[type[BaseModel]],
-    seen: set[int],
+    models: list[tuple[type[Any], Mapping[Any, Any]]],
+    seen: set[tuple[int, tuple[tuple[int, int], ...]]],
+    type_parameters: Mapping[Any, Any],
 ) -> None:
-    if id(annotation) in seen:
+    visit_key = (
+        id(annotation),
+        tuple(sorted((id(key), id(value)) for key, value in type_parameters.items())),
+    )
+    if visit_key in seen:
         return
-    seen.add(id(annotation))
+    seen.add(visit_key)
     if isinstance(annotation, _TYPE_ALIAS_TYPES):
-        _collect_immediate_base_models(annotation.__value__, models=models, seen=seen)
+        _collect_immediate_base_model_representations(
+            annotation.__value__,
+            models=models,
+            seen=seen,
+            type_parameters=type_parameters,
+        )
         return
     if isinstance(annotation, TypeVar):
-        for value in _type_parameter_values(annotation):
-            _collect_immediate_base_models(value, models=models, seen=seen)
+        resolved = type_parameters.get(annotation, _MISSING)
+        values = _type_parameter_values(annotation) if resolved is _MISSING else (resolved,)
+        for value in values:
+            _collect_immediate_base_model_representations(
+                value,
+                models=models,
+                seen=seen,
+                type_parameters=type_parameters,
+            )
         return
     supertype = _instance_dict(annotation).get("__supertype__")
     if supertype is not None and supertype is not annotation:
-        _collect_immediate_base_models(supertype, models=models, seen=seen)
+        _collect_immediate_base_model_representations(
+            supertype,
+            models=models,
+            seen=seen,
+            type_parameters=type_parameters,
+        )
         return
-    is_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
-    if is_model:
-        models.append(annotation)
+    origin = get_origin(annotation)
+    arguments = get_args(annotation)
+    if isinstance(origin, _TYPE_ALIAS_TYPES):
+        bindings = _bound_annotation_parameters(
+            annotation,
+            inherited=type_parameters,
+        )
+        _collect_immediate_base_model_representations(
+            origin.__value__,
+            models=models,
+            seen=seen,
+            type_parameters=bindings,
+        )
         return
-    if get_origin(annotation) is Literal:
+    if origin is Annotated:
+        _collect_immediate_base_model_representations(
+            arguments[0],
+            models=models,
+            seen=seen,
+            type_parameters=type_parameters,
+        )
         return
-    for argument in get_args(annotation):
+    runtime_type = origin if isinstance(origin, type) else annotation
+    if isinstance(runtime_type, type) and issubclass(runtime_type, BaseModel):
+        models.append(
+            (
+                runtime_type,
+                _bound_annotation_parameters(
+                    annotation,
+                    inherited=type_parameters,
+                ),
+            ),
+        )
+        return
+    if origin is Literal:
+        return
+    for argument in arguments:
         if argument is Ellipsis:
             continue
-        _collect_immediate_base_models(argument, models=models, seen=seen)
+        _collect_immediate_base_model_representations(
+            argument,
+            models=models,
+            seen=seen,
+            type_parameters=type_parameters,
+        )
 
 
 def _alias_paths(alias: Any) -> tuple[tuple[str | int, ...], ...]:
@@ -2655,7 +3930,7 @@ def _raise_projection_unsupported(
     family: SchemaFamily[Any],
     projection: _VersionProjection,
     detail: str,
-) -> None:
+) -> Never:
     msg = (
         f"Automatic wire model for family {family.name!r}, version "
         f"{projection.label!r}, and model {_model_display(family.model)!r} "
@@ -2664,7 +3939,7 @@ def _raise_projection_unsupported(
     raise UnsupportedWireModelError(msg)
 
 
-def _model_display(model: type[BaseModel]) -> str:
+def _model_display(model: type[Any]) -> str:
     return f"{model.__module__}.{model.__qualname__}"
 
 
@@ -2821,7 +4096,7 @@ def _compile_decorator_nested_families(
                     "unresolved type parameter",
                 )
             return
-        if is_typeddict(annotation):
+        if _is_typed_dict(annotation):
             if _annotation_has_decorator_child(owner, annotation):
                 _raise_unsupported(
                     owner,
@@ -2943,7 +4218,7 @@ def _compile_decorator_nested_families(
                 )
             union_routes = tuple(route for routes in branch_routes for route in routes)
             if union_routes:
-                if any(is_typeddict(argument) for argument in branch_arguments):
+                if any(_is_typed_dict(argument) for argument in branch_arguments):
                     _raise_unsupported(
                         owner,
                         f"decorator children beneath union path {field_path!r} use a "
@@ -3142,7 +4417,7 @@ def _annotation_has_decorator_child(
             _annotation_has_decorator_child(owner, value, seen=visited)
             for value in _type_parameter_values(annotation)
         )
-    if is_typeddict(annotation):
+    if _is_typed_dict(annotation):
         return any(
             _annotation_has_decorator_child(owner, value, seen=visited)
             for value in annotation.__annotations__.values()

--- a/tests/unit/test_explicit_nested_annotation_contract.py
+++ b/tests/unit/test_explicit_nested_annotation_contract.py
@@ -1,0 +1,1541 @@
+from __future__ import annotations
+
+import typing
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from enum import Enum
+from typing import (
+    Annotated,
+    Any,
+    Generic,
+    Literal,
+    Never,
+    NewType,
+    NotRequired,
+    TypedDict,
+    TypeVar,
+)
+
+import pytest
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    computed_field,
+    create_model,
+    field_serializer,
+    model_serializer,
+    with_config,
+)
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+from pydantic.functional_serializers import PlainSerializer
+from pydantic_core import core_schema
+from typing_extensions import TypedDict as ExtensionsTypedDict  # noqa: UP035
+from typing_extensions import TypeVar as ExtensionsTypeVar  # noqa: UP035
+
+from pydantic_versions import (
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    UnsupportedWireModelError,
+    VersionTransition,
+    matching_labels,
+)
+
+
+class _Child(BaseModel):
+    value: int
+
+
+class _Parent(BaseModel):
+    child: _Child
+
+
+_CHILD_FAMILY = SchemaFamily(
+    model=_Child,
+    name="explicit_annotation_contract_child",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+)
+
+
+class _DictionarySchemaCarrier:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: Any,
+    ) -> core_schema.CoreSchema:
+        del cls, source_type, handler
+        return core_schema.dict_schema(
+            core_schema.str_schema(),
+            core_schema.any_schema(),
+        )
+
+
+class _CustomList(list[str]):
+    pass
+
+
+class _HistoricalChildModel(BaseModel):
+    value: int
+
+
+class _HistoricalChildWithSchemaHook(BaseModel):
+    value: int
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        schema: core_schema.CoreSchema,
+        handler: Any,
+    ) -> dict[str, Any]:
+        del cls
+        return handler(schema)
+
+
+@dataclass
+class _HistoricalChildDataclass:
+    value: int
+
+
+@dataclass
+class _HistoricalDataclassSchemaCarrier:
+    value: int
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: Any,
+    ) -> core_schema.CoreSchema:
+        del cls, source_type, handler
+        return core_schema.dict_schema(
+            core_schema.str_schema(),
+            core_schema.any_schema(),
+        )
+
+
+class _MappingValuedHistoricalChildEnum(Enum):
+    OBJECT = {"value": 1}
+    TEXT = "legacy"
+
+
+type _mapping_enum_items[Item] = list[Item]
+type _mapping_enum_structural_items = (
+    list[_MappingValuedHistoricalChildEnum] | list[_HistoricalChildDataclass]
+)
+_mapping_enum_alias = NewType(
+    "_mapping_enum_alias",
+    _MappingValuedHistoricalChildEnum,
+)
+_mapping_enum_structural_leaf = TypeVar(
+    "_mapping_enum_structural_leaf",
+    _MappingValuedHistoricalChildEnum,
+    _HistoricalChildModel,
+)
+
+
+class _ExtensionsHistoricalChildTypedDict(ExtensionsTypedDict):
+    value: int
+
+
+class _GenericHistoricalChildTypedDict[Item](TypedDict):
+    value: Item
+
+
+_LegacyTypedDictItem = TypeVar("_LegacyTypedDictItem")
+
+
+class _LegacyGenericHistoricalChildTypedDict(
+    TypedDict,
+    Generic[_LegacyTypedDictItem],  # noqa: UP046 - exercise legacy generic metadata
+):
+    value: _LegacyTypedDictItem
+
+
+_DefaultTypedDictItem = ExtensionsTypeVar("_DefaultTypedDictItem", default=int)
+
+
+class _DefaultGenericHistoricalChildTypedDict(
+    TypedDict,
+    Generic[_DefaultTypedDictItem],  # noqa: UP046 - exercise defaulted legacy metadata
+):
+    value: _DefaultTypedDictItem
+
+
+@with_config(ConfigDict(extra="allow"))
+class _ExtraAllowHistoricalChildTypedDict(TypedDict):
+    value: int
+
+
+class _ExtraItemsHistoricalChildTypedDict(ExtensionsTypedDict, extra_items=str):
+    value: int
+
+
+class _HistoricalChildRoot(RootModel[dict[str, int]]):
+    pass
+
+
+class _HistoricalGenericChild[item](BaseModel):
+    value: item
+
+
+_IncompleteHistoricalChild = create_model(
+    "_IncompleteHistoricalChild",
+    value=("_NeverDefinedHistoricalChild", ...),
+)
+
+
+type _safe_items[_safe_item] = list[_safe_item]
+type _safe_annotated_alias = Annotated[str, Field(description="legacy scalar")]
+type _safe_recursive_alias = str | list[_safe_recursive_alias]
+_safe_identifier = NewType("_safe_identifier", str)
+_safe_bound = TypeVar("_safe_bound", bound=str)
+_unbound = TypeVar("_unbound")
+_unsafe_constraint = TypeVar("_unsafe_constraint", str, Any)
+type _unsafe_alias = list[Any]
+type _unsafe_annotated_alias = Annotated[Any, Field(description="broad")]
+_unsafe_mapping = NewType("_unsafe_mapping", dict[str, int])
+_relocating_serializer = PlainSerializer(
+    lambda value: {"relocated": value, "schema_version": "secret"},
+    return_type=dict[str, Any],
+)
+type _serialized_direct_alias = Annotated[str, _relocating_serializer]
+type _serialized_generic_alias[_serialized_item] = Annotated[
+    _serialized_item,
+    _relocating_serializer,
+]
+type _serializer_passthrough[_serialized_item] = list[_serialized_item]
+_serialized_new_type = NewType(
+    "_serialized_new_type",
+    _serialized_direct_alias,  # ty: ignore[invalid-newtype]
+)
+_serialized_bound = TypeVar("_serialized_bound", bound=_serialized_direct_alias)
+
+
+class _SerializedHistoricalChildModel(BaseModel):
+    value: int
+
+    @model_serializer
+    def serialize_model(self) -> dict[str, Any]:
+        return {"relocated": self.value, "schema_version": "secret"}
+
+
+@dataclass
+class _SerializedStdlibHistoricalChildDataclass:
+    value: int
+
+    @model_serializer
+    def serialize_model(self) -> dict[str, Any]:
+        return {"relocated": self.value, "schema_version": "secret"}
+
+
+@dataclass
+class _InheritedSerializedStdlibDataclassBase:
+    @model_serializer
+    def serialize_model(self) -> dict[str, Any]:
+        return {"relocated": 1, "schema_version": "secret"}
+
+
+@dataclass
+class _InheritedSerializedStdlibHistoricalChildDataclass(
+    _InheritedSerializedStdlibDataclassBase,
+):
+    value: int
+
+
+def _leaf_family(
+    annotation: Any,
+    *,
+    case: str,
+    arbitrary_types_allowed: bool = False,
+) -> SchemaFamily[_Parent]:
+    config = ConfigDict(arbitrary_types_allowed=True) if arbitrary_types_allowed else None
+    historical_parent = create_model(
+        f"ExplicitAnnotation{case.title().replace('_', '')}HistoricalParent",
+        __config__=config,
+        child=(annotation, ...),
+    )
+    return SchemaFamily(
+        model=_Parent,
+        name=f"explicit_annotation_{case}",
+        versions=(
+            SchemaVersion("1", wire_model=historical_parent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", _CHILD_FAMILY, matching_labels()),),
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation", "diagnostic"),
+    [
+        ("any", Any, "broad annotation"),
+        ("object", object, "broad annotation"),
+        ("bare_dict", dict, "mapping container"),
+        ("typed_dict_container", dict[str, int], "mapping container"),
+        ("bare_mapping", Mapping, "mapping container"),
+        ("mapping", Mapping[str, int], "abstract or custom container"),
+        ("bare_list", list, "unparameterized collection"),
+        ("typing_tuple", typing.Tuple, "unparameterized collection"),  # noqa: UP006
+        ("list_of_any", list[Any], "broad annotation"),
+        ("tuple_of_any", tuple[Any, ...], "broad annotation"),
+        ("sequence", Sequence[str], "abstract or custom container"),
+        (
+            "schema_carrier",
+            _DictionarySchemaCarrier,
+            "unsupported custom annotation schema hook",
+        ),
+        (
+            "model_schema_hook",
+            _HistoricalChildWithSchemaHook,
+            "unsupported custom annotation schema hook",
+        ),
+        (
+            "dataclass_schema_hook",
+            _HistoricalDataclassSchemaCarrier,
+            "unsupported custom annotation schema hook",
+        ),
+        ("root_model", _HistoricalChildRoot, "RootModel that is not object-shaped"),
+        ("generic_model", _HistoricalGenericChild, "unparameterized generic model"),
+        ("incomplete_model", _IncompleteHistoricalChild, "incomplete model"),
+        ("unsafe_alias", _unsafe_alias, "broad annotation"),
+        ("unsafe_annotated_alias", _unsafe_annotated_alias, "broad annotation"),
+        ("unsafe_new_type", _unsafe_mapping, "mapping container"),
+        ("unbound_type_var", _unbound, "unresolved type parameter"),
+        (
+            "unbound_type_var_union",
+            _unbound | _HistoricalChildDataclass,
+            "unresolved type parameter",
+        ),
+        ("unsafe_constraint", _unsafe_constraint, "broad annotation"),
+        ("broad_union_arm", str | Any, "broad annotation"),
+        ("unresolved_forward", "_NeverDefinedExplicitLeaf", "unresolved annotation"),
+        ("unsupported_generic", type[int], "unsupported generic annotation"),
+    ],
+)
+def test_explicit_managed_leaf_rejects_shape_erasing_annotations(
+    case: str,
+    annotation: Any,
+    diagnostic: str,
+) -> None:
+    family = _leaf_family(annotation, case=case)
+
+    with pytest.raises(UnsupportedWireModelError, match=diagnostic) as exc_info:
+        family.model_for("1")
+
+    message = str(exc_info.value)
+    assert f"explicit_annotation_{case}" in message
+    assert "version '1'" in message
+    assert "declared nested path ('child',)" in message
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("optional_scalar", str | None),
+        ("empty_tuple", tuple[()]),
+        ("frozenset", frozenset[str]),
+        ("extensions_typed_dict", _ExtensionsHistoricalChildTypedDict),
+        (
+            "legacy_generic_typed_dict",
+            _LegacyGenericHistoricalChildTypedDict[int],
+        ),
+        ("defaulted_generic_typed_dict", _DefaultGenericHistoricalChildTypedDict),
+        ("new_type", _safe_identifier),
+        ("annotated_alias", _safe_annotated_alias),
+        ("generic_alias", _safe_items[str]),
+        ("recursive_alias", _safe_recursive_alias),
+        ("bounded_type_var", _safe_bound),
+        ("model_or_scalar", _HistoricalChildModel | str),
+        ("model_or_literal", _HistoricalChildModel | Literal["legacy"]),
+        ("mapping_valued_enum", _MappingValuedHistoricalChildEnum),
+        (
+            "mapping_valued_enum_literal",
+            Literal[_MappingValuedHistoricalChildEnum.OBJECT],
+        ),
+        (
+            "mapping_valued_enum_or_scalar",
+            _MappingValuedHistoricalChildEnum | str,
+        ),
+        (
+            "mapping_enum_distinct_depth_union",
+            _MappingValuedHistoricalChildEnum | list[_HistoricalChildModel],
+        ),
+        (
+            "mapping_enum_distinct_fixed_tuple_positions",
+            tuple[_MappingValuedHistoricalChildEnum, str] | tuple[str, _HistoricalChildModel],
+        ),
+    ],
+)
+def test_explicit_managed_leaf_accepts_shape_preserving_annotations(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _leaf_family(annotation, case=f"safe_{case}")
+
+    historical = family.model_for("1")
+
+    assert "child" in historical.model_fields
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        (
+            "direct",
+            _MappingValuedHistoricalChildEnum | _HistoricalChildModel,
+        ),
+        (
+            "collection",
+            list[_MappingValuedHistoricalChildEnum] | list[_HistoricalChildDataclass],
+        ),
+        (
+            "fixed_tuple",
+            tuple[_MappingValuedHistoricalChildEnum, str] | tuple[_HistoricalChildDataclass, str],
+        ),
+        (
+            "fixed_and_variadic_tuple",
+            tuple[str, _MappingValuedHistoricalChildEnum] | tuple[_HistoricalChildDataclass, ...],
+        ),
+        (
+            "coercible_collection_reversed",
+            tuple[_HistoricalChildModel, ...] | list[_MappingValuedHistoricalChildEnum],
+        ),
+        (
+            "coercible_collection_kinds",
+            frozenset[_MappingValuedHistoricalChildEnum] | list[_HistoricalChildModel],
+        ),
+        ("generic_alias", _mapping_enum_structural_items),
+        (
+            "applied_generic_alias",
+            _mapping_enum_items[_MappingValuedHistoricalChildEnum]
+            | _mapping_enum_items[_HistoricalChildDataclass],
+        ),
+        (
+            "annotated",
+            Annotated[
+                _MappingValuedHistoricalChildEnum,
+                Field(description="legacy object-shaped scalar"),
+            ]
+            | _HistoricalChildModel,
+        ),
+        ("new_type", _mapping_enum_alias | _HistoricalChildModel),
+        (
+            "literal",
+            Literal[_MappingValuedHistoricalChildEnum.OBJECT] | _HistoricalChildModel,
+        ),
+        ("type_parameter", list[_mapping_enum_structural_leaf]),
+    ],
+)
+def test_managed_union_rejects_mapping_enum_and_structural_ambiguity(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _leaf_family(annotation, case=f"ambiguous_mapping_enum_{case}")
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match=("object-shaped Enum scalar.*structural representation.*same traversal position"),
+    ):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("direct_alias", _serialized_direct_alias),
+        ("generic_alias", _serialized_generic_alias[str]),
+        ("generic_alias_argument", _serializer_passthrough[_serialized_direct_alias]),
+        ("new_type", _serialized_new_type),
+        ("bounded_type_var", _serialized_bound),
+    ],
+)
+def test_explicit_managed_leaf_rejects_functional_serializers_hidden_by_wrappers(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _leaf_family(annotation, case=f"serialized_{case}")
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="annotation-level serializer",
+    ):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation", "diagnostic"),
+    [
+        (
+            "model_serializer",
+            _SerializedHistoricalChildModel,
+            "model-level serializer on a managed model leaf",
+        ),
+        (
+            "stdlib_dataclass_serializer",
+            _SerializedStdlibHistoricalChildDataclass,
+            "model-level serializer on a managed dataclass leaf",
+        ),
+        (
+            "inherited_stdlib_dataclass_serializer",
+            _InheritedSerializedStdlibHistoricalChildDataclass,
+            "model-level serializer on a managed dataclass leaf",
+        ),
+    ],
+)
+def test_explicit_managed_leaf_rejects_model_level_serializers(
+    case: str,
+    annotation: Any,
+    diagnostic: str,
+) -> None:
+    family = _leaf_family(annotation, case=case)
+
+    with pytest.raises(UnsupportedWireModelError, match=diagnostic):
+        family.model_for("1")
+
+
+def test_explicit_managed_leaf_rejects_unresolved_typed_dict_fields() -> None:
+    class LocalTypedDict(TypedDict):
+        value: _OnlyVisibleInThisTest
+
+    class _OnlyVisibleInThisTest(BaseModel):
+        value: int
+
+    family = _leaf_family(LocalTypedDict, case="local_typed_dict_forward")
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="TypedDict with unresolved field annotations",
+    ):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation", "diagnostic"),
+    [
+        (
+            "generic_typed_dict",
+            _GenericHistoricalChildTypedDict,
+            "unparameterized generic TypedDict",
+        ),
+        (
+            "legacy_generic_typed_dict",
+            _LegacyGenericHistoricalChildTypedDict,
+            "unparameterized generic TypedDict",
+        ),
+        (
+            "extra_allow_typed_dict",
+            _ExtraAllowHistoricalChildTypedDict,
+            "TypedDict with extra='allow'",
+        ),
+        (
+            "extra_items_typed_dict",
+            _ExtraItemsHistoricalChildTypedDict,
+            "TypedDict with extra_items",
+        ),
+    ],
+)
+def test_explicit_managed_leaf_rejects_ambiguous_typed_dict_contracts(
+    case: str,
+    annotation: Any,
+    diagnostic: str,
+) -> None:
+    family = _leaf_family(annotation, case=case)
+
+    with pytest.raises(UnsupportedWireModelError, match=diagnostic):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "field"),
+    [
+        ("exclude", Field(exclude=True)),
+        ("exclude_if", Field(exclude_if=lambda value: value is not None)),
+    ],
+)
+def test_explicit_historical_managed_path_rejects_serialization_exclusion(
+    case: str,
+    field: Any,
+) -> None:
+    historical_parent = create_model(
+        f"ExplicitAnnotationExcluded{case.title()}HistoricalParent",
+        child=(_HistoricalChildModel, field),
+    )
+    family = SchemaFamily(
+        model=_Parent,
+        name=f"explicit_annotation_excluded_{case}",
+        versions=(
+            SchemaVersion("1", wire_model=historical_parent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", _CHILD_FAMILY, matching_labels()),),
+    )
+
+    with pytest.raises(UnsupportedWireModelError, match="excludes field 'child'"):
+        family.model_for("1")
+
+
+class _TransitiveGrandchild(BaseModel):
+    value: int
+
+
+_TRANSITIVE_GRANDCHILD_FAMILY = SchemaFamily(
+    model=_TransitiveGrandchild,
+    name="explicit_annotation_transitive_grandchild",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+)
+
+
+class _TransitiveChild(BaseModel):
+    grandchild: _TransitiveGrandchild
+
+
+_TRANSITIVE_CHILD_FAMILY = SchemaFamily(
+    model=_TransitiveChild,
+    name="explicit_annotation_transitive_child",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+    nested=(
+        NestedFamily(
+            "grandchild",
+            _TRANSITIVE_GRANDCHILD_FAMILY,
+            matching_labels(),
+        ),
+    ),
+)
+
+
+class _TransitiveParent(BaseModel):
+    child: _TransitiveChild
+
+
+class _BroadTransitiveChildModel(BaseModel):
+    grandchild: Any
+
+
+class _DeepTransitiveWrapper(BaseModel):
+    grandchild: _TransitiveGrandchild
+
+
+class _DeepTransitiveChild(BaseModel):
+    wrapper: _DeepTransitiveWrapper
+
+
+_DEEP_TRANSITIVE_CHILD_FAMILY = SchemaFamily(
+    model=_DeepTransitiveChild,
+    name="explicit_annotation_deep_transitive_child",
+    versions=(SchemaVersion("1"), SchemaVersion("2")),
+    nested=(
+        NestedFamily(
+            ("wrapper", "grandchild"),
+            _TRANSITIVE_GRANDCHILD_FAMILY,
+            matching_labels(),
+        ),
+    ),
+)
+
+
+class _DeepTransitiveParent(BaseModel):
+    child: _DeepTransitiveChild
+
+
+_DeepWrapperNewType = NewType("_DeepWrapperNewType", _BroadTransitiveChildModel)
+type _DeepWrapperAlias = _DeepWrapperNewType
+type _deep_wrapper_representations[Item] = Annotated[
+    tuple[Item, ...] | Literal["omitted"],
+    Field(description="historical wrapper representation"),
+]
+type _recursive_deep_wrapper = _BroadTransitiveChildModel | list[_recursive_deep_wrapper]
+
+
+@dataclass
+class _BroadTransitiveChildDataclass:
+    grandchild: Any
+
+
+class _BroadTransitiveChildTypedDict(TypedDict):
+    grandchild: Any
+
+
+class _GenericTransitiveChildTypedDict[Item](TypedDict):
+    grandchild: Item
+
+
+class _QualifiedGenericTransitiveChildTypedDict[Item](TypedDict):
+    grandchild: NotRequired[Item]
+
+
+class _DefaultGenericTransitiveChildTypedDict(
+    TypedDict,
+    Generic[_DefaultTypedDictItem],  # noqa: UP046 - exercise defaulted legacy metadata
+):
+    grandchild: _DefaultTypedDictItem
+
+
+@dataclass
+class _GenericTransitiveChildDataclass[Item]:
+    grandchild: Item
+
+
+@pydantic_dataclass
+class _GenericTransitiveChildPydanticDataclass[Item]:
+    grandchild: Item
+
+
+class _GenericDataclassTransitiveTypedDict[Item](TypedDict):
+    grandchild: NotRequired[_GenericTransitiveChildDataclass[Item]]
+
+
+type _StringTransitiveChildDataclass = _GenericTransitiveChildDataclass[str]
+type _ModelTransitiveChildDataclass = _GenericTransitiveChildDataclass[_HistoricalChildModel]
+type _transitive_dataclass_union[Item] = Item | _GenericTransitiveChildDataclass[str]
+type _transitive_dataclass_identity[Item] = Item
+_ambiguous_transitive_dataclass_constraint = TypeVar(
+    "_ambiguous_transitive_dataclass_constraint",
+    _GenericTransitiveChildDataclass[str],
+    _GenericTransitiveChildDataclass[_HistoricalChildModel],
+)
+_StringTransitiveChildDataclassNewType = NewType(
+    "_StringTransitiveChildDataclassNewType",
+    _GenericTransitiveChildDataclass[str],
+)
+
+
+@dataclass
+class _SafeTransitiveChildDataclass:
+    grandchild: str
+
+
+@dataclass
+class _DefaultOverridesAnnotatedManagedChildDataclass:
+    grandchild: Annotated[str, Field(exclude=True)] = Field(exclude=False)
+
+
+class _LaterAnnotatedFieldInfoWinsManagedChildTypedDict(TypedDict):
+    grandchild: Annotated[
+        str,
+        Field(exclude=True, serialization_alias="old-grandchild"),
+        Field(exclude=False, serialization_alias="grandchild"),
+    ]
+
+
+@dataclass
+class _OmittedTransitiveChildDataclass:
+    note: str
+
+
+class _ComputedOmittedTransitiveChildModel(BaseModel):
+    note: str
+
+    @computed_field(alias="grandchild")
+    @property
+    def legacy_grandchild(self) -> dict[str, int]:
+        return {"value": 1}
+
+
+@pydantic_dataclass
+class _ComputedOmittedTransitiveChildPydanticDataclass:
+    note: str
+
+    @computed_field(alias="grandchild")
+    @property
+    def legacy_grandchild(self) -> dict[str, int]:
+        return {"value": 1}
+
+
+@dataclass
+class _SerializedTransitiveChildDataclass:
+    grandchild: str
+
+    @field_serializer("grandchild")
+    def serialize_grandchild(self, value: str) -> dict[str, str]:
+        return {"relocated": value}
+
+
+@pydantic_dataclass
+class _PydanticSerializedTransitiveChildDataclass:
+    grandchild: str
+
+    @field_serializer("grandchild")
+    def serialize_grandchild(self, value: str) -> dict[str, str]:
+        return {"relocated": value}
+
+
+@dataclass
+class _AnnotatedSerializedTransitiveChildDataclass:
+    grandchild: _serialized_direct_alias
+
+
+class _ExcludedTransitiveChildModel(BaseModel):
+    grandchild: str = Field(exclude=True)
+
+
+@dataclass
+class _ExcludedTransitiveChildDataclass:
+    grandchild: Annotated[str, Field(exclude=True)]
+
+
+class _ExcludedTransitiveChildTypedDict(TypedDict):
+    grandchild: Annotated[str, Field(exclude=True)]
+
+
+@dataclass
+class _MetadataExcludedTransitiveChildDataclass:
+    grandchild: str = dataclass_field(metadata={"exclude": True})
+
+
+@dataclass
+class _InheritedSerializedTransitiveDataclassBase:
+    @field_serializer("grandchild", check_fields=False)
+    def serialize_grandchild(self, value: str) -> dict[str, str]:
+        return {"relocated": value}
+
+
+@dataclass
+class _InheritedSerializedTransitiveChildDataclass(
+    _InheritedSerializedTransitiveDataclassBase,
+):
+    grandchild: str
+
+
+@dataclass
+class _AliasedOmittedTransitiveChildDataclass:
+    legacy_grandchild: Annotated[
+        str,
+        Field(serialization_alias="grandchild"),
+    ]
+
+
+@dataclass
+class _DefaultAliasedOmittedTransitiveChildDataclass:
+    legacy_grandchild: str = Field(serialization_alias="grandchild")
+
+
+@dataclass
+class _MetadataAliasedOmittedTransitiveChildDataclass:
+    legacy_grandchild: str = dataclass_field(
+        metadata={
+            "validation_alias": "grandchild",
+            "serialization_alias": "grandchild",
+        },
+    )
+
+
+@dataclass
+class _DefaultOverridesAnnotatedOmittedTransitiveChildDataclass:
+    legacy_grandchild: Annotated[
+        str,
+        Field(serialization_alias="grandchild"),
+    ] = Field(serialization_alias="legacy_grandchild")
+
+
+@dataclass
+class _EmptyAliasOverridesAnnotatedOmittedTransitiveChildDataclass:
+    legacy_grandchild: Annotated[
+        str,
+        Field(
+            validation_alias="grandchild",
+            serialization_alias="grandchild",
+        ),
+    ] = Field(validation_alias="", serialization_alias="")
+
+
+@dataclass
+class _ClearedSerializationAliasOmittedTransitiveChildDataclass:
+    legacy_grandchild: Annotated[
+        str,
+        Field(
+            alias="legacy-wire",
+            serialization_alias="grandchild",
+        ),
+        Field(serialization_alias=None),
+    ]
+
+
+@dataclass
+class _DefaultOccupiesAnnotatedOmittedTransitiveChildDataclass:
+    legacy_grandchild: Annotated[
+        str,
+        Field(serialization_alias="legacy_grandchild"),
+    ] = Field(serialization_alias="grandchild")
+
+
+@dataclass
+class _MetadataOccupiesAnnotatedOmittedTransitiveChildDataclass:
+    legacy_grandchild: Annotated[
+        str,
+        Field(serialization_alias="legacy_grandchild"),
+    ] = dataclass_field(metadata={"serialization_alias": "grandchild"})
+
+
+class _LaterAnnotatedAliasOmittedTransitiveChildTypedDict(TypedDict):
+    legacy_grandchild: Annotated[
+        str,
+        Field(serialization_alias="legacy_grandchild"),
+        Field(serialization_alias="grandchild"),
+    ]
+
+
+def _generated_transitive_alias(field_name: str) -> str:
+    return f"wire_{field_name}"
+
+
+@with_config(ConfigDict(alias_generator=_generated_transitive_alias))
+@dataclass
+class _GeneratedAliasTransitiveChildDataclass:
+    grandchild: str
+
+
+@with_config(ConfigDict(alias_generator=_generated_transitive_alias))
+class _GeneratedAliasTransitiveChildTypedDict(TypedDict):
+    grandchild: str
+
+
+class _AliasedOmittedTransitiveChildTypedDict(TypedDict):
+    legacy_grandchild: Annotated[
+        str,
+        Field(serialization_alias="grandchild"),
+    ]
+
+
+type _transitive_representations[Item] = list[Item] | str
+
+
+def _managed_child_family(
+    *,
+    model: type[BaseModel],
+    child_family: SchemaFamily[Any],
+    annotation: Any,
+    case: str,
+    prefix: str,
+    defer_build: bool = False,
+) -> SchemaFamily[Any]:
+    historical_parent = create_model(
+        f"Explicit{prefix.title().replace('_', '')}{case.title().replace('_', '')}HistoricalParent",
+        __config__=ConfigDict(defer_build=True) if defer_build else None,
+        child=(annotation, ...),
+    )
+    return SchemaFamily(
+        model=model,
+        name=f"explicit_annotation_{prefix}_{case}",
+        versions=(
+            SchemaVersion("1", wire_model=historical_parent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+    )
+
+
+def _transitive_family(
+    annotation: Any,
+    *,
+    case: str,
+    defer_build: bool = False,
+) -> SchemaFamily[Any]:
+    return _managed_child_family(
+        model=_TransitiveParent,
+        child_family=_TRANSITIVE_CHILD_FAMILY,
+        annotation=annotation,
+        case=case,
+        prefix="transitive_parent",
+        defer_build=defer_build,
+    )
+
+
+def _deep_transitive_family(
+    wrapper_annotation: Any,
+    *,
+    case: str,
+) -> SchemaFamily[Any]:
+    historical_child = create_model(
+        f"ExplicitDeepTransitive{case.title().replace('_', '')}HistoricalChild",
+        wrapper=(wrapper_annotation, ...),
+    )
+    return _managed_child_family(
+        model=_DeepTransitiveParent,
+        child_family=_DEEP_TRANSITIVE_CHILD_FAMILY,
+        annotation=historical_child,
+        case=case,
+        prefix="deep_transitive_parent",
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("model", _BroadTransitiveChildModel),
+        ("dataclass", _BroadTransitiveChildDataclass),
+        ("typed_dict", _BroadTransitiveChildTypedDict),
+        ("bound_generic_typed_dict", _GenericTransitiveChildTypedDict[Any]),
+        (
+            "qualified_generic_typed_dict",
+            _QualifiedGenericTransitiveChildTypedDict[Any],
+        ),
+        (
+            "generic_typed_dict_union",
+            _GenericTransitiveChildTypedDict[int] | _GenericTransitiveChildTypedDict[Any],
+        ),
+    ],
+)
+def test_structural_child_representation_recurses_into_nested_route_annotations(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(annotation, case=case)
+
+    with pytest.raises(UnsupportedWireModelError, match="broad annotation") as exc_info:
+        family.model_for("1")
+
+    message = str(exc_info.value)
+    assert "explicit_annotation_transitive_child" in message
+    assert "nested path ('grandchild',)" in message
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        (
+            "wrapped",
+            _deep_wrapper_representations[_DeepWrapperAlias],
+        ),
+        ("recursive", _recursive_deep_wrapper),
+    ],
+)
+def test_structural_child_representation_recurses_through_multicomponent_routes(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _deep_transitive_family(annotation, case=case)
+
+    with pytest.raises(UnsupportedWireModelError, match="broad annotation") as exc_info:
+        family.model_for("1")
+
+    assert "nested path ('wrapper', 'grandchild')" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        (
+            "stdlib",
+            _GenericTransitiveChildDataclass[str]
+            | _GenericTransitiveChildDataclass[_HistoricalChildModel],
+        ),
+        (
+            "pydantic",
+            _GenericTransitiveChildPydanticDataclass[str]
+            | _GenericTransitiveChildPydanticDataclass[_HistoricalChildModel],
+        ),
+        (
+            "plain_alias",
+            _StringTransitiveChildDataclass | _ModelTransitiveChildDataclass,
+        ),
+        (
+            "bound_type_parameter",
+            _transitive_dataclass_union[_GenericTransitiveChildDataclass[_HistoricalChildModel]],
+        ),
+        (
+            "constrained_type_parameter",
+            _ambiguous_transitive_dataclass_constraint,
+        ),
+        (
+            "applied_alias_arms",
+            _transitive_dataclass_identity[_GenericTransitiveChildDataclass[str]]
+            | _transitive_dataclass_identity[
+                _GenericTransitiveChildDataclass[_HistoricalChildModel]
+            ],
+        ),
+        (
+            "new_type",
+            _StringTransitiveChildDataclassNewType
+            | _GenericTransitiveChildDataclass[_HistoricalChildModel],
+        ),
+        (
+            "annotated",
+            Annotated[
+                _GenericTransitiveChildDataclass[str],
+                Field(description="legacy child"),
+            ]
+            | _GenericTransitiveChildDataclass[_HistoricalChildModel],
+        ),
+        (
+            "list",
+            list[_GenericTransitiveChildDataclass[str]]
+            | list[_GenericTransitiveChildDataclass[_HistoricalChildModel]],
+        ),
+        (
+            "coercible_list_tuple",
+            list[_GenericTransitiveChildDataclass[str]]
+            | tuple[_GenericTransitiveChildDataclass[_HistoricalChildModel], ...],
+        ),
+        (
+            "coercible_tuple_list_reversed",
+            tuple[_GenericTransitiveChildDataclass[_HistoricalChildModel], ...]
+            | list[_GenericTransitiveChildDataclass[str]],
+        ),
+        (
+            "same_fixed_tuple_position",
+            tuple[_GenericTransitiveChildDataclass[str], str]
+            | tuple[_GenericTransitiveChildDataclass[_HistoricalChildModel], str],
+        ),
+        (
+            "typed_dict_erased_origin",
+            _GenericDataclassTransitiveTypedDict[str]
+            | _GenericDataclassTransitiveTypedDict[_HistoricalChildModel],
+        ),
+    ],
+)
+def test_managed_union_rejects_distinct_generic_dataclass_parameterizations(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(
+        annotation,
+        case=f"ambiguous_generic_dataclass_union_{case}",
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="multiple parameterizations of the same dataclass origin",
+    ):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("dataclass", _SafeTransitiveChildDataclass),
+        (
+            "dataclass_default_overrides_exclusion",
+            _DefaultOverridesAnnotatedManagedChildDataclass,
+        ),
+        (
+            "typed_dict_later_annotated_field_info",
+            _LaterAnnotatedFieldInfoWinsManagedChildTypedDict,
+        ),
+        ("generic_typed_dict", _GenericTransitiveChildTypedDict[int]),
+        (
+            "qualified_generic_typed_dict",
+            _QualifiedGenericTransitiveChildTypedDict[int],
+        ),
+        ("defaulted_generic_typed_dict", _DefaultGenericTransitiveChildTypedDict),
+        ("omitted", _OmittedTransitiveChildDataclass),
+        (
+            "omitted_default_overrides_annotated_alias",
+            _DefaultOverridesAnnotatedOmittedTransitiveChildDataclass,
+        ),
+        (
+            "omitted_empty_alias_overrides_annotated_alias",
+            _EmptyAliasOverridesAnnotatedOmittedTransitiveChildDataclass,
+        ),
+        (
+            "omitted_explicitly_cleared_serialization_alias",
+            _ClearedSerializationAliasOmittedTransitiveChildDataclass,
+        ),
+        (
+            "alias_collection_union",
+            _transitive_representations[_SafeTransitiveChildDataclass],
+        ),
+        (
+            "generic_dataclass_distinct_fixed_tuple_positions",
+            tuple[_GenericTransitiveChildDataclass[str], str]
+            | tuple[str, _GenericTransitiveChildDataclass[_HistoricalChildModel]],
+        ),
+    ],
+)
+def test_structural_child_representation_preserves_safe_and_omitted_semantics(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(annotation, case=f"safe_{case}")
+
+    historical = family.model_for("1")
+
+    assert "child" in historical.model_fields
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation", "diagnostic"),
+    [
+        (
+            "direct",
+            _SerializedTransitiveChildDataclass,
+            "serializes field 'grandchild'",
+        ),
+        (
+            "inherited",
+            _InheritedSerializedTransitiveChildDataclass,
+            "serializes field 'grandchild'",
+        ),
+        (
+            "pydantic",
+            _PydanticSerializedTransitiveChildDataclass,
+            "serializes field 'grandchild'",
+        ),
+        (
+            "annotation",
+            _AnnotatedSerializedTransitiveChildDataclass,
+            "annotation-level serializer on field 'grandchild'",
+        ),
+    ],
+)
+def test_structural_child_representation_rejects_inner_serializer(
+    case: str,
+    annotation: Any,
+    diagnostic: str,
+) -> None:
+    family = _transitive_family(annotation, case=f"inner_serializer_{case}")
+
+    with pytest.raises(UnsupportedWireModelError, match=diagnostic):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("model", _ExcludedTransitiveChildModel),
+        ("dataclass", _ExcludedTransitiveChildDataclass),
+        ("dataclass_metadata", _MetadataExcludedTransitiveChildDataclass),
+        ("typed_dict", _ExcludedTransitiveChildTypedDict),
+    ],
+)
+def test_transitive_explicit_historical_managed_path_rejects_serialization_exclusion(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(annotation, case=f"inner_exclusion_{case}")
+
+    with pytest.raises(UnsupportedWireModelError, match="excludes field 'grandchild'"):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("dataclass", _GeneratedAliasTransitiveChildDataclass),
+        ("typed_dict", _GeneratedAliasTransitiveChildTypedDict),
+    ],
+)
+def test_structural_child_representation_rejects_unmaterialized_alias_generator(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(annotation, case=f"alias_generator_{case}")
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="unmaterialized alias_generator",
+    ):
+        family.model_for("1")
+
+
+def test_structural_child_representation_rejects_json_encoders() -> None:
+    with pytest.warns(DeprecationWarning, match="json_encoders"):
+
+        class JsonEncodedChild(BaseModel):
+            model_config = ConfigDict(
+                json_encoders={str: lambda value: {"relocated": value}},
+            )
+
+            grandchild: str
+
+    family = _transitive_family(JsonEncodedChild, case="json_encoders")
+
+    with pytest.raises(UnsupportedWireModelError, match="configures json_encoders"):
+        family.model_for("1")
+
+
+def test_structural_child_representation_rejects_unresolved_field_hints() -> None:
+    @dataclass
+    class LocalChild:
+        grandchild: _OnlyVisibleInThisTest
+
+    class _OnlyVisibleInThisTest(BaseModel):
+        value: int
+
+    family = _transitive_family(
+        LocalChild,
+        case="unresolved_field_hints",
+        defer_build=True,
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="unresolved field annotations",
+    ):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("model", _ComputedOmittedTransitiveChildModel),
+        (
+            "pydantic_dataclass",
+            _ComputedOmittedTransitiveChildPydanticDataclass,
+        ),
+    ],
+)
+def test_structural_child_representation_reserves_omitted_computed_output(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(annotation, case=f"omitted_computed_{case}")
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="computed field 'legacy_grandchild'.*managed component 'grandchild'",
+    ):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("dataclass", _AliasedOmittedTransitiveChildDataclass),
+        ("dataclass_default", _DefaultAliasedOmittedTransitiveChildDataclass),
+        ("dataclass_metadata", _MetadataAliasedOmittedTransitiveChildDataclass),
+        (
+            "dataclass_default_precedence",
+            _DefaultOccupiesAnnotatedOmittedTransitiveChildDataclass,
+        ),
+        (
+            "dataclass_metadata_precedence",
+            _MetadataOccupiesAnnotatedOmittedTransitiveChildDataclass,
+        ),
+        ("typed_dict", _AliasedOmittedTransitiveChildTypedDict),
+        (
+            "typed_dict_later_annotated_alias",
+            _LaterAnnotatedAliasOmittedTransitiveChildTypedDict,
+        ),
+    ],
+)
+def test_structural_child_representation_reserves_omitted_nested_route_alias(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _transitive_family(annotation, case=f"omitted_alias_{case}")
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="occupies managed component 'grandchild'.*alias",
+    ):
+        family.model_for("1")
+
+
+def test_omitted_managed_path_rejects_field_alias_occupancy() -> None:
+    class HistoricalParent(BaseModel):
+        legacy_child: _HistoricalChildModel = Field(
+            validation_alias="child",
+            serialization_alias="child",
+        )
+
+    family = SchemaFamily(
+        model=_Parent,
+        name="explicit_annotation_omitted_alias",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily("child", _CHILD_FAMILY, matching_labels()),),
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="field 'legacy_child'.*managed component 'child'.*alias",
+    ):
+        family.model_for("1")
+
+
+def test_omitted_managed_path_rejects_computed_field_output_occupancy() -> None:
+    class ExactHistoricalParent(BaseModel):
+        @computed_field
+        @property
+        def child(self) -> dict[str, Any]:
+            return {"value": 1, "schema_version": "secret"}
+
+    class AliasedHistoricalParent(BaseModel):
+        @computed_field(alias="child")
+        @property
+        def derived_child(self) -> dict[str, Any]:
+            return {"value": 1, "schema_version": "secret"}
+
+    for case, historical_parent, computed_name in (
+        ("exact", ExactHistoricalParent, "child"),
+        ("alias", AliasedHistoricalParent, "derived_child"),
+    ):
+        family = SchemaFamily(
+            model=_Parent,
+            name=f"explicit_annotation_omitted_computed_{case}",
+            versions=(
+                SchemaVersion("1", wire_model=historical_parent),
+                SchemaVersion("2"),
+            ),
+            nested=(NestedFamily("child", _CHILD_FAMILY, matching_labels()),),
+        )
+
+        with pytest.raises(
+            UnsupportedWireModelError,
+            match=rf"computed field '{computed_name}'.*managed component 'child'",
+        ):
+            family.model_for("1")
+
+
+def test_unrelated_broad_fields_do_not_affect_the_managed_path_contract() -> None:
+    class HistoricalParent(BaseModel):
+        child: str
+        unrelated_payload: Any = "visible"
+        unrelated_mapping: Mapping[str, Any] = Field(default_factory=dict)
+        unrelated_excluded: str = Field("excluded", exclude=True)
+        unrelated_conditionally_excluded: str = Field(
+            "conditionally-excluded",
+            exclude_if=lambda value: value == "conditionally-excluded",
+        )
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {"child": {"value": int(data["child"])}}
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {"child": str(data["child"]["value"])}
+
+    family = SchemaFamily(
+        model=_Parent,
+        name="explicit_annotation_unrelated_broad_fields",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=upgrade,
+                downgrade=downgrade,
+                downgrade_semantics="exact",
+            ),
+        ),
+        nested=(NestedFamily("child", _CHILD_FAMILY, matching_labels()),),
+    )
+
+    historical = family.model_for("1")
+
+    assert {
+        "child",
+        "unrelated_payload",
+        "unrelated_mapping",
+        "unrelated_excluded",
+        "unrelated_conditionally_excluded",
+        "schema_version",
+    } == set(historical.model_fields)
+    assert family.dump(version="1", data=_Parent(child=_Child(value=7))) == {
+        "child": "7",
+        "unrelated_payload": "visible",
+        "unrelated_mapping": {},
+        "schema_version": "1",
+    }
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation", "diagnostic"),
+    [
+        ("custom_container", _CustomList, "abstract or custom container"),
+        ("opaque_annotation", Never, "unsupported opaque annotation"),
+    ],
+)
+def test_explicit_managed_leaf_rejects_arbitrary_shape_erasing_types(
+    case: str,
+    annotation: Any,
+    diagnostic: str,
+) -> None:
+    if annotation is Never:
+        with pytest.warns(UserWarning, match="not a Python type"):
+            family = _leaf_family(
+                annotation,
+                case=case,
+                arbitrary_types_allowed=True,
+            )
+    else:
+        family = _leaf_family(
+            annotation,
+            case=case,
+            arbitrary_types_allowed=True,
+        )
+
+    with pytest.raises(UnsupportedWireModelError, match=diagnostic):
+        family.model_for("1")
+
+
+class _Wrapper(BaseModel):
+    child: _Child
+
+
+class _WrappedParent(BaseModel):
+    wrapper: _Wrapper
+
+
+class _HistoricalWrapperModel(BaseModel):
+    child: str
+
+
+@dataclass
+class _HistoricalWrapperDataclass:
+    child: str
+
+
+class _HistoricalWrapperTypedDict(TypedDict):
+    child: str
+
+
+def _intermediate_family(annotation: Any, *, case: str) -> SchemaFamily[_WrappedParent]:
+    historical_parent = create_model(
+        f"ExplicitIntermediate{case.title().replace('_', '')}HistoricalParent",
+        wrapper=(annotation, ...),
+    )
+    return SchemaFamily(
+        model=_WrappedParent,
+        name=f"explicit_intermediate_annotation_{case}",
+        versions=(
+            SchemaVersion("1", wire_model=historical_parent),
+            SchemaVersion("2"),
+        ),
+        nested=(NestedFamily(("wrapper", "child"), _CHILD_FAMILY, matching_labels()),),
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation", "diagnostic"),
+    [
+        ("dataclass", _HistoricalWrapperDataclass, "dataclass at an intermediate"),
+        ("typed_dict", _HistoricalWrapperTypedDict, "TypedDict at an intermediate"),
+        ("broad", Any, "broad annotation"),
+    ],
+)
+def test_explicit_managed_path_rejects_untraversed_structured_intermediates(
+    case: str,
+    annotation: Any,
+    diagnostic: str,
+) -> None:
+    family = _intermediate_family(annotation, case=case)
+
+    with pytest.raises(UnsupportedWireModelError, match=diagnostic):
+        family.model_for("1")
+
+
+@pytest.mark.parametrize(
+    ("case", "annotation"),
+    [
+        ("model_collection", list[_HistoricalWrapperModel]),
+        ("model_or_scalar", _HistoricalWrapperModel | str),
+    ],
+)
+def test_explicit_managed_path_accepts_traversable_or_scalar_intermediates(
+    case: str,
+    annotation: Any,
+) -> None:
+    family = _intermediate_family(annotation, case=f"safe_{case}")
+
+    historical = family.model_for("1")
+
+    assert "wrapper" in historical.model_fields

--- a/tests/unit/test_explicit_nested_runtime_shape_contract.py
+++ b/tests/unit/test_explicit_nested_runtime_shape_contract.py
@@ -1,0 +1,2946 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from enum import Enum
+from typing import Annotated, Any, Literal, NewType, NotRequired, Required, TypedDict, TypeVar, cast
+
+import pytest
+from pydantic import (
+    AliasChoices,
+    AliasPath,
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    create_model,
+    field_serializer,
+    field_validator,
+    model_validator,
+    with_config,
+)
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+from typing_extensions import ReadOnly
+from typing_extensions import TypeVar as ExtensionsTypeVar  # noqa: UP035
+
+from pydantic_versions import (
+    InvalidMigrationError,
+    NestedFamily,
+    SchemaFamily,
+    SchemaVersion,
+    SchemaVersionError,
+    TransitionFunc,
+    VersionMetadata,
+    VersionPath,
+    VersionTransition,
+    matching_labels,
+)
+
+type RuntimeItems[RuntimeItem] = list[RuntimeItem]
+type RuntimeScalarAlias = str
+type RuntimeUnionItems[RuntimeItem] = list[RuntimeItem] | tuple[RuntimeItem, ...]
+type RuntimeAnnotatedItems[RuntimeItem] = Annotated[list[RuntimeItem], Field(min_length=1)]
+RuntimeNewScalar = NewType("RuntimeNewScalar", str)
+RuntimeBoundScalar = TypeVar("RuntimeBoundScalar", bound=str)
+RuntimeConstrainedScalar = TypeVar("RuntimeConstrainedScalar", str, bytes)
+RuntimeDefaultScalar = ExtensionsTypeVar("RuntimeDefaultScalar", default=str)
+
+
+class RuntimeHistoricalMappingScalar(Enum):
+    legacy = {
+        "schema_version": "foreign",
+        "value": "mapping-secret",
+    }
+
+
+type RuntimeAliasedHistoricalScalar = Annotated[
+    RuntimeHistoricalMappingScalar,
+    Field(serialization_alias="legacyGrandchild"),
+]
+
+
+@dataclass
+class RuntimeAssignmentAliasRepresentation:
+    grandchild: RuntimeHistoricalMappingScalar = Field(
+        serialization_alias="legacyGrandchild",
+    )
+
+
+@dataclass
+class RuntimeMetadataAliasRepresentation:
+    grandchild: RuntimeHistoricalMappingScalar = dataclass_field(
+        metadata={"serialization_alias": "legacyGrandchild"},
+    )
+
+
+@dataclass
+class RuntimeAliasPrecedenceRepresentation:
+    grandchild: Annotated[
+        RuntimeHistoricalMappingScalar,
+        Field(serialization_alias="annotatedGrandchild"),
+    ] = dataclass_field(
+        default=Field(serialization_alias="assignedGrandchild"),
+        metadata={"serialization_alias": "metadataGrandchild"},
+    )
+
+
+@dataclass
+class RuntimeMergedAliasRepresentation:
+    grandchild: Annotated[
+        RuntimeHistoricalMappingScalar,
+        Field(serialization_alias="annotatedGrandchild"),
+    ] = dataclass_field(default=Field(exclude=False))
+
+
+@dataclass
+class RuntimeClearedAliasRepresentation:
+    grandchild: Annotated[
+        RuntimeHistoricalMappingScalar,
+        Field(alias="annotatedGrandchild"),
+    ] = Field(serialization_alias=None)
+
+
+class RuntimeBaseModelClearedAliasRepresentation(BaseModel):
+    grandchild: Annotated[
+        RuntimeHistoricalMappingScalar,
+        Field(alias="annotatedGrandchild"),
+    ] = Field(serialization_alias=None)
+
+
+@dataclass
+class RuntimeMultipleAnnotatedAliasRepresentation:
+    grandchild: Annotated[
+        RuntimeHistoricalMappingScalar,
+        Field(serialization_alias="firstGrandchild"),
+        Field(serialization_alias="secondGrandchild"),
+    ]
+
+
+@dataclass
+class RuntimeEmptyAliasRepresentation:
+    grandchild: Annotated[
+        RuntimeHistoricalMappingScalar,
+        Field(alias="lowerGrandchild"),
+    ] = dataclass_field(
+        metadata={
+            "validation_alias": "",
+            "serialization_alias": "",
+        },
+    )
+
+
+@dataclass
+class RuntimeTypeAliasRepresentation:
+    grandchild: RuntimeAliasedHistoricalScalar
+
+
+class RuntimeTypedDictAliasRepresentation[Item](TypedDict):
+    grandchild: Annotated[Item, Field(serialization_alias="legacyGrandchild")]
+
+
+class RuntimeSmartUnionGrandchildPayload(TypedDict):
+    value: int
+    schema_version: str
+
+
+class RuntimeSmartUnionExactTypedDictArm(TypedDict):
+    grandchild: RuntimeSmartUnionGrandchildPayload
+    alternate: RuntimeSmartUnionGrandchildPayload
+
+
+class RuntimePreflightGrandchildRepresentation(BaseModel):
+    value: int
+
+
+@dataclass
+class RuntimePreflightDataclassAliasRepresentation:
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(
+            validation_alias=AliasChoices(
+                "legacyGrandchild",
+                AliasPath("legacy", "grandchild"),
+            ),
+        ),
+    ]
+
+
+class RuntimePreflightTypedDictAliasRepresentation(TypedDict):
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias=AliasPath("legacy", "grandchild")),
+    ]
+
+
+@dataclass
+class RuntimePreflightAliasDisabledDataclassRepresentation:
+    __pydantic_config__ = ConfigDict(validate_by_alias=False)
+
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="legacyGrandchild"),
+    ]
+
+
+@with_config(ConfigDict(validate_by_alias=False))
+class RuntimePreflightAliasDisabledTypedDictRepresentation(TypedDict):
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="legacyGrandchild"),
+    ]
+
+
+@dataclass
+class RuntimePreflightPopulateByNameDataclassRepresentation:
+    __pydantic_config__ = ConfigDict(populate_by_name=True)
+
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="legacyGrandchild"),
+    ]
+
+
+@with_config(ConfigDict(populate_by_name=True))
+class RuntimePreflightPopulateByNameTypedDictRepresentation(TypedDict):
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="legacyGrandchild"),
+    ]
+
+
+@dataclass
+class RuntimePreflightClearedAliasRepresentation:
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="legacyGrandchild"),
+    ] = Field(alias=None)
+
+
+@dataclass
+class RuntimePreflightMultipleAnnotatedAliasRepresentation:
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="firstGrandchild"),
+        Field(validation_alias="secondGrandchild"),
+    ]
+
+
+@dataclass
+class RuntimePreflightMetadataAliasRepresentation:
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="annotatedGrandchild"),
+    ] = dataclass_field(metadata={"validation_alias": "metadataGrandchild"})
+
+
+@dataclass
+class RuntimePreflightAssignedAliasRepresentation:
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(validation_alias="annotatedGrandchild"),
+    ] = dataclass_field(
+        default=Field(validation_alias="assignedGrandchild"),
+        metadata={"validation_alias": "metadataGrandchild"},
+    )
+
+
+@dataclass
+class RuntimePreflightEmptyAliasRepresentation:
+    grandchild: Annotated[
+        RuntimePreflightGrandchildRepresentation,
+        Field(alias="lowerGrandchild"),
+    ] = dataclass_field(
+        metadata={
+            "validation_alias": "",
+            "serialization_alias": "",
+        },
+    )
+
+
+_DEFAULT_RUNTIME_VERSION_METADATA = VersionMetadata()
+
+
+def _runtime_family(
+    *,
+    model: type[BaseModel],
+    name: str,
+    wire_model: type[BaseModel] | None = None,
+    upgrade: TransitionFunc | None = None,
+    downgrade: TransitionFunc | None = None,
+    exact_downgrade: bool = False,
+    nested: tuple[NestedFamily, ...] = (),
+    version_metadata: VersionMetadata | None = _DEFAULT_RUNTIME_VERSION_METADATA,
+) -> SchemaFamily[Any]:
+    transitions = (
+        (
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=upgrade,
+                downgrade=downgrade,
+                downgrade_semantics="exact" if exact_downgrade else None,
+            ),
+        )
+        if upgrade is not None or downgrade is not None
+        else ()
+    )
+    return SchemaFamily(
+        model=model,
+        name=name,
+        versions=(
+            SchemaVersion("1", wire_model=wire_model)
+            if wire_model is not None
+            else SchemaVersion("1"),
+            SchemaVersion("2"),
+        ),
+        transitions=transitions,
+        nested=nested,
+        version_metadata=version_metadata,
+    )
+
+
+def _nested_runtime_family(
+    *,
+    model: type[BaseModel],
+    name: str,
+    child_family: SchemaFamily[Any],
+    nested_path: VersionPath,
+    wire_model: type[BaseModel] | None = None,
+    upgrade: TransitionFunc | None = None,
+    downgrade: TransitionFunc | None = None,
+    exact_downgrade: bool = False,
+    version_metadata: VersionMetadata | None = _DEFAULT_RUNTIME_VERSION_METADATA,
+) -> SchemaFamily[Any]:
+    return _runtime_family(
+        model=model,
+        name=name,
+        wire_model=wire_model,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=exact_downgrade,
+        nested=(NestedFamily(nested_path, child_family, matching_labels()),),
+        version_metadata=version_metadata,
+    )
+
+
+def test_explicit_source_rejects_shape_break_before_migration_without_payload() -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_source_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        children: list[Child]
+
+    class HistoricalParent(BaseModel):
+        children: RuntimeItems[str]
+
+        @field_validator("children", mode="after")
+        @classmethod
+        def break_declared_shape(cls, value: list[str]) -> Any:
+            return [{"foreign_version": value[0]}]
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"children": [{"value": int(item)} for item in data["children"]]}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_source_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path="children",
+        version_metadata=None,
+    )
+
+    secret = "source-secret"
+    with pytest.raises(ValueError) as caught:
+        family.validate({"children": [secret]}, version="1")
+
+    message = str(caught.value)
+    assert "runtime_shape_source_parent" in message
+    assert "version '1'" in message
+    assert "nested path ('children',)" in message
+    assert secret not in message
+    assert migrations == []
+
+
+def test_explicit_source_rejects_shape_break_from_model_validator() -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_root_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: str
+
+        @model_validator(mode="after")
+        def break_model_shape(self) -> Any:
+            return {"child": self.child}
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"child": {"value": int(data["child"])}}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_root_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match=r"nested path \('child',\)"):
+        family.validate({"child": "8"}, version="1")
+
+    assert migrations == []
+
+
+def test_exact_union_subclass_cannot_be_masked_by_a_base_arm() -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_union_subclass_child",
+        version_metadata=None,
+    )
+
+    class Wrapper(BaseModel):
+        child: Child
+
+    class Parent(BaseModel):
+        wrapper: Wrapper
+
+    class HistoricalBase(BaseModel):
+        note: str = "base"
+
+    class HistoricalWrapper(HistoricalBase):
+        child: str
+
+        @field_validator("child", mode="after")
+        @classmethod
+        def break_declared_shape(cls, value: str) -> Any:
+            return {"payload": value}
+
+    class HistoricalParent(BaseModel):
+        wrapper: HistoricalBase | HistoricalWrapper
+
+    def upgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"wrapper": {"child": {"value": 1}}}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_union_subclass_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path=("wrapper", "child"),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.validate(
+            {"wrapper": HistoricalWrapper(child="union-secret")},
+            version="1",
+        )
+
+    message = str(caught.value)
+    assert "runtime_shape_union_subclass_parent" in message
+    assert "nested path ('wrapper', 'child')" in message
+    assert "union-secret" not in message
+    assert migrations == []
+
+    base_arm = family.validate(
+        {"wrapper": HistoricalBase(note="whole-subtree")},
+        version="1",
+    )
+    assert base_arm.current_model == Parent(wrapper=Wrapper(child=Child(value=1)))
+    assert migrations == ["upgrade"]
+
+
+def test_fixed_tuple_union_members_preserve_model_and_scalar_arms() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_fixed_tuple_child",
+        version_metadata=None,
+    )
+
+    class Wrapper(BaseModel):
+        child: Child
+
+    class Parent(BaseModel):
+        wrappers: list[Wrapper]
+
+    class HistoricalWrapper(BaseModel):
+        child: str
+
+    class HistoricalParent(BaseModel):
+        wrappers: tuple[HistoricalWrapper, str]
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "wrappers": [
+                {
+                    "child": {
+                        "value": int(data["wrappers"][0]["child"]),
+                    },
+                },
+            ],
+        }
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_fixed_tuple_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path=("wrappers", "child"),
+        version_metadata=None,
+    )
+
+    validated = family.validate(
+        {
+            "wrappers": [
+                {"child": "9"},
+                "whole-subtree",
+            ],
+        },
+        version="1",
+    )
+
+    assert validated.current_model == Parent(wrappers=[Wrapper(child=Child(value=9))])
+
+
+def test_explicit_source_rejects_a_deleted_declared_managed_field() -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_deleted_source_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: str
+
+        @model_validator(mode="after")
+        def delete_child(self) -> HistoricalParent:
+            return type(self).model_construct()
+
+    def upgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"child": {"value": 1}}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_deleted_source_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.validate({"child": "deleted-source-secret"}, version="1")
+
+    assert "runtime_shape_deleted_source_parent" in str(caught.value)
+    assert "deleted-source-secret" not in str(caught.value)
+    assert migrations == []
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["target", "defaults_for", "dump_none"],
+    ids=["target", "defaults", "dump-none"],
+)
+def test_explicit_target_and_defaults_reject_a_deleted_managed_field(
+    operation: str,
+) -> None:
+    events: list[str] = []
+
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_deleted_target_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(default_factory=Child)
+
+    class HistoricalParent(BaseModel):
+        child: str = "deleted-default-secret"
+        audit: str = "audit"
+
+        @model_validator(mode="after")
+        def delete_child(self) -> HistoricalParent:
+            incomplete = type(self).model_construct(audit=self.audit)
+            del incomplete.child
+            return incomplete
+
+        @field_serializer("audit")
+        def serialize_audit(self, value: str) -> str:
+            events.append("serializer")
+            return value
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("downgrade")
+        return {
+            "child": f"deleted-target-secret-{data['child']['value']}",
+            "audit": "audit",
+        }
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_deleted_target_parent",
+        wire_model=HistoricalParent,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        if operation == "target":
+            family.dump(version="1", data=Parent(child=Child(value=7)))
+        elif operation == "defaults_for":
+            family.defaults_for(version="1")
+        else:
+            family.dump(version="1", data=None)
+
+    message = str(caught.value)
+    assert "runtime_shape_deleted_target_parent" in message
+    assert "deleted-target-secret" not in message
+    assert "deleted-default-secret" not in message
+    assert events == (["downgrade"] if operation == "target" else [])
+
+
+def test_explicit_source_rejects_an_extra_at_an_omitted_managed_route() -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_omitted_source_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        note: str
+
+    def upgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"child": {"value": 1}}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_omitted_source_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.validate(
+            {
+                "note": "historical",
+                "child": {
+                    "value": "omitted-source-secret",
+                },
+            },
+            version="1",
+        )
+
+    assert "runtime_shape_omitted_source_parent" in str(caught.value)
+    assert "omitted-source-secret" not in str(caught.value)
+    assert migrations == []
+
+
+@pytest.mark.parametrize(
+    "mutated",
+    [
+        "not-an-object",
+        {},
+        {"value": 1, "foreign": "typed-secret"},
+        {"value": "wrong-type"},
+    ],
+    ids=["not-mapping", "missing-required", "extra-key", "wrong-value-shape"],
+)
+def test_explicit_source_rejects_typed_dict_after_validator_mutations(
+    mutated: Any,
+) -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_typed_dict_child",
+        version_metadata=None,
+    )
+
+    class HistoricalBody(TypedDict):
+        value: int
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalBody
+
+        @field_validator("child", mode="after")
+        @classmethod
+        def mutate_body(cls, _value: HistoricalBody) -> Any:
+            return mutated
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"child": data["child"]}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_typed_dict_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.validate({"child": {"value": 1}}, version="1")
+
+    assert "runtime_shape_typed_dict_parent" in str(caught.value)
+    assert "typed-secret" not in str(caught.value)
+    assert migrations == []
+
+
+def test_explicit_target_rejects_shape_break_before_serialization_without_payload() -> None:
+    events: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_target_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+        audit: str
+
+    class HistoricalParent(BaseModel):
+        child: str
+        audit: str
+
+        @field_validator("child", mode="after")
+        @classmethod
+        def break_declared_shape(cls, value: str) -> Any:
+            return {"foreign_version": value}
+
+        @field_serializer("audit")
+        def serialize_audit(self, value: str) -> str:
+            events.append("serializer")
+            return value
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("downgrade")
+        return {"child": str(data["child"]["value"]), "audit": data["audit"]}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_target_parent",
+        wire_model=HistoricalParent,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.dump(
+            version="1",
+            data=Parent(child=Child(value=7), audit="target-secret"),
+        )
+
+    message = str(caught.value)
+    assert "runtime_shape_target_parent" in message
+    assert "version '1'" in message
+    assert "nested path ('child',)" in message
+    assert "target-secret" not in message
+    assert events == ["downgrade"]
+
+
+def test_explicit_defaults_reject_shape_break_before_serialization() -> None:
+    serializers: list[str] = []
+
+    class Child(BaseModel):
+        value: int = 1
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_defaults_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(default_factory=Child)
+
+    class HistoricalParent(BaseModel):
+        child: str = Field("default-secret", validate_default=True)
+        audit: str = "audit"
+
+        @field_validator("child", mode="after")
+        @classmethod
+        def break_declared_shape(cls, value: str) -> Any:
+            return {"foreign_version": value}
+
+        @field_serializer("audit")
+        def serialize_audit(self, value: str) -> str:
+            serializers.append("serializer")
+            return value
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_defaults_parent",
+        wire_model=HistoricalParent,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError, match=r"nested path \('child',\)") as caught:
+        family.dump(version="1")
+
+    assert "default-secret" not in str(caught.value)
+    assert serializers == []
+
+
+def test_parameterized_alias_shape_preserving_validator_remains_supported() -> None:
+    serializers: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_alias_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        children: list[Child]
+        audit: str
+
+    class HistoricalParent(BaseModel):
+        children: RuntimeItems[str] | None
+        audit: str
+
+        @field_validator("children", mode="after")
+        @classmethod
+        def preserve_declared_shape(cls, value: list[str] | None) -> list[str] | None:
+            return None if value is None else [item.strip() for item in value]
+
+        @field_serializer("audit")
+        def serialize_audit(self, value: str) -> str:
+            serializers.append("serializer")
+            return value
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        children = data["children"]
+        return {
+            "children": None if children is None else [{"value": int(item)} for item in children],
+            "audit": data["audit"],
+        }
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        children = data["children"]
+        return {
+            "children": None if children is None else [str(child["value"]) for child in children],
+            "audit": data["audit"],
+        }
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_alias_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="children",
+        version_metadata=None,
+    )
+
+    validated = family.validate(
+        {"children": [" 7 "], "audit": "source"},
+        version="1",
+    )
+    assert validated.current_model == Parent(
+        children=[Child(value=7)],
+        audit="source",
+    )
+    assert family.dump(version="1", data=validated.current_model) == {
+        "children": ["7"],
+        "audit": "source",
+    }
+    assert serializers == ["serializer"]
+
+
+def test_supported_scalar_wrappers_preserve_their_runtime_contract() -> None:
+    field_names = (
+        "aliased",
+        "new_type",
+        "bounded",
+        "constrained",
+        "defaulted",
+    )
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_wrappers_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        aliased: Child
+        new_type: Child
+        bounded: Child
+        constrained: Child
+        defaulted: Child
+        union_items: list[Child]
+        annotated_items: list[Child]
+
+    historical_parent = create_model(
+        "RuntimeShapeWrappersHistoricalParent",
+        aliased=(RuntimeScalarAlias, ...),
+        new_type=(RuntimeNewScalar, ...),
+        bounded=(RuntimeBoundScalar, ...),
+        constrained=(RuntimeConstrainedScalar, ...),
+        defaulted=(RuntimeDefaultScalar, ...),
+        union_items=(RuntimeUnionItems[str], ...),
+        annotated_items=(RuntimeAnnotatedItems[str], ...),
+    )
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        upgraded: dict[str, Any] = {name: {"value": int(data[name])} for name in field_names}
+        upgraded["union_items"] = [{"value": int(item)} for item in data["union_items"]]
+        upgraded["annotated_items"] = [{"value": int(item)} for item in data["annotated_items"]]
+        return upgraded
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        downgraded: dict[str, Any] = {name: str(data[name]["value"]) for name in field_names}
+        downgraded["union_items"] = tuple(str(item["value"]) for item in data["union_items"])
+        downgraded["annotated_items"] = [str(item["value"]) for item in data["annotated_items"]]
+        return downgraded
+
+    family = _runtime_family(
+        model=Parent,
+        name="runtime_shape_wrappers_parent",
+        wire_model=historical_parent,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        nested=tuple(
+            NestedFamily(name, child_family, matching_labels())
+            for name in (*field_names, "union_items", "annotated_items")
+        ),
+        version_metadata=None,
+    )
+    historical = {
+        **{name: f" {index} " for index, name in enumerate(field_names, start=1)},
+        "union_items": [" 6 "],
+        "annotated_items": [" 7 "],
+    }
+
+    validated = family.validate(historical, version="1")
+    assert {
+        name: validated.current_model.model_dump()[name]["value"] for name in field_names
+    } == dict(zip(field_names, range(1, 6), strict=True))
+    assert validated.current_model.union_items == [Child(value=6)]
+    assert validated.current_model.annotated_items == [Child(value=7)]
+    assert family.dump(version="1", data=validated.current_model) == {
+        **{name: str(index) for index, name in enumerate(field_names, start=1)},
+        "union_items": ["6"],
+        "annotated_items": ["7"],
+    }
+
+
+def test_nested_explicit_source_rejects_shape_break_before_child_migration() -> None:
+    migrations: list[str] = []
+
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_nested_grandchild",
+        version_metadata=None,
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+        @field_validator("grandchild", mode="after")
+        @classmethod
+        def break_declared_shape(cls, value: str) -> Any:
+            return {"foreign_version": value}
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("child-upgrade")
+        return {"grandchild": {"value": int(data["grandchild"])}}
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_nested_child",
+        wire_model=HistoricalChild,
+        upgrade=upgrade,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    @dataclass
+    class HistoricalChildRepresentation:
+        grandchild: str
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+
+    def upgrade_parent(data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("parent-upgrade")
+        return data
+
+    parent_family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_nested_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade_parent,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    secret = "nested-secret"
+    with pytest.raises(ValueError) as caught:
+        parent_family.validate(
+            {"child": {"grandchild": secret}},
+            version="1",
+        )
+
+    message = str(caught.value)
+    assert "runtime_shape_nested_child" in message
+    assert "nested path ('grandchild',)" in message
+    assert secret not in message
+    assert migrations == []
+
+
+def test_applied_alias_collection_prunes_nested_child_metadata() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_alias_pruning_child",
+    )
+    historical_child = child_family.model_for("1")
+
+    class Wrapper(BaseModel):
+        child: Child
+
+    class Parent(BaseModel):
+        wrappers: list[Wrapper]
+
+    historical_wrapper = create_model(
+        "RuntimeShapeAliasPruningHistoricalWrapper",
+        child=(historical_child, ...),
+    )
+
+    applied_alias = cast(Any, RuntimeItems)[historical_wrapper]
+    historical_parent = create_model(
+        "RuntimeShapeAliasPruningHistoricalParent",
+        wrappers=(applied_alias, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_alias_pruning_parent",
+        wire_model=historical_parent,
+        child_family=child_family,
+        nested_path=("wrappers", "child"),
+    )
+
+    assert family.dump(
+        version="1",
+        data=Parent(wrappers=[Wrapper(child=Child(value=3))]),
+    ) == {
+        "wrappers": [{"child": {"value": 3}}],
+        "schema_version": "1",
+    }
+
+
+def test_scalar_enum_mapping_preserves_foreign_version_metadata() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_scalar_mapping_child",
+    )
+
+    class HistoricalScalar(Enum):
+        value = {
+            "schema_version": "foreign",
+            "value": "mapping-secret",
+        }
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalScalar
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {"child": {"value": 1}}
+
+    def downgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        return {"child": HistoricalScalar.value}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_scalar_mapping_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    assert family.dump(
+        version="1",
+        data=Parent(child=Child(value=4)),
+    ) == {
+        "child": {
+            "schema_version": "foreign",
+            "value": "mapping-secret",
+        },
+    }
+
+
+def test_omitted_nested_route_rejects_target_extra_without_payload() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_omitted_extra_child",
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        note: str
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {"child": {"value": 1}}
+
+    def downgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "note": "historical",
+            "child": {
+                "schema_version": "foreign",
+                "value": "omitted-secret",
+            },
+        }
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_omitted_extra_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.dump(
+            version="1",
+            data=Parent(child=Child(value=4)),
+        )
+
+    message = str(caught.value)
+    assert "runtime_shape_omitted_extra_child" in message
+    assert "does not match expected label" in message
+    assert "omitted-secret" not in message
+
+
+def test_empty_tuple_nested_replacement_preserves_zero_cardinality() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_empty_tuple_child",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        children: list[Child]
+
+    class HistoricalParent(BaseModel):
+        children: tuple[()]
+
+    def upgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        return {"children": []}
+
+    def downgrade(_data: dict[str, Any]) -> dict[str, Any]:
+        return {"children": ()}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_empty_tuple_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="children",
+        version_metadata=None,
+    )
+
+    assert family.validate({"children": []}, version="1").current_model == Parent(
+        children=[],
+    )
+    assert family.dump(version="1", data=Parent(children=[])) == {"children": []}
+
+
+def _recursive_target_family(events: list[str]) -> SchemaFamily[Any]:
+    class Grandchild(BaseModel):
+        value: int = 1
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_recursive_target_grandchild",
+        version_metadata=None,
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild = Field(default_factory=Grandchild)
+        audit: str = "audit"
+
+    class HistoricalChild(BaseModel):
+        grandchild: str = Field("recursive-default-secret", validate_default=True)
+        audit: str = "audit"
+
+        @field_validator("grandchild", mode="after")
+        @classmethod
+        def break_declared_shape(cls, value: str) -> Any:
+            events.append("validator")
+            return {"foreign_version": value}
+
+        @field_serializer("audit")
+        def serialize_audit(self, value: str) -> str:
+            events.append("serializer")
+            return value
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "grandchild": {"value": int(data["grandchild"])},
+            "audit": data["audit"],
+        }
+
+    def downgrade(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("downgrade")
+        return {
+            "grandchild": f"grandchild-secret-{data['grandchild']['value']}",
+            "audit": data["audit"],
+        }
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_recursive_target_child",
+        wire_model=HistoricalChild,
+        upgrade=upgrade,
+        downgrade=downgrade,
+        exact_downgrade=True,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(default_factory=Child)
+
+    return _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_recursive_target_parent",
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+
+def test_generated_target_recursively_rejects_explicit_child_shape_break() -> None:
+    events: list[str] = []
+    family = _recursive_target_family(events)
+
+    with pytest.raises(ValueError) as caught:
+        family.dump(
+            version="1",
+            data={
+                "child": {
+                    "grandchild": {"value": 7},
+                    "audit": "dump-secret",
+                },
+            },
+        )
+
+    message = str(caught.value)
+    assert "runtime_shape_recursive_target_child" in message
+    assert "version '1'" in message
+    assert "nested path ('grandchild',)" in message
+    assert "grandchild-secret" not in message
+    assert "dump-secret" not in message
+    assert events == ["downgrade", "validator"]
+
+
+@pytest.mark.parametrize("operation", ["defaults_for", "dump"], ids=["defaults", "dump-none"])
+def test_generated_defaults_recursively_reject_explicit_child_shape_break(
+    operation: str,
+) -> None:
+    events: list[str] = []
+    family = _recursive_target_family(events)
+
+    with pytest.raises(ValueError) as caught:
+        if operation == "defaults_for":
+            family.defaults_for(version="1")
+        else:
+            family.dump(version="1", data=None)
+
+    message = str(caught.value)
+    assert "runtime_shape_recursive_target_child" in message
+    assert "nested path ('grandchild',)" in message
+    assert "recursive-default-secret" not in message
+    assert events == ["validator"]
+
+
+@pytest.mark.parametrize("representation_kind", ["model", "dataclass"])
+def test_independent_structural_child_rejects_transitive_shape_break(
+    representation_kind: str,
+) -> None:
+    events: list[str] = []
+
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name=f"runtime_shape_transitive_{representation_kind}_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+    def downgrade_child(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("child-downgrade")
+        return {"grandchild": f"transitive-secret-{data['grandchild']['value']}"}
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name=f"runtime_shape_transitive_{representation_kind}_child",
+        wire_model=HistoricalChild,
+        downgrade=downgrade_child,
+        exact_downgrade=True,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    class Parent(BaseModel):
+        child: Child
+        audit: str
+
+    if representation_kind == "model":
+
+        class HistoricalChildRepresentation(BaseModel):
+            grandchild: str
+
+            @field_validator("grandchild", mode="after")
+            @classmethod
+            def corrupt_grandchild(cls, value: str) -> Any:
+                events.append("validator")
+                return {"schema_version": "foreign", "value": value}
+
+    else:
+
+        @pydantic_dataclass
+        class HistoricalChildRepresentation:
+            grandchild: str
+
+            @field_validator("grandchild", mode="after")
+            @classmethod
+            def corrupt_grandchild(cls, value: str) -> Any:
+                events.append("validator")
+                return {"schema_version": "foreign", "value": value}
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+        audit: str
+
+        @field_serializer("audit")
+        def serialize_audit(self, value: str) -> str:
+            events.append("serializer")
+            return value
+
+    def downgrade_parent(data: dict[str, Any]) -> dict[str, Any]:
+        events.append("parent-downgrade")
+        return data
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_transitive_{representation_kind}_parent",
+        wire_model=HistoricalParent,
+        downgrade=downgrade_parent,
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.dump(
+            version="1",
+            data=Parent(
+                child=Child(grandchild=Grandchild(value=7)),
+                audit="audit-secret",
+            ),
+        )
+
+    message = str(caught.value)
+    assert child_family.name in message
+    assert "nested path ('grandchild',)" in message
+    assert "transitive-secret" not in message
+    assert "audit-secret" not in message
+    assert events == ["child-downgrade", "parent-downgrade", "validator"]
+
+
+def test_alias_union_collection_rejects_transitive_dataclass_shape_break() -> None:
+    migrations: list[str] = []
+
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_alias_union_collection_grandchild",
+        version_metadata=None,
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_alias_union_collection_child",
+        wire_model=HistoricalChild,
+        upgrade=lambda data: migrations.append("child-upgrade") or data,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        children: list[Child]
+
+    @pydantic_dataclass
+    class HistoricalChildRepresentation:
+        grandchild: str
+
+    type HistoricalChildren = list[HistoricalChildRepresentation] | str
+
+    class HistoricalParent(BaseModel):
+        children: HistoricalChildren
+
+        @field_validator("children", mode="after")
+        @classmethod
+        def corrupt_grandchild(cls, value: HistoricalChildren) -> Any:
+            if isinstance(value, list):
+                value[0].grandchild = cast(
+                    Any,
+                    {
+                        "schema_version": "foreign",
+                        "value": "alias-union-collection-secret",
+                    },
+                )
+            return value
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_alias_union_collection_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: migrations.append("parent-upgrade") or data,
+        child_family=child_family,
+        nested_path="children",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.validate(
+            {"children": [{"grandchild": "7"}]},
+            version="1",
+        )
+
+    message = str(caught.value)
+    assert child_family.name in message
+    assert "nested path ('grandchild',)" in message
+    assert "alias-union-collection-secret" not in message
+    assert migrations == []
+
+
+def test_independent_dataclass_default_rejects_transitive_shape_break() -> None:
+    events: list[str] = []
+
+    class Grandchild(BaseModel):
+        value: int = 1
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_transitive_default_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild = Field(default_factory=Grandchild)
+
+    class HistoricalChild(BaseModel):
+        grandchild: str = "official"
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_transitive_default_child",
+        wire_model=HistoricalChild,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    class Parent(BaseModel):
+        child: Child = Field(default_factory=Child)
+
+    @pydantic_dataclass
+    class HistoricalChildRepresentation:
+        grandchild: str = Field("transitive-default-secret", validate_default=True)
+
+        @field_validator("grandchild", mode="after")
+        @classmethod
+        def corrupt_grandchild(cls, value: str) -> Any:
+            events.append("validator")
+            return {"schema_version": "foreign", "value": value}
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation = Field(
+            default_factory=HistoricalChildRepresentation,
+        )
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_transitive_default_parent",
+        wire_model=HistoricalParent,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.defaults_for(version="1")
+
+    message = str(caught.value)
+    assert child_family.name in message
+    assert "transitive-default-secret" not in message
+    assert events == ["validator"]
+
+
+@pytest.mark.filterwarnings("ignore:Item 'readonly'.*ReadOnly")
+def test_parameterized_typed_dict_qualifiers_are_checked_after_validation() -> None:
+    migrations: list[str] = []
+
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_generic_typed_dict_grandchild",
+        version_metadata=None,
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_generic_typed_dict_child",
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=None,
+    )
+
+    class HistoricalChildRepresentation[Item](TypedDict, total=False):
+        grandchild: Required[Item]
+        optional: NotRequired[Item]
+        readonly: ReadOnly[Item]
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation[str]
+
+        @field_validator("child", mode="after")
+        @classmethod
+        def corrupt_grandchild(
+            cls,
+            value: HistoricalChildRepresentation[str],
+        ) -> Any:
+            value["grandchild"] = cast(
+                Any,
+                {
+                    "schema_version": "foreign",
+                    "value": "typed-dict-secret",
+                },
+            )
+            return value
+
+    def upgrade(data: dict[str, Any]) -> dict[str, Any]:
+        migrations.append("upgrade")
+        return {"child": {"grandchild": {"value": 1}}}
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_generic_typed_dict_parent",
+        wire_model=HistoricalParent,
+        upgrade=upgrade,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.validate({"child": {"grandchild": "1"}}, version="1")
+
+    message = str(caught.value)
+    assert family.name in message
+    assert "typed-dict-secret" not in message
+    assert migrations == []
+
+
+@pytest.mark.parametrize(
+    "alias_style",
+    [
+        "assignment",
+        "base_model_cleared",
+        "cleared",
+        "empty",
+        "merged",
+        "metadata",
+        "multiple_annotated",
+        "precedence",
+        "type_alias",
+    ],
+)
+@pytest.mark.filterwarnings("ignore:The 'serialization_alias'.*no effect")
+def test_independent_structural_scalar_alias_preserves_foreign_metadata(
+    alias_style: str,
+) -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name=f"runtime_shape_dataclass_alias_{alias_style}_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name=f"runtime_shape_dataclass_alias_{alias_style}_child",
+        wire_model=HistoricalChild,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    representations = {
+        "assignment": RuntimeAssignmentAliasRepresentation,
+        "base_model_cleared": RuntimeBaseModelClearedAliasRepresentation,
+        "cleared": RuntimeClearedAliasRepresentation,
+        "empty": RuntimeEmptyAliasRepresentation,
+        "merged": RuntimeMergedAliasRepresentation,
+        "metadata": RuntimeMetadataAliasRepresentation,
+        "multiple_annotated": RuntimeMultipleAnnotatedAliasRepresentation,
+        "precedence": RuntimeAliasPrecedenceRepresentation,
+        "type_alias": RuntimeTypeAliasRepresentation,
+    }
+    historical_child_representation = representations[alias_style]
+    output_name = {
+        "assignment": "legacyGrandchild",
+        "base_model_cleared": "grandchild",
+        "cleared": "grandchild",
+        "empty": "",
+        "merged": "annotatedGrandchild",
+        "metadata": "legacyGrandchild",
+        "multiple_annotated": "secondGrandchild",
+        "precedence": "assignedGrandchild",
+        "type_alias": "grandchild",
+    }[alias_style]
+    input_name = {
+        "base_model_cleared": "annotatedGrandchild",
+        "cleared": "annotatedGrandchild",
+        "empty": "",
+    }.get(alias_style, "grandchild")
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        f"RuntimeDataclassAlias{alias_style.title()}HistoricalParent",
+        child=(historical_child_representation, ...),
+    )
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_dataclass_alias_{alias_style}_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        downgrade=lambda _data: {
+            "child": {input_name: RuntimeHistoricalMappingScalar.legacy},
+        },
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    dumped = family.dump(
+        version="1",
+        data=Parent(child=Child(grandchild=Grandchild(value=7))),
+    )
+    assert dumped == {
+        "child": {
+            output_name: {
+                "schema_version": "foreign",
+                "value": "mapping-secret",
+            },
+        },
+        "schema_version": "1",
+    }
+    assert family.dump(
+        version="1",
+        data=Parent(child=Child(grandchild=Grandchild(value=7))),
+        by_alias=False,
+    ) == {
+        "child": {
+            "grandchild": {
+                "schema_version": "foreign",
+                "value": "mapping-secret",
+            },
+        },
+        "schema_version": "1",
+    }
+
+
+def test_parameterized_typed_dict_scalar_alias_preserves_foreign_metadata() -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_typed_dict_alias_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_typed_dict_alias_child",
+        wire_model=HistoricalChild,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: RuntimeTypedDictAliasRepresentation[RuntimeHistoricalMappingScalar]
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_typed_dict_alias_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        downgrade=lambda _data: {
+            "child": {"grandchild": RuntimeHistoricalMappingScalar.legacy},
+        },
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    assert family.dump(
+        version="1",
+        data=Parent(child=Child(grandchild=Grandchild(value=7))),
+    ) == {
+        "child": {
+            "legacyGrandchild": {
+                "schema_version": "foreign",
+                "value": "mapping-secret",
+            },
+        },
+        "schema_version": "1",
+    }
+
+
+def test_independent_dataclass_can_omit_an_inner_managed_route() -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_structural_omission_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_structural_omission_child",
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    @dataclass
+    class HistoricalChildRepresentation:
+        note: str
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_structural_omission_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        downgrade=lambda _data: {"child": {"note": "historical"}},
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    assert family.dump(
+        version="1",
+        data=Parent(child=Child(grandchild=Grandchild(value=7))),
+    ) == {
+        "child": {"note": "historical"},
+        "schema_version": "1",
+    }
+
+
+@pytest.mark.parametrize("injection", ["declared_default", "computed"])
+def test_independent_structural_child_cannot_inject_foreign_family_metadata(
+    injection: str,
+) -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name=f"runtime_shape_metadata_{injection}_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name=f"runtime_shape_metadata_{injection}_child",
+        wire_model=HistoricalChild,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    if injection == "declared_default":
+
+        class HistoricalChildRepresentation(BaseModel):
+            grandchild: str
+            schema_version: str = "metadata-secret"
+
+    else:
+
+        class HistoricalChildRepresentation(BaseModel):
+            grandchild: str
+
+            @computed_field
+            @property
+            def schema_version(self) -> str:
+                return "metadata-secret"
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_metadata_{injection}_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        downgrade=lambda _data: {"child": {"grandchild": "historical"}},
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.dump(
+            version="1",
+            data=Parent(child=Child(grandchild=Grandchild(value=7))),
+        )
+
+    message = str(caught.value)
+    assert child_family.name in message
+    assert "does not match expected label" in message
+    assert "metadata-secret" not in message
+
+
+def test_independent_structural_metadata_envelope_rejects_siblings() -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_metadata_envelope_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: str
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_metadata_envelope_child",
+        wire_model=HistoricalChild,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalChildRepresentation(BaseModel):
+        grandchild: str
+        contract: dict[str, Any] = Field(
+            default_factory=lambda: {"version": "1", "sibling": "envelope-secret"},
+        )
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_metadata_envelope_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        downgrade=lambda _data: {"child": {"grandchild": "historical"}},
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+    )
+
+    with pytest.raises(ValueError) as caught:
+        family.dump(
+            version="1",
+            data=Parent(child=Child(grandchild=Grandchild(value=7))),
+        )
+
+    message = str(caught.value)
+    assert "without siblings" in message
+    assert "envelope-secret" not in message
+
+
+@pytest.mark.parametrize(
+    ("contract", "expected_message"),
+    [
+        pytest.param(
+            {"version": "1", "sibling": "source-envelope-secret"},
+            "without siblings",
+            id="sibling",
+        ),
+        pytest.param(
+            {"sibling": "source-envelope-secret"},
+            "without siblings",
+            id="incomplete",
+        ),
+        pytest.param(
+            {"version": "source-envelope-secret"},
+            "payload declares a different label",
+            id="foreign-label",
+        ),
+    ],
+)
+def test_source_preflight_rejects_invalid_family_metadata_envelope(
+    contract: dict[str, str],
+    expected_message: str,
+) -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_source_envelope_child",
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    class HistoricalChildRepresentation(BaseModel):
+        value: int
+        version: str = Field(
+            default="1",
+            validation_alias=AliasPath("contract", "version"),
+            exclude=True,
+        )
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_source_envelope_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate(
+            {
+                "child": {
+                    "value": 1,
+                    "contract": contract,
+                },
+            },
+            version="1",
+        )
+
+    message = str(caught.value)
+    assert expected_message in message
+    assert "source-envelope-secret" not in message
+
+
+@pytest.mark.parametrize("injection", ["default", "validator"])
+def test_validated_source_cannot_inject_excluded_family_metadata(
+    injection: str,
+) -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name=f"runtime_shape_validated_source_{injection}_child",
+    )
+
+    if injection == "default":
+
+        class HistoricalChildRepresentation(BaseModel):
+            value: int
+            schema_version: str = Field(
+                default="validated-source-secret",
+                exclude=True,
+            )
+
+    else:
+
+        class HistoricalChildRepresentation(BaseModel):
+            value: int
+            schema_version: str = Field(default="1", exclude=True)
+
+            @model_validator(mode="after")
+            def inject_metadata(self) -> HistoricalChildRepresentation:
+                self.schema_version = "validated-source-secret"
+                return self
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        f"RuntimeValidatedSource{injection.title()}Parent",
+        child=(HistoricalChildRepresentation, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_validated_source_{injection}_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: migrations.append("upgrade") or data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate({"child": {"value": 1}}, version="1")
+
+    assert "validated-source-secret" not in str(caught.value)
+    assert migrations == []
+
+
+def test_exact_nested_source_validation_cannot_inject_transitive_metadata() -> None:
+    migrations: list[str] = []
+
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_exact_source_stage_grandchild",
+    )
+
+    class GrandchildRepresentation(BaseModel):
+        value: int
+        schema_version: str = Field(
+            default="exact-source-stage-secret",
+            exclude=True,
+        )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: GrandchildRepresentation
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_exact_source_stage_child",
+        wire_model=HistoricalChild,
+        upgrade=lambda data: migrations.append("child-upgrade") or data,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=None,
+    )
+
+    @dataclass
+    class IndependentGrandchildRepresentation:
+        value: int
+
+    @dataclass
+    class IndependentChildRepresentation:
+        grandchild: IndependentGrandchildRepresentation
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        "RuntimeExactSourceStageHistoricalParent",
+        child=(IndependentChildRepresentation, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_exact_source_stage_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate(
+            {"child": {"grandchild": {"value": 1}}},
+            version="1",
+        )
+
+    assert "exact-source-stage-secret" not in str(caught.value)
+    assert migrations == []
+
+
+def test_exact_nested_source_validation_cannot_mutate_own_model_metadata() -> None:
+    migrations: list[str] = []
+
+    class Child(BaseModel):
+        schema_version: str
+        value: int
+
+    class HistoricalChild(BaseModel):
+        schema_version: Literal["1"] = "1"
+        value: int
+
+        @model_validator(mode="after")
+        def inject_metadata(self) -> HistoricalChild:
+            self.schema_version = cast(Any, "exact-source-model-secret")
+            return self
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_exact_source_model_child",
+        wire_model=HistoricalChild,
+        upgrade=lambda data: migrations.append("child-upgrade") or data,
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    @dataclass
+    class IndependentChildRepresentation:
+        value: int
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        "RuntimeExactSourceModelHistoricalParent",
+        child=(IndependentChildRepresentation, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_exact_source_model_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate({"child": {"value": 1}}, version="1")
+
+    assert "exact-source-model-secret" not in str(caught.value)
+    assert migrations == []
+
+
+@pytest.mark.parametrize("placement", ["direct", "nested"])
+def test_validated_source_cannot_inject_family_owned_root_metadata(
+    placement: str,
+) -> None:
+    migrations: list[str] = []
+
+    class Current(BaseModel):
+        value: int
+
+    class Historical(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+        @model_validator(mode="after")
+        def inject_metadata(self) -> Historical:
+            assert self.__pydantic_extra__ is not None
+            self.__pydantic_extra__["schema_version"] = "family-root-secret"
+            return self
+
+    nested_family = _runtime_family(
+        model=Current,
+        name=f"runtime_shape_family_root_{placement}_child",
+        wire_model=Historical,
+        upgrade=lambda data: migrations.append("upgrade") or data,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        if placement == "direct":
+            nested_family.validate(
+                {"value": 1, "schema_version": "1"},
+                version="1",
+            )
+        else:
+
+            @dataclass
+            class IndependentRepresentation:
+                value: int
+
+            class Parent(BaseModel):
+                child: Current
+
+            historical_parent = create_model(
+                "RuntimeFamilyRootNestedHistoricalParent",
+                child=(IndependentRepresentation, ...),
+            )
+            family = _nested_runtime_family(
+                model=Parent,
+                name="runtime_shape_family_root_nested_parent",
+                wire_model=historical_parent,
+                upgrade=lambda data: data,
+                child_family=nested_family,
+                nested_path="child",
+                version_metadata=None,
+            )
+            family.validate({"child": {"value": 1}}, version="1")
+
+    assert "family-root-secret" not in str(caught.value)
+    assert migrations == []
+
+
+def test_validated_source_cannot_delete_model_owned_root_metadata() -> None:
+    migrations: list[str] = []
+
+    class Current(BaseModel):
+        schema_version: str
+        value: int
+
+    class Historical(BaseModel):
+        schema_version: Literal["1"] = "1"
+        value: int
+
+        @model_validator(mode="after")
+        def delete_metadata(self) -> Historical:
+            incomplete = type(self).model_construct(value=self.value)
+            del incomplete.schema_version
+            return incomplete
+
+    family = _runtime_family(
+        model=Current,
+        name="runtime_shape_deleted_model_metadata",
+        wire_model=Historical,
+        upgrade=lambda data: migrations.append("upgrade") or data,
+        version_metadata=VersionMetadata("schema_version", owner="model"),
+    )
+
+    with pytest.raises(SchemaVersionError, match="omitted required version metadata"):
+        family.validate(
+            {"schema_version": "1", "value": 1},
+            version="1",
+        )
+
+    assert migrations == []
+
+
+@pytest.mark.parametrize("representation_kind", ["stdlib", "pydantic"])
+def test_source_preflight_reads_slots_dataclass_metadata(
+    representation_kind: str,
+) -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name=f"runtime_shape_slots_{representation_kind}_child",
+    )
+
+    if representation_kind == "stdlib":
+
+        @dataclass(slots=True)
+        class HistoricalChildRepresentation:
+            value: int
+            schema_version: str = Field(exclude=True)
+
+    else:
+
+        @pydantic_dataclass(slots=True)
+        class HistoricalChildRepresentation:
+            value: int
+            schema_version: str = Field(exclude=True)
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        f"RuntimeSlots{representation_kind.title()}Parent",
+        child=(HistoricalChildRepresentation, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_slots_{representation_kind}_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+    historical = HistoricalChildRepresentation(
+        value=1,
+        schema_version="slots-metadata-secret",
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate({"child": historical}, version="1")
+
+    assert "slots-metadata-secret" not in str(caught.value)
+
+
+@pytest.mark.parametrize("metadata", ["wrong", "expected"])
+def test_prevalidated_alias_path_metadata_is_checked_without_synthetic_siblings(
+    metadata: str,
+) -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name=f"runtime_shape_prevalidated_alias_{metadata}_child",
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    class HistoricalChildRepresentation(BaseModel):
+        value: int
+        version: str = Field(
+            validation_alias=AliasChoices(
+                AliasPath("contract", "version"),
+                AliasPath("contract", "legacy_version"),
+            ),
+            exclude=True,
+        )
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        f"RuntimePrevalidatedAlias{metadata.title()}Parent",
+        child=(HistoricalChildRepresentation, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_prevalidated_alias_{metadata}_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+    declared = "prevalidated-alias-secret" if metadata == "wrong" else "1"
+    historical = HistoricalChildRepresentation.model_validate(
+        {
+            "value": 1,
+            "contract": {"version": declared},
+        },
+    )
+
+    if metadata == "wrong":
+        with pytest.raises(SchemaVersionError) as caught:
+            family.validate({"child": historical}, version="1")
+        assert "prevalidated-alias-secret" not in str(caught.value)
+        return
+
+    validated = family.validate({"child": historical}, version="1")
+    assert validated.current_model == Parent(child=Child(value=1))
+
+
+def test_source_preflight_rejects_transitive_collection_metadata_envelope() -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_transitive_source_envelope_grandchild",
+        version_metadata=VersionMetadata(("contract", "version"), owner="family"),
+    )
+
+    class HistoricalGrandchildRepresentation(BaseModel):
+        value: int
+        version: str = Field(
+            validation_alias=AliasPath("contract", "version"),
+            exclude=True,
+        )
+
+    class Child(BaseModel):
+        grandchildren: list[Grandchild]
+
+    class HistoricalChild(BaseModel):
+        grandchildren: list[HistoricalGrandchildRepresentation]
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_transitive_source_envelope_child",
+        wire_model=HistoricalChild,
+        upgrade=lambda data: data,
+        child_family=grandchild_family,
+        nested_path="grandchildren",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_child_representation = create_model(
+        "RuntimeShapeTransitiveSourceEnvelopeRepresentation",
+        grandchildren=(list[HistoricalGrandchildRepresentation], ...),
+    )
+
+    historical_parent = create_model(
+        "RuntimeShapeTransitiveSourceEnvelopeParentModel",
+        child=(historical_child_representation, ...),
+    )
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_transitive_source_envelope_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate(
+            {
+                "child": {
+                    "grandchildren": [
+                        {
+                            "value": 1,
+                            "contract": {
+                                "version": "1",
+                                "sibling": "transitive-envelope-secret",
+                            },
+                        },
+                    ],
+                },
+            },
+            version="1",
+        )
+
+    message = str(caught.value)
+    assert grandchild_family.name in message
+    assert "without siblings" in message
+    assert "transitive-envelope-secret" not in message
+
+
+@pytest.mark.parametrize(
+    ("representation", "input_path"),
+    [
+        pytest.param(
+            RuntimePreflightDataclassAliasRepresentation,
+            ("legacy", "grandchild"),
+            id="dataclass-alias-choices",
+        ),
+        pytest.param(
+            RuntimePreflightTypedDictAliasRepresentation,
+            ("legacy", "grandchild"),
+            id="typed-dict-alias-path",
+        ),
+        pytest.param(
+            RuntimePreflightAliasDisabledDataclassRepresentation,
+            ("grandchild",),
+            id="dataclass-alias-disabled-uses-name",
+        ),
+        pytest.param(
+            RuntimePreflightAliasDisabledTypedDictRepresentation,
+            ("grandchild",),
+            id="typed-dict-alias-disabled-uses-name",
+        ),
+        pytest.param(
+            RuntimePreflightPopulateByNameDataclassRepresentation,
+            ("grandchild",),
+            id="dataclass-populate-by-name",
+        ),
+        pytest.param(
+            RuntimePreflightPopulateByNameTypedDictRepresentation,
+            ("grandchild",),
+            id="typed-dict-populate-by-name",
+        ),
+        pytest.param(
+            RuntimePreflightMultipleAnnotatedAliasRepresentation,
+            ("secondGrandchild",),
+            id="later-annotated",
+        ),
+        pytest.param(
+            RuntimePreflightMetadataAliasRepresentation,
+            ("metadataGrandchild",),
+            id="dataclass-metadata",
+        ),
+        pytest.param(
+            RuntimePreflightAssignedAliasRepresentation,
+            ("assignedGrandchild",),
+            id="assigned-field",
+        ),
+        pytest.param(
+            RuntimePreflightClearedAliasRepresentation,
+            ("grandchild",),
+            id="explicit-none-clears",
+        ),
+        pytest.param(
+            RuntimePreflightEmptyAliasRepresentation,
+            ("",),
+            id="empty-string-override",
+        ),
+    ],
+)
+def test_source_preflight_follows_structural_validation_aliases(
+    representation: Any,
+    input_path: tuple[str, ...],
+) -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_structural_alias_preflight_grandchild",
+    )
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: RuntimePreflightGrandchildRepresentation
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_structural_alias_preflight_child",
+        wire_model=HistoricalChild,
+        upgrade=lambda data: data,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        f"RuntimeStructuralAliasPreflight{representation.__name__}",
+        child=(representation, ...),
+    )
+    family = _nested_runtime_family(
+        model=Parent,
+        name=f"runtime_shape_structural_alias_preflight_{representation.__name__}",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    child_payload: dict[str, Any] = {
+        "value": 1,
+        "schema_version": "alias-preflight-secret",
+    }
+    for component in reversed(input_path):
+        child_payload = {component: child_payload}
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate({"child": child_payload}, version="1")
+
+    message = str(caught.value)
+    assert grandchild_family.name in message
+    assert "payload declares a different label" in message
+    assert "alias-preflight-secret" not in message
+
+
+def test_source_preflight_checks_optional_structural_union_arm() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_optional_preflight_child",
+    )
+
+    class HistoricalChildRepresentation(BaseModel):
+        value: int
+
+    class Parent(BaseModel):
+        child: Child
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation | None
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_optional_preflight_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate(
+            {
+                "child": {
+                    "value": 1,
+                    "schema_version": "optional-preflight-secret",
+                },
+            },
+            version="1",
+        )
+
+    assert "optional-preflight-secret" not in str(caught.value)
+
+
+def test_source_preflight_checks_every_smart_union_structural_arm() -> None:
+    class Grandchild(BaseModel):
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_smart_union_preflight_grandchild",
+    )
+
+    class HistoricalGrandchildRepresentation(BaseModel):
+        value: int
+
+    class Child(BaseModel):
+        grandchild: Grandchild
+
+    class HistoricalChild(BaseModel):
+        grandchild: HistoricalGrandchildRepresentation
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_smart_union_preflight_child",
+        wire_model=HistoricalChild,
+        upgrade=lambda data: data,
+        child_family=grandchild_family,
+        nested_path="grandchild",
+        version_metadata=None,
+    )
+
+    class AliasScoredModelArm(BaseModel):
+        grandchild: HistoricalGrandchildRepresentation = Field(
+            validation_alias="alternate",
+        )
+        first_score: dict[str, Any] = Field(validation_alias="grandchild")
+        second_score: dict[str, Any] = Field(validation_alias="grandchild")
+
+    class Parent(BaseModel):
+        child: Child
+
+    historical_parent = create_model(
+        "RuntimeSmartUnionPreflightHistoricalParent",
+        child=(RuntimeSmartUnionExactTypedDictArm | AliasScoredModelArm, ...),
+    )
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_smart_union_preflight_parent",
+        wire_model=historical_parent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+    payload = {
+        "child": {
+            "grandchild": {"value": 1, "schema_version": "1"},
+            "alternate": {
+                "value": 2,
+                "schema_version": "smart-union-preflight-secret",
+            },
+        },
+    }
+
+    selected = cast(Any, historical_parent.model_validate(payload)).child
+    assert isinstance(selected, AliasScoredModelArm)
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate(payload, version="1")
+
+    message = str(caught.value)
+    assert grandchild_family.name in message
+    assert "payload declares a different label" in message
+    assert "smart-union-preflight-secret" not in message
+
+
+def test_source_preflight_checks_scalar_first_collection_union_arm() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = _runtime_family(
+        model=Child,
+        name="runtime_shape_collection_union_preflight_child",
+    )
+
+    class HistoricalChildRepresentation(BaseModel):
+        value: int
+
+    class Parent(BaseModel):
+        children: list[Child]
+
+    class HistoricalParent(BaseModel):
+        children: list[str] | list[HistoricalChildRepresentation]
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_collection_union_preflight_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        child_family=child_family,
+        nested_path="children",
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaVersionError) as caught:
+        family.validate(
+            {
+                "children": [
+                    {
+                        "value": 1,
+                        "schema_version": "collection-union-preflight-secret",
+                    },
+                ],
+            },
+            version="1",
+        )
+
+    assert "collection-union-preflight-secret" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    ("downgraded_values", "should_collapse"),
+    [
+        pytest.param([1, "1"], True, id="collapse"),
+        pytest.param([1, 2], False, id="preserve"),
+    ],
+)
+def test_independent_dataclass_preserves_recursive_set_cardinality_check(
+    downgraded_values: list[int | str],
+    should_collapse: bool,
+) -> None:
+    class Grandchild(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int | str
+
+    class HistoricalGrandchild(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    grandchild_family = _runtime_family(
+        model=Grandchild,
+        name="runtime_shape_structural_cardinality_grandchild",
+        wire_model=HistoricalGrandchild,
+        version_metadata=None,
+    )
+
+    class Child(BaseModel):
+        grandchildren: set[Grandchild]
+
+    child_family = _nested_runtime_family(
+        model=Child,
+        name="runtime_shape_structural_cardinality_child",
+        child_family=grandchild_family,
+        nested_path="grandchildren",
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    @dataclass
+    class HistoricalChildRepresentation:
+        grandchildren: set[int]
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChildRepresentation
+
+    family = _nested_runtime_family(
+        model=Parent,
+        name="runtime_shape_structural_cardinality_parent",
+        wire_model=HistoricalParent,
+        upgrade=lambda data: data,
+        downgrade=lambda _data: {
+            "child": {"grandchildren": downgraded_values},
+        },
+        exact_downgrade=True,
+        child_family=child_family,
+        nested_path="child",
+        version_metadata=None,
+    )
+    current = Parent(
+        child=Child(
+            grandchildren={
+                Grandchild(value=1),
+                Grandchild(value="1"),
+            },
+        ),
+    )
+
+    if should_collapse:
+        with pytest.raises(InvalidMigrationError, match="set cardinality"):
+            family.dump(version="1", data=current)
+        return
+
+    dumped = family.dump(version="1", data=current)
+    assert set(dumped["child"]["grandchildren"]) == {1, 2}

--- a/tests/unit/test_target_wire_contract.py
+++ b/tests/unit/test_target_wire_contract.py
@@ -610,7 +610,7 @@ def test_nested_model_owned_metadata_is_verified_after_parent_serialization() ->
 
         @model_serializer
         def serialize_model(self) -> dict[str, Any]:
-            return {"schema_version": "wrong", "value": self.value}
+            return {"schema_version": "model-owned-secret", "value": self.value}
 
     child_family = SchemaFamily(
         model=Child,
@@ -641,11 +641,16 @@ def test_nested_model_owned_metadata_is_verified_after_parent_serialization() ->
         nested=(NestedFamily("child", child_family, matching_labels()),),
     )
 
-    with pytest.raises(ValueError, match="serialized version metadata.*wrong.*expected '1'"):
+    with pytest.raises(
+        ValueError,
+        match="serialized version metadata.*as a different label.*expected '1'",
+    ) as caught:
         parent_family.dump(
             version="1",
             data=Parent(child=Child(schema_version="2", value=7)),
         )
+
+    assert "model-owned-secret" not in str(caught.value)
 
 
 def test_nested_target_serializer_must_remain_object_shaped() -> None:

--- a/tests/unit/test_wire_coverage_contract.py
+++ b/tests/unit/test_wire_coverage_contract.py
@@ -892,6 +892,8 @@ def test_explicit_wire_model_prunes_a_structural_dataclass_body() -> None:
 
 
 def test_explicit_wire_model_rejects_a_relocated_dataclass_body() -> None:
+    serializer_calls = 0
+
     class Child(BaseModel):
         value: int
 
@@ -911,6 +913,8 @@ def test_explicit_wire_model_rejects_a_relocated_dataclass_body() -> None:
 
         @model_serializer
         def serialize(self) -> str:
+            nonlocal serializer_calls
+            serializer_calls += 1
             return "relocated"
 
     class HistoricalParent(BaseModel):
@@ -926,8 +930,13 @@ def test_explicit_wire_model_rejects_a_relocated_dataclass_body() -> None:
         nested=(NestedFamily("child", child_family, matching_labels()),),
     )
 
-    with pytest.raises(ValueError, match="Nested target wire model.*must serialize to an object"):
-        family.dump(version="1", data=Parent(child=Child(value=8)))
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="model-level serializer on a managed dataclass leaf",
+    ):
+        family.compile()
+
+    assert serializer_calls == 0
 
 
 def test_explicit_wire_model_prunes_a_typed_dict_union_arm() -> None:


### PR DESCRIPTION
## Summary

- compile explicit historical nested routes only when their representation is
  statically owned and runtime-recoverable;
- verify source, target, default, and recursively nested shapes before
  migration, metadata pruning, or serialization;
- preflight and recheck family/model metadata across aliases, validators,
  defaults, extras, unions, collections, dataclasses, and `TypedDict` values;
- keep diagnostics payload-safe and preserve recoverable scalar and omitted
  route behavior;
- document the explicit historical grammar as part of the 1.x stability
  contract.

## Compatibility

This preserves the 0.3.0 rule that authoritative current-model fields marked
with `Field(exclude=True)` or `exclude_if` are omitted from automatic wire
projections. The new compile-time rejection is limited to an explicit
historical managed route whose own effective field contract serializes that
declared route away.

The immutable 0.3.0 compatibility contract remains unchanged and passes.
Larger behavior-preserving module extraction remains tracked separately in
#94 and #95.

## Validation

- `uv run make ci`: 856 passed, 95.81% coverage
- release-equivalent non-editable/no-build-isolation gate: passed
- Python 3.12/Pydantic 2.12.3 focused contract matrix: passed
- Python 3.14/Pydantic 2.13.4 focused contract matrix: passed
- strict documentation build: passed
- immutable v0.3.0 contract: passed
- locked dependency audit: no known vulnerabilities
- wheel and sdist strict metadata checks: passed
- isolated wheel/sdist public API smoke on Python 3.12-3.14: passed

Closes #104
