### PR TITLE
refactor: remove stale cardinality selection input

### DIFF
--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -370,7 +370,6 @@ def _dump_family[T: BaseModel](
         validated_model=target_model,
         compiled=compiled,
         parent_label=requested,
-        selections=decorator_selections,
     )
     return _serialize_target_model(
         compiled=compiled,
@@ -829,9 +828,7 @@ def _validate_nested_collection_cardinality(
     validated_model: BaseModel,
     compiled: _CompiledFamily,
     parent_label: str,
-    selections: tuple[_DecoratorRouteSelection, ...],
 ) -> None:
-    del selections
     if not compiled.nested and not compiled.decorator_nested:
         return
     target = compiled.version(parent_label)

--- a/tests/unit/test_decorator_nested_boundaries.py
+++ b/tests/unit/test_decorator_nested_boundaries.py
@@ -698,6 +698,55 @@ def test_decorator_set_projection_rejects_target_cardinality_collapse() -> None:
         )
 
 
+def test_unselected_overlapping_union_route_checks_nested_set_cardinality() -> None:
+    @versioned_schema(
+        name="all_route_cardinality_grand",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Grand(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    @versioned_schema(
+        name="all_route_cardinality_set_branch",
+        versions=("1", "2"),
+        current="2",
+    )
+    class SetBranch(BaseModel):
+        values: set[Grand]
+
+    @versioned_schema(
+        name="all_route_cardinality_selected_branch",
+        versions=("1", "2"),
+        current="2",
+    )
+    class SelectedBranch(BaseModel):
+        values: list[dict[str, int | str]]
+
+    @versioned_schema(
+        name="all_route_cardinality_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        item: SetBranch | SelectedBranch
+
+    source = Parent(
+        item=SelectedBranch(
+            values=[{"value": 1}, {"value": "1"}],
+        ),
+    )
+
+    assert type(source.item) is SelectedBranch
+    with pytest.raises(InvalidMigrationError, match="set cardinality") as error:
+        dump_versioned(Parent, version="1", data=source)
+
+    assert "all_route_cardinality_grand" in str(error.value)
+    assert "('values',)" in str(error.value)
+
+
 def test_decorator_boundaries_recurse_across_decorated_families() -> None:
     @versioned_schema(name="recursive_grandchild", versions=("1", "2"), current="2")
     @schema_version("1", patches=(field_renamed("value", "legacy_value"),))


### PR DESCRIPTION
## Summary

- add a public overlapping-union regression proving nested set cardinality must traverse every compiled decorator route
- show the authoritative source selects a list-backed arm with no set traversal while target validation selects an unselected set-backed arm and collapses `1`/`"1"` from two members to one
- remove the stale `selections` argument, parameter, and `del` from the cardinality entry point
- leave recursive all-route validation unchanged

## Compatibility

This establishes existing behavior rather than changing it. The public error remains `InvalidMigrationError` and identifies the nested Grand family plus `('values',)`. A selected-routes-only implementation demonstrably cannot reach the collapsing set route.

All exclusion-related modules and the recursive cardinality implementation are unchanged, so `Field(exclude=True)` and effective `exclude_if` behavior remains intact.

## Validation

- locked Pydantic 2.13.4: 859 passed, 95.86% coverage
- exact lower-bound Pydantic 2.12.3: 859 passed, 95.76% coverage
- focused decorator file: 29 passed on each dependency endpoint
- independent mechanism/boundary subset: 6 passed
- Ruff format/check: passed
- ty and strict mypy consumer contract: passed
- Vulture: passed
- strict documentation build: passed
- immutable v0.3.0 compatibility contract: passed
- Conventional Commit validation: passed

Closes #118
Refs #94
Refs #100