### PR TITLE
test: make smart union preflight regression portable

### DIFF
--- a/tests/unit/test_explicit_nested_runtime_shape_contract.py
+++ b/tests/unit/test_explicit_nested_runtime_shape_contract.py
@@ -12,6 +12,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    TypeAdapter,
     computed_field,
     create_model,
     field_serializer,
@@ -2811,8 +2812,12 @@ def test_source_preflight_checks_every_smart_union_structural_arm() -> None:
         },
     }
 
-    selected = cast(Any, historical_parent.model_validate(payload)).child
-    assert isinstance(selected, AliasScoredModelArm)
+    # Both arms intentionally accept the input. Smart-union scoring may select
+    # either one across supported Pydantic minors, while the library contract is
+    # to preflight every compatible structural arm before validation.
+    TypeAdapter(RuntimeSmartUnionExactTypedDictArm).validate_python(payload["child"])
+    AliasScoredModelArm.model_validate(payload["child"])
+    historical_parent.model_validate(payload)
     with pytest.raises(SchemaVersionError) as caught:
         family.validate(payload, version="1")
 


### PR DESCRIPTION
## What changed

- validate both compatible structural union arms independently
- stop depending on Pydantic's version-specific smart-union winner
- retain the public preflight rejection, diagnostic, and secret-redaction assertions

This is a test compatibility correction only. Production behavior is unchanged, including generated projections omitting current-model fields marked exclude=True or exclude_if.

## Validation

- exact CI lower bound: Python 3.12.13 / Pydantic 2.12.3, 856 passed, 95.74% coverage
- locked CI gate: 856 passed, 95.83% coverage; Ruff, ty, strict mypy, and Vulture passed
- targeted exclusion contract: 7 passed on Pydantic 2.12.3
- strict documentation build passed
- immutable v0.3.0 compatibility contract passed

Closes #104