### PR TITLE
refactor: extract runtime versioning helpers

### DIFF
--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -24,13 +24,7 @@ from typing import (
     is_typeddict as stdlib_is_typeddict,
 )
 
-from pydantic import (
-    AliasChoices,
-    AliasPath,
-    BaseModel,
-    ConfigDict,
-    create_model,
-)
+from pydantic import BaseModel, ConfigDict, create_model
 from pydantic_core import SchemaValidator, core_schema, to_jsonable_python
 from typing_extensions import (  # noqa: UP035
     TypeAliasType as ExtensionsTypeAliasType,
@@ -42,14 +36,36 @@ from pydantic_versions._compiler import (
     _CompiledFamily,
     _CompiledVersion,
 )
+from pydantic_versions._runtime_versioning import (
+    _MISSING,
+    _alias_paths,
+    _apply_serialized_version_metadata,
+    _copy_alias_payload_value,
+    _current_validation_input,
+    _detect_version,
+    _get_version_field,
+    _matches_version_label,
+    _model_metadata_field_name,
+    _normalize_payload_field_aliases,
+    _path_has_payload,
+    _remove_version_field,
+    _safe_nested_version_display,
+    _serialized_field_name,
+    _set_version_field,
+    _to_current_names,
+    _to_version_names,
+    _validate_include_version_mode,
+    _verify_serialized_model_metadata,
+    _version_field_display,
+)
+from pydantic_versions._runtime_versioning import (
+    _runtime_label as _runtime_label,
+)
 from pydantic_versions.declarations import VersionedValidation, VersionPath
 from pydantic_versions.exceptions import (
     InvalidMigrationError,
     IrreversibleTransitionError,
-    MissingSchemaVersionError,
-    SchemaCompilationError,
     SchemaVersionError,
-    UnknownSchemaVersionError,
     UnsupportedWireModelError,
 )
 
@@ -90,15 +106,7 @@ _SUPPORTED_MODEL_DUMP_OPTIONS = frozenset(
         "warnings",
     }
 )
-_MISSING = object()
 _TYPE_ALIAS_TYPES = (StdlibTypeAliasType, ExtensionsTypeAliasType)
-
-
-def _runtime_label(value: object, *, family_name: str) -> str:
-    if not isinstance(value, str) or not value:
-        msg = f"Schema version for {family_name!r} must be a non-empty string"
-        raise UnknownSchemaVersionError(msg)
-    return value
 
 
 def _extract_declared_fields(
@@ -1509,164 +1517,6 @@ def _validate_model_dump_options(dump_kwargs: Mapping[str, Any]) -> None:
             "omit computed target contract fields"
         )
         raise ValueError(msg)
-
-
-def _validate_include_version_mode(
-    compiled: _CompiledFamily,
-    include_version: bool,
-) -> None:
-    metadata = compiled.version_metadata
-    if include_version or metadata is None or metadata.owner != "model":
-        return
-    msg = (
-        f"Schema family {compiled.name!r} uses model-owned version metadata; "
-        "include_version=False is unavailable because that field is part of the body contract"
-    )
-    raise ValueError(msg)
-
-
-def _apply_serialized_version_metadata(
-    *,
-    dumped: dict[str, Any],
-    compiled: _CompiledFamily,
-    requested: str,
-    target_model: type[BaseModel],
-    include_version: bool,
-    by_alias: Any,
-) -> None:
-    metadata = compiled.version_metadata
-    if metadata is None:
-        return
-    if metadata.owner == "family":
-        if include_version:
-            _ensure_serialized_version_field(
-                dumped,
-                metadata.path,
-                requested,
-                family_name=compiled.name,
-            )
-        else:
-            _remove_version_field(dumped, metadata.path)
-        return
-
-    _verify_serialized_model_metadata(
-        dumped,
-        compiled=compiled,
-        requested=requested,
-        target_model=target_model,
-        by_alias=by_alias,
-    )
-
-
-def _verify_serialized_model_metadata(
-    dumped: Mapping[str, Any],
-    *,
-    compiled: _CompiledFamily,
-    requested: str,
-    target_model: type[BaseModel],
-    by_alias: Any,
-) -> None:
-    field_name = _model_metadata_field_name(compiled)
-    output_key = _serialized_field_name(target_model, field_name, by_alias=by_alias)
-    candidate_keys = _model_metadata_serialization_keys(
-        compiled,
-        target_model=target_model,
-        field_name=field_name,
-    )
-    value = dumped.get(output_key, _MISSING)
-    if value is _MISSING:
-        msg = (
-            f"Target wire model for family {compiled.name!r} and version "
-            f"{requested!r} omitted model-owned version metadata {output_key!r}"
-        )
-        raise ValueError(msg)
-    if not _matches_version_label(value, requested):
-        value_display = _safe_nested_version_display(value, compiled=compiled)
-        msg = (
-            f"Target wire model for family {compiled.name!r} serialized version "
-            f"metadata {output_key!r} as {value_display}, expected {requested!r}"
-        )
-        raise ValueError(msg)
-    duplicate_keys = tuple(key for key in candidate_keys if key != output_key and key in dumped)
-    if duplicate_keys:
-        formatted = ", ".join(repr(key) for key in duplicate_keys)
-        msg = (
-            f"Target wire model for family {compiled.name!r} serialized duplicate "
-            f"version metadata at {formatted}"
-        )
-        raise ValueError(msg)
-
-
-def _ensure_serialized_version_field(
-    data: dict[str, Any],
-    version_field: VersionPath,
-    value: str,
-    *,
-    family_name: str,
-) -> None:
-    existing = _serialized_version_field(data, version_field)
-    if existing is not _MISSING:
-        if existing != value:
-            msg = (
-                f"Target wire model for family {family_name!r} serialized version "
-                f"metadata {_version_field_display(version_field)!r} as "
-                f"{existing!r}, expected {value!r}"
-            )
-            raise ValueError(msg)
-        return
-    _set_version_field(data, version_field, value)
-
-
-def _serialized_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
-    if isinstance(version_field, str):
-        return data[version_field] if version_field in data else _MISSING
-    current: Any = data
-    for part in version_field:
-        if not isinstance(current, Mapping) or part not in current:
-            return _MISSING
-        current = current[part]
-    return current
-
-
-def _model_metadata_serialization_keys(
-    compiled: _CompiledFamily,
-    *,
-    target_model: type[BaseModel],
-    field_name: str,
-) -> tuple[str, ...]:
-    metadata = compiled.version_metadata
-    keys: list[str] = [field_name]
-    if metadata is not None and isinstance(metadata.path, str):
-        keys.append(metadata.path)
-    for model in (compiled.model, target_model):
-        field_info = model.model_fields[field_name]
-        for candidate in (
-            field_info.alias,
-            field_info.validation_alias,
-            field_info.serialization_alias,
-        ):
-            if isinstance(candidate, str):
-                keys.append(candidate)
-    return tuple(dict.fromkeys(keys))
-
-
-def _serialized_field_name(
-    model: type[BaseModel],
-    field_name: str,
-    *,
-    by_alias: Any,
-) -> str:
-    use_alias = (
-        model.model_config.get("serialize_by_alias", False) is True
-        if by_alias is None
-        else by_alias is True
-    )
-    field_info = model.model_fields[field_name]
-    if use_alias:
-        output_alias = field_info.serialization_alias
-        if isinstance(output_alias, str):
-            return output_alias
-    return field_name
 
 
 def _prune_serialized_decorator_metadata(
@@ -3526,18 +3376,6 @@ def _declared_nested_version_metadata(
     return True, normalized[metadata_field]
 
 
-def _safe_nested_version_display(value: Any, *, compiled: _CompiledFamily) -> str:
-    if type(value) is str and any(
-        value == version.projection.label for version in compiled.versions
-    ):
-        return repr(value)
-    return "a different label"
-
-
-def _matches_version_label(value: Any, label: str) -> bool:
-    return type(value) is str and value == label
-
-
 def _verify_validated_family_version_metadata(
     *,
     value: BaseModel,
@@ -4210,22 +4048,6 @@ def _runtime_structural_validation_alias_paths(
         annotated_field_infos=annotated_field_infos,
     )
     return config, _alias_paths(validation_alias, fallback=alias)
-
-
-def _alias_paths(
-    alias: Any,
-    *,
-    fallback: Any = _MISSING,
-) -> tuple[tuple[str | int, ...], ...]:
-    if (alias is _MISSING or alias is None) and fallback is not _MISSING:
-        alias = fallback
-    if isinstance(alias, str):
-        return ((alias,),)
-    if isinstance(alias, AliasPath):
-        return (tuple(alias.path),)
-    if isinstance(alias, AliasChoices):
-        return tuple(path for choice in alias.choices for path in _alias_paths(choice))
-    return ()
 
 
 def _runtime_annotation_field_infos(annotation: Any) -> tuple[Any, ...]:
@@ -5521,294 +5343,3 @@ def _payload_value_at_access_path(payload: Any, path: tuple[Any, ...]) -> Any:
     for part in path:
         current = current[part]
     return current
-
-
-def _infer_metadata_owner(
-    model_cls: type[BaseModel],
-    version_path: VersionPath,
-) -> Literal["family", "model"]:
-    if not isinstance(version_path, str):
-        return "family"
-    if version_path in model_cls.model_fields:
-        return "model"
-    if any(field.alias == version_path for field in model_cls.model_fields.values()):
-        return "model"
-    return "family"
-
-
-def _detect_version(
-    compiled: _CompiledFamily,
-    data: Any,
-    *,
-    explicit_version: str | None,
-) -> str:
-    if explicit_version is not None:
-        version = _runtime_label(explicit_version, family_name=compiled.name)
-        compiled.index(version)
-        return version
-    if isinstance(data, Mapping) and compiled.version_metadata is not None:
-        version_value = _get_version_field(data, compiled.version_metadata.path)
-        if version_value is not None:
-            version = _runtime_label(version_value, family_name=compiled.name)
-            compiled.index(version)
-            return version
-    if compiled.missing_version is not None:
-        return compiled.missing_version
-    field_display = (
-        "explicit version"
-        if compiled.version_metadata is None
-        else _version_field_display(compiled.version_metadata.path)
-    )
-    msg = f"Input data for {compiled.name!r} does not include {field_display!r}"
-    raise MissingSchemaVersionError(msg)
-
-
-def _get_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
-    if isinstance(version_field, str):
-        return data.get(version_field)
-    current: Any = data
-    for part in version_field:
-        if not isinstance(current, Mapping) or part not in current:
-            return None
-        current = current[part]
-    return current
-
-
-def _set_version_field(data: dict[str, Any], version_field: VersionPath, value: str) -> None:
-    if isinstance(version_field, str):
-        data[version_field] = value
-        return
-    current = data
-    for part in version_field[:-1]:
-        next_value = current.get(part)
-        if part not in current:
-            next_value = {}
-            current[part] = next_value
-        elif not isinstance(next_value, dict):
-            msg = (
-                f"Cannot set version metadata at {version_field!r} because "
-                f"intermediate value {part!r} is not an object"
-            )
-            raise InvalidMigrationError(msg)
-        current = next_value
-    current[version_field[-1]] = value
-
-
-def _remove_version_field(data: dict[str, Any], version_field: VersionPath) -> None:
-    if isinstance(version_field, str):
-        data.pop(version_field, None)
-        return
-    current: Any = data
-    parents: list[tuple[dict[str, Any], str]] = []
-    for part in version_field[:-1]:
-        if not isinstance(current, dict) or not isinstance(current.get(part), dict):
-            return
-        parents.append((current, part))
-        current = current[part]
-    if isinstance(current, dict):
-        current.pop(version_field[-1], None)
-    for parent, part in reversed(parents):
-        child = parent.get(part)
-        if isinstance(child, dict) and not child:
-            parent.pop(part, None)
-
-
-def _version_field_display(version_field: VersionPath) -> str:
-    if isinstance(version_field, str):
-        return version_field
-    return ".".join(version_field)
-
-
-def _to_current_names(
-    compiled: _CompiledFamily,
-    version: _CompiledVersion,
-    payload: dict[str, Any],
-) -> dict[str, Any]:
-    normalized = dict(payload)
-    metadata = compiled.version_metadata
-    if metadata is not None:
-        if metadata.owner == "family":
-            _remove_version_field(normalized, metadata.path)
-        else:
-            metadata_field = _model_metadata_field_name(compiled)
-            if metadata.path != metadata_field:
-                normalized.pop(metadata.path, None)
-            normalized[metadata_field] = compiled.current_version
-    renamed = tuple(
-        field
-        for field in version.projection.fields
-        if field.version_name is not None and field.version_name != field.current_name
-    )
-    original = dict(normalized)
-    renamed_values: dict[str, Any] = {}
-    for field in renamed:
-        if field.version_name is None:  # pragma: no cover - narrowed by renamed
-            continue
-        if field.version_name in original:
-            renamed_values[field.current_name] = original[field.version_name]
-    for field in renamed:
-        normalized.pop(field.version_name, None)
-    normalized.update(renamed_values)
-    return normalized
-
-
-def _current_validation_input(
-    model_cls: type[BaseModel], payload: dict[str, Any]
-) -> dict[str, Any]:
-    current_payload = dict(payload)
-    if model_cls.model_config.get("validate_by_alias", True) is False:
-        return current_payload
-    return _normalize_payload_field_aliases(model_cls, current_payload, prefer_aliases=True)
-
-
-def _normalize_payload_field_aliases(
-    model_cls: type[BaseModel],
-    payload: Mapping[str, Any],
-    *,
-    prefer_aliases: bool = False,
-) -> dict[str, Any]:
-    normalized = {key: _copy_alias_payload_value(value) for key, value in payload.items()}
-    for name, field_info in model_cls.model_fields.items():
-        alias_paths = _alias_paths(
-            field_info.validation_alias,
-            fallback=field_info.alias,
-        )
-        if name in normalized:
-            if prefer_aliases:
-                value = normalized[name]
-                mapped_aliases = tuple(
-                    path for path in alias_paths if not (len(path) == 1 and path[0] == name)
-                )
-                if mapped_aliases:
-                    mapped_alias = mapped_aliases[0]
-                    for alias_path in mapped_aliases:
-                        _remove_payload_path(normalized, alias_path)
-                    _set_payload_path(normalized, mapped_alias, value)
-                    normalized.pop(name, None)
-                continue
-
-            for alias_path in alias_paths:
-                if len(alias_path) == 1 and alias_path[0] == name:
-                    continue
-                _remove_payload_path(normalized, alias_path)
-            continue
-        source_path = _next_alias_path(field_info)
-        if source_path is not None and _path_has_payload(normalized, source_path):
-            value = _get_payload_path(normalized, source_path)
-            _remove_payload_path(normalized, source_path)
-            normalized[name] = value
-    return normalized
-
-
-def _copy_alias_payload_value(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {key: _copy_alias_payload_value(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_copy_alias_payload_value(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_copy_alias_payload_value(item) for item in value)
-    return value
-
-
-def _next_alias_path(field_info: Any) -> tuple[Any, ...] | None:
-    paths = _alias_paths(
-        field_info.validation_alias,
-        fallback=field_info.alias,
-    )
-    for path in paths:
-        if path:
-            return path
-    return None
-
-
-def _path_has_payload(payload: Mapping[Any, Any], path: tuple[Any, ...]) -> bool:
-    current: Any = payload
-    for part in path:
-        if not isinstance(current, Mapping) or part not in current:
-            return False
-        current = current[part]
-    return True
-
-
-def _get_payload_path(payload: Mapping[Any, Any], path: tuple[Any, ...]) -> Any:
-    current: Any = payload
-    for part in path:
-        current = current[part]
-    return current
-
-
-def _remove_payload_path(payload: dict[str, Any], path: tuple[Any, ...]) -> None:
-    parent_path: list[tuple[dict[str, Any], Any]] = []
-    current: Any = payload
-    for part in path[:-1]:
-        if part not in current:
-            return
-        if not isinstance(current[part], dict):
-            return
-        parent_path.append((current, part))
-        current = current[part]
-    removed = path[-1] in current
-    if removed:
-        current.pop(path[-1], None)
-    if removed:
-        for parent, part in reversed(parent_path):
-            child = parent[part]
-            if isinstance(child, Mapping) and len(child) == 0:
-                parent.pop(part, None)
-
-
-def _set_payload_path(payload: dict[str, Any], path: tuple[Any, ...], value: Any) -> None:
-    current = payload
-    for part in path[:-1]:
-        next_value = current.get(part)
-        if part not in current:
-            next_value = {}
-            current[part] = next_value
-        elif not isinstance(next_value, dict):
-            return
-        current = next_value
-    current[path[-1]] = value
-
-
-def _model_metadata_field_name(compiled: _CompiledFamily) -> str:
-    metadata = compiled.version_metadata
-    if metadata is None or metadata.owner != "model" or not isinstance(metadata.path, str):
-        msg = f"Compiled family {compiled.name!r} has invalid model-owned version metadata"
-        raise SchemaCompilationError(msg)
-    for field_name, field_info in compiled.model.model_fields.items():
-        if metadata.path in (
-            field_name,
-            field_info.alias,
-            field_info.validation_alias,
-            field_info.serialization_alias,
-        ):
-            return field_name
-    msg = f"Compiled family {compiled.name!r} lost its model-owned version metadata field"
-    raise SchemaCompilationError(msg)
-
-
-def _to_version_names(
-    version: _CompiledVersion,
-    payload: dict[str, Any],
-) -> dict[str, Any]:
-    normalized = _normalize_payload_field_aliases(version.model, payload)
-    original = dict(normalized)
-    versioned = dict(normalized)
-    renamed = tuple(
-        field
-        for field in version.projection.fields
-        if field.version_name is not None and field.version_name != field.current_name
-    )
-    for field in version.projection.fields:
-        if field.version_name is None:
-            versioned.pop(field.current_name, None)
-    renamed_values: dict[str, Any] = {}
-    for field in renamed:
-        if field.version_name is None:  # pragma: no cover - narrowed by renamed
-            continue
-        if field.current_name in original:
-            renamed_values[field.version_name] = original[field.current_name]
-    for field in renamed:
-        versioned.pop(field.current_name, None)
-    versioned.update(renamed_values)
-    return versioned

--- a/src/pydantic_versions/_runtime_versioning.py
+++ b/src/pydantic_versions/_runtime_versioning.py
@@ -1,0 +1,499 @@
+"""Version metadata and field-name normalization runtime helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from pydantic import AliasChoices, AliasPath, BaseModel
+
+from pydantic_versions._compiler import _CompiledFamily, _CompiledVersion
+from pydantic_versions.declarations import VersionPath
+from pydantic_versions.exceptions import (
+    InvalidMigrationError,
+    MissingSchemaVersionError,
+    SchemaCompilationError,
+    UnknownSchemaVersionError,
+)
+
+_MISSING = object()
+
+
+def _runtime_label(value: object, *, family_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        msg = f"Schema version for {family_name!r} must be a non-empty string"
+        raise UnknownSchemaVersionError(msg)
+    return value
+
+
+def _safe_nested_version_display(value: Any, *, compiled: _CompiledFamily) -> str:
+    if type(value) is str and any(
+        value == version.projection.label for version in compiled.versions
+    ):
+        return repr(value)
+    return "a different label"
+
+
+def _matches_version_label(value: Any, label: str) -> bool:
+    return type(value) is str and value == label
+
+
+def _validate_include_version_mode(
+    compiled: _CompiledFamily,
+    include_version: bool,
+) -> None:
+    metadata = compiled.version_metadata
+    if include_version or metadata is None or metadata.owner != "model":
+        return
+    msg = (
+        f"Schema family {compiled.name!r} uses model-owned version metadata; "
+        "include_version=False is unavailable because that field is part of the body contract"
+    )
+    raise ValueError(msg)
+
+
+def _apply_serialized_version_metadata(
+    *,
+    dumped: dict[str, Any],
+    compiled: _CompiledFamily,
+    requested: str,
+    target_model: type[BaseModel],
+    include_version: bool,
+    by_alias: Any,
+) -> None:
+    metadata = compiled.version_metadata
+    if metadata is None:
+        return
+    if metadata.owner == "family":
+        if include_version:
+            _ensure_serialized_version_field(
+                dumped,
+                metadata.path,
+                requested,
+                family_name=compiled.name,
+            )
+        else:
+            _remove_version_field(dumped, metadata.path)
+        return
+
+    _verify_serialized_model_metadata(
+        dumped,
+        compiled=compiled,
+        requested=requested,
+        target_model=target_model,
+        by_alias=by_alias,
+    )
+
+
+def _verify_serialized_model_metadata(
+    dumped: Mapping[str, Any],
+    *,
+    compiled: _CompiledFamily,
+    requested: str,
+    target_model: type[BaseModel],
+    by_alias: Any,
+) -> None:
+    field_name = _model_metadata_field_name(compiled)
+    output_key = _serialized_field_name(target_model, field_name, by_alias=by_alias)
+    candidate_keys = _model_metadata_serialization_keys(
+        compiled,
+        target_model=target_model,
+        field_name=field_name,
+    )
+    value = dumped.get(output_key, _MISSING)
+    if value is _MISSING:
+        msg = (
+            f"Target wire model for family {compiled.name!r} and version "
+            f"{requested!r} omitted model-owned version metadata {output_key!r}"
+        )
+        raise ValueError(msg)
+    if not _matches_version_label(value, requested):
+        value_display = _safe_nested_version_display(value, compiled=compiled)
+        msg = (
+            f"Target wire model for family {compiled.name!r} serialized version "
+            f"metadata {output_key!r} as {value_display}, expected {requested!r}"
+        )
+        raise ValueError(msg)
+    duplicate_keys = tuple(key for key in candidate_keys if key != output_key and key in dumped)
+    if duplicate_keys:
+        formatted = ", ".join(repr(key) for key in duplicate_keys)
+        msg = (
+            f"Target wire model for family {compiled.name!r} serialized duplicate "
+            f"version metadata at {formatted}"
+        )
+        raise ValueError(msg)
+
+
+def _ensure_serialized_version_field(
+    data: dict[str, Any],
+    version_field: VersionPath,
+    value: str,
+    *,
+    family_name: str,
+) -> None:
+    existing = _serialized_version_field(data, version_field)
+    if existing is not _MISSING:
+        if existing != value:
+            msg = (
+                f"Target wire model for family {family_name!r} serialized version "
+                f"metadata {_version_field_display(version_field)!r} as "
+                f"{existing!r}, expected {value!r}"
+            )
+            raise ValueError(msg)
+        return
+    _set_version_field(data, version_field, value)
+
+
+def _serialized_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
+    if isinstance(version_field, str):
+        return data[version_field] if version_field in data else _MISSING
+    current: Any = data
+    for part in version_field:
+        if not isinstance(current, Mapping) or part not in current:
+            return _MISSING
+        current = current[part]
+    return current
+
+
+def _model_metadata_serialization_keys(
+    compiled: _CompiledFamily,
+    *,
+    target_model: type[BaseModel],
+    field_name: str,
+) -> tuple[str, ...]:
+    metadata = compiled.version_metadata
+    keys: list[str] = [field_name]
+    if metadata is not None and isinstance(metadata.path, str):
+        keys.append(metadata.path)
+    for model in (compiled.model, target_model):
+        field_info = model.model_fields[field_name]
+        for candidate in (
+            field_info.alias,
+            field_info.validation_alias,
+            field_info.serialization_alias,
+        ):
+            if isinstance(candidate, str):
+                keys.append(candidate)
+    return tuple(dict.fromkeys(keys))
+
+
+def _serialized_field_name(
+    model: type[BaseModel],
+    field_name: str,
+    *,
+    by_alias: Any,
+) -> str:
+    use_alias = (
+        model.model_config.get("serialize_by_alias", False) is True
+        if by_alias is None
+        else by_alias is True
+    )
+    field_info = model.model_fields[field_name]
+    if use_alias:
+        output_alias = field_info.serialization_alias
+        if isinstance(output_alias, str):
+            return output_alias
+    return field_name
+
+
+def _infer_metadata_owner(
+    model_cls: type[BaseModel],
+    version_path: VersionPath,
+) -> Literal["family", "model"]:
+    if not isinstance(version_path, str):
+        return "family"
+    if version_path in model_cls.model_fields:
+        return "model"
+    if any(field.alias == version_path for field in model_cls.model_fields.values()):
+        return "model"
+    return "family"
+
+
+def _detect_version(
+    compiled: _CompiledFamily,
+    data: Any,
+    *,
+    explicit_version: str | None,
+) -> str:
+    if explicit_version is not None:
+        version = _runtime_label(explicit_version, family_name=compiled.name)
+        compiled.index(version)
+        return version
+    if isinstance(data, Mapping) and compiled.version_metadata is not None:
+        version_value = _get_version_field(data, compiled.version_metadata.path)
+        if version_value is not None:
+            version = _runtime_label(version_value, family_name=compiled.name)
+            compiled.index(version)
+            return version
+    if compiled.missing_version is not None:
+        return compiled.missing_version
+    field_display = (
+        "explicit version"
+        if compiled.version_metadata is None
+        else _version_field_display(compiled.version_metadata.path)
+    )
+    msg = f"Input data for {compiled.name!r} does not include {field_display!r}"
+    raise MissingSchemaVersionError(msg)
+
+
+def _get_version_field(data: Mapping[str, Any], version_field: VersionPath) -> Any:
+    if isinstance(version_field, str):
+        return data.get(version_field)
+    current: Any = data
+    for part in version_field:
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _set_version_field(data: dict[str, Any], version_field: VersionPath, value: str) -> None:
+    if isinstance(version_field, str):
+        data[version_field] = value
+        return
+    current = data
+    for part in version_field[:-1]:
+        next_value = current.get(part)
+        if part not in current:
+            next_value = {}
+            current[part] = next_value
+        elif not isinstance(next_value, dict):
+            msg = (
+                f"Cannot set version metadata at {version_field!r} because "
+                f"intermediate value {part!r} is not an object"
+            )
+            raise InvalidMigrationError(msg)
+        current = next_value
+    current[version_field[-1]] = value
+
+
+def _remove_version_field(data: dict[str, Any], version_field: VersionPath) -> None:
+    if isinstance(version_field, str):
+        data.pop(version_field, None)
+        return
+    current: Any = data
+    parents: list[tuple[dict[str, Any], str]] = []
+    for part in version_field[:-1]:
+        if not isinstance(current, dict) or not isinstance(current.get(part), dict):
+            return
+        parents.append((current, part))
+        current = current[part]
+    if isinstance(current, dict):
+        current.pop(version_field[-1], None)
+    for parent, part in reversed(parents):
+        child = parent.get(part)
+        if isinstance(child, dict) and not child:
+            parent.pop(part, None)
+
+
+def _version_field_display(version_field: VersionPath) -> str:
+    if isinstance(version_field, str):
+        return version_field
+    return ".".join(version_field)
+
+
+def _to_current_names(
+    compiled: _CompiledFamily,
+    version: _CompiledVersion,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(payload)
+    metadata = compiled.version_metadata
+    if metadata is not None:
+        if metadata.owner == "family":
+            _remove_version_field(normalized, metadata.path)
+        else:
+            metadata_field = _model_metadata_field_name(compiled)
+            if metadata.path != metadata_field:
+                normalized.pop(metadata.path, None)
+            normalized[metadata_field] = compiled.current_version
+    renamed = tuple(
+        (field.current_name, field.version_name)
+        for field in version.projection.fields
+        if field.version_name is not None and field.version_name != field.current_name
+    )
+    original = dict(normalized)
+    renamed_values: dict[str, Any] = {}
+    for current_name, version_name in renamed:
+        if version_name in original:
+            renamed_values[current_name] = original[version_name]
+    for _, version_name in renamed:
+        normalized.pop(version_name, None)
+    normalized.update(renamed_values)
+    return normalized
+
+
+def _current_validation_input(
+    model_cls: type[BaseModel], payload: dict[str, Any]
+) -> dict[str, Any]:
+    current_payload = dict(payload)
+    if model_cls.model_config.get("validate_by_alias", True) is False:
+        return current_payload
+    return _normalize_payload_field_aliases(model_cls, current_payload, prefer_aliases=True)
+
+
+def _normalize_payload_field_aliases(
+    model_cls: type[BaseModel],
+    payload: Mapping[str, Any],
+    *,
+    prefer_aliases: bool = False,
+) -> dict[str, Any]:
+    normalized = {key: _copy_alias_payload_value(value) for key, value in payload.items()}
+    for name, field_info in model_cls.model_fields.items():
+        alias_paths = _alias_paths(
+            field_info.validation_alias,
+            fallback=field_info.alias,
+        )
+        if name in normalized:
+            if prefer_aliases:
+                value = normalized[name]
+                mapped_aliases = tuple(
+                    path for path in alias_paths if not (len(path) == 1 and path[0] == name)
+                )
+                if mapped_aliases:
+                    mapped_alias = mapped_aliases[0]
+                    for alias_path in mapped_aliases:
+                        _remove_payload_path(normalized, alias_path)
+                    _set_payload_path(normalized, mapped_alias, value)
+                    normalized.pop(name, None)
+                continue
+
+            for alias_path in alias_paths:
+                if len(alias_path) == 1 and alias_path[0] == name:
+                    continue
+                _remove_payload_path(normalized, alias_path)
+            continue
+        source_path = _next_alias_path(field_info)
+        if source_path is not None and _path_has_payload(normalized, source_path):
+            value = _get_payload_path(normalized, source_path)
+            _remove_payload_path(normalized, source_path)
+            normalized[name] = value
+    return normalized
+
+
+def _copy_alias_payload_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _copy_alias_payload_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_alias_payload_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_copy_alias_payload_value(item) for item in value)
+    return value
+
+
+def _alias_paths(
+    alias: Any,
+    *,
+    fallback: Any = _MISSING,
+) -> tuple[tuple[str | int, ...], ...]:
+    if (alias is _MISSING or alias is None) and fallback is not _MISSING:
+        alias = fallback
+    if isinstance(alias, str):
+        return ((alias,),)
+    if isinstance(alias, AliasPath):
+        return (tuple(alias.path),)
+    if isinstance(alias, AliasChoices):
+        return tuple(path for choice in alias.choices for path in _alias_paths(choice))
+    return ()
+
+
+def _next_alias_path(field_info: Any) -> tuple[Any, ...] | None:
+    paths = _alias_paths(
+        field_info.validation_alias,
+        fallback=field_info.alias,
+    )
+    for path in paths:
+        if path:
+            return path
+    return None
+
+
+def _path_has_payload(payload: Mapping[Any, Any], path: tuple[Any, ...]) -> bool:
+    current: Any = payload
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
+def _get_payload_path(payload: Mapping[Any, Any], path: tuple[Any, ...]) -> Any:
+    current: Any = payload
+    for part in path:
+        current = current[part]
+    return current
+
+
+def _remove_payload_path(payload: dict[str, Any], path: tuple[Any, ...]) -> None:
+    parent_path: list[tuple[dict[str, Any], Any]] = []
+    current: Any = payload
+    for part in path[:-1]:
+        if part not in current:
+            return
+        if not isinstance(current[part], dict):
+            return
+        parent_path.append((current, part))
+        current = current[part]
+    removed = path[-1] in current
+    if removed:
+        current.pop(path[-1], None)
+    if removed:
+        for parent, part in reversed(parent_path):
+            child = parent[part]
+            if isinstance(child, Mapping) and len(child) == 0:
+                parent.pop(part, None)
+
+
+def _set_payload_path(payload: dict[str, Any], path: tuple[Any, ...], value: Any) -> None:
+    current = payload
+    for part in path[:-1]:
+        next_value = current.get(part)
+        if part not in current:
+            next_value = {}
+            current[part] = next_value
+        elif not isinstance(next_value, dict):
+            return
+        current = next_value
+    current[path[-1]] = value
+
+
+def _model_metadata_field_name(compiled: _CompiledFamily) -> str:
+    metadata = compiled.version_metadata
+    if metadata is None or metadata.owner != "model" or not isinstance(metadata.path, str):
+        msg = f"Compiled family {compiled.name!r} has invalid model-owned version metadata"
+        raise SchemaCompilationError(msg)
+    for field_name, field_info in compiled.model.model_fields.items():
+        if metadata.path in (
+            field_name,
+            field_info.alias,
+            field_info.validation_alias,
+            field_info.serialization_alias,
+        ):
+            return field_name
+    msg = f"Compiled family {compiled.name!r} lost its model-owned version metadata field"
+    raise SchemaCompilationError(msg)
+
+
+def _to_version_names(
+    version: _CompiledVersion,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    normalized = _normalize_payload_field_aliases(version.model, payload)
+    original = dict(normalized)
+    versioned = dict(normalized)
+    renamed = tuple(
+        (field.current_name, field.version_name)
+        for field in version.projection.fields
+        if field.version_name is not None and field.version_name != field.current_name
+    )
+    for field in version.projection.fields:
+        if field.version_name is None:
+            versioned.pop(field.current_name, None)
+    renamed_values: dict[str, Any] = {}
+    for current_name, version_name in renamed:
+        if current_name in original:
+            renamed_values[version_name] = original[current_name]
+    for current_name, _ in renamed:
+        versioned.pop(current_name, None)
+    versioned.update(renamed_values)
+    return versioned

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -68,6 +68,7 @@ from pydantic_versions._compiler import (
     _stable_digest,
     _VersionProjection,
 )
+from pydantic_versions._runtime_versioning import _remove_version_field, _to_version_names
 from pydantic_versions.exceptions import SchemaCompilationError, UnsupportedWireModelError
 
 if TYPE_CHECKING:
@@ -5152,8 +5153,6 @@ def _project_child_default_value(
         for name in fields_set
         if name in source_model.model_fields and name in value.__dict__
     }
-
-    from pydantic_versions._runtime import _remove_version_field, _to_version_names
 
     target_version = child._compiled_family().version(version)
     projected = _to_version_names(target_version, payload)

--- a/src/pydantic_versions/core.py
+++ b/src/pydantic_versions/core.py
@@ -10,7 +10,7 @@ from pydantic_versions._compiler import (
     _ensure_pydantic_v2_model,
     _ensure_unique_versions,
 )
-from pydantic_versions._runtime import _infer_metadata_owner, _runtime_label
+from pydantic_versions._runtime_versioning import _infer_metadata_owner, _runtime_label
 from pydantic_versions.declarations import (
     JsonValue as JsonValue,
 )


### PR DESCRIPTION
## What changed

- move version discovery, metadata serialization, alias-path normalization, and field-name projection into _runtime_versioning.py
- keep the shared missing-value sentinel in that leaf and import it everywhere that needs identity semantics
- remove _wire.py's late dependency on the entire runtime implementation
- point core metadata-owner inference directly at the leaf module

The new module is a cohesive 499-line subsystem. This is a mechanical private refactor; public exports and call paths are unchanged.

## Compatibility preservation

- retained #104's exact-string version-label checks and secret-safe diagnostics
- retained recursive AliasChoices and AliasPath handling from #104
- retained generated-projection omission for current-model exclude=True and exclude_if fields
- retained the immutable v0.3.0 contract

## Validation

- uv run make ci: passed; 856 passed; 95.83% coverage
- Python 3.12 / Pydantic 2.12.3: 856 passed; 95.73% coverage
- strict documentation build passed
- immutable v0.3.0 compatibility contract passed

Closes #108
Refs #94