### PR TITLE
ci(commits): enforce rendered validation structure

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -20,7 +20,8 @@
 
 - `<command>`: <result>
 
-; Or use: Validation: not run because <specific reason>.
+; Keep multiple results as top-level `- ` list items under this heading. For
+; one result, you may use: Validation: not run because <specific reason>.
 ; Delete optional sections that do not apply and remove every template token.
 ; PR metadata supplements this body. Wrap commit prose at about 72 columns;
 ; use natural Markdown without artificial hard wrapping in PR descriptions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,10 @@ template suggests this layout:
 ```
 
 The headings are guidance, not a required format. Unstructured prose is equally
-valid when it provides the same durable context. Do not retain template tokens,
+valid when it provides the same durable context. A single validation result can
+use a concise `Validation: ...` sentence. Put multiple results in separate
+top-level `- ` Markdown list items under `## Validation`, so rendered history
+does not collapse them into one paragraph. Do not retain template tokens,
 development-only notes such as "address review feedback," a body that merely
 repeats the subject, or validation commands without their result. For work that
 cannot be run locally, state a concrete reason instead of writing a placeholder.
@@ -95,6 +98,8 @@ git config --worktree core.commentChar ";"
 
 The comment-character setting preserves optional `##` headings when Git opens
 the template; instructional comments begin with `;` and are removed by Git.
+Keep these settings worktree-scoped: `--local` writes shared repository config
+and can make one linked checkout use another checkout's template path.
 
 A PR should explain the problem and approach, call out compatibility or release
 impact, list aggregate validation results, and link its issue with
@@ -136,5 +141,8 @@ migrations before the authoritative current-model validation boundary.
 Keep schema labels opaque and leave YAML parsing to callers. Document the
 legacy unversioned fallback and Django Ninja inspection boundary.
 
-Validation: `uv run make ci` passed; strict docs and package build passed.
+## Validation
+
+- `uv run make ci`: passed.
+- Strict docs and package build: passed.
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,7 +75,10 @@ template suggests this layout:
 ```
 
 The headings are guidance, not a required format. Unstructured prose is equally
-valid when it provides the same durable context. Do not retain template tokens,
+valid when it provides the same durable context. A single validation result can
+use a concise `Validation: ...` sentence. Put multiple results in separate
+top-level `- ` Markdown list items under `## Validation`, so rendered history
+does not collapse them into one paragraph. Do not retain template tokens,
 development-only notes such as "address review feedback," a body that merely
 repeats the subject, or validation commands without their result. For work that
 cannot be run locally, state a concrete reason instead of writing a placeholder.
@@ -95,6 +98,8 @@ git config --worktree core.commentChar ";"
 
 The comment-character setting preserves optional `##` headings when Git opens
 the template; instructional comments begin with `;` and are removed by Git.
+Keep these settings worktree-scoped: `--local` writes shared repository config
+and can make one linked checkout use another checkout's template path.
 
 A PR should explain the problem and approach, call out compatibility or release
 impact, list aggregate validation results, and link its issue with
@@ -136,5 +141,8 @@ migrations before the authoritative current-model validation boundary.
 Keep schema labels opaque and leave YAML parsing to callers. Document the
 legacy unversioned fallback and Django Ninja inspection boundary.
 
-Validation: `uv run make ci` passed; strict docs and package build passed.
+## Validation
+
+- `uv run make ci`: passed.
+- Strict docs and package build: passed.
 ```

--- a/scripts/check_conventional_commits.py
+++ b/scripts/check_conventional_commits.py
@@ -25,6 +25,7 @@ _ALLOWED_TYPES = frozenset(
         "fix",
         "perf",
         "refactor",
+        "release",
         "revert",
         "style",
         "test",
@@ -108,6 +109,11 @@ _VALIDATION_NARRATIVE_RE = re.compile(
     r"\b(?:earlier|historical|previous|prior)(?!-)\b",
     re.IGNORECASE,
 )
+_VALIDATION_LAYOUT_NARRATIVE_RE = re.compile(
+    r"\b(?:brings?|ensures?|holds?|keeps?|leaves?|makes?|maintains?|"
+    r"preserves?|restores?|returns?|sets?)\b",
+    re.IGNORECASE,
+)
 _GENERIC_VALIDATION_SUBJECT_RE = re.compile(
     r"^(?:(?:all|the)\s+)?(?:tests?|checks?)$",
     re.IGNORECASE,
@@ -168,6 +174,11 @@ _DEPENDABOT_GROUP_SUMMARY_RE = re.compile(
     re.IGNORECASE,
 )
 _BULLET_RE = re.compile(r"^\s*[-*+]\s+(?:\[[ xX]\]\s+)?")
+_MARKDOWN_LIST_ITEM_RE = re.compile(
+    r"^(?P<indent> {0,3})(?P<marker>[-*+]|[0-9]{1,9}[.)])"
+    r"[ \t]+(?:\[[ xX]\][ \t]+)?"
+)
+_VALIDATION_SENTENCE_BOUNDARY_RE = re.compile(r"(?:(?<=[.!?])|;)[ \t]+")
 _ISSUE_TRAILER_RE = re.compile(
     r"^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\s+#\d+(?:\s*,\s*#\d+)*$",
     re.IGNORECASE,
@@ -240,10 +251,52 @@ def validate_header(header: str, *, label: str) -> str | None:
 
 def _strip_markup(line: str) -> str:
     """Return visible prose without list markers or unwrappable destinations."""
-    stripped = _BULLET_RE.sub("", line.strip()).strip()
+    stripped = _MARKDOWN_LIST_ITEM_RE.sub("", line.strip()).strip()
+    stripped = _BULLET_RE.sub("", stripped).strip()
     stripped = _MARKDOWN_LINK_RE.sub(lambda match: match.group(1), stripped)
     stripped = _URL_RE.sub("", stripped)
     return re.sub(r"[`*_~]+", "", stripped).strip()
+
+
+def _validation_list_item_owners(lines: Sequence[str]) -> dict[int, int]:
+    """Map canonical top-level validation items and their continuations."""
+    owners: dict[int, int] = {}
+    active_owner: int | None = None
+    in_html_comment = False
+    setext_lines = _setext_heading_lines(lines)
+    top_level_indexes = _top_level_line_indexes(lines)
+
+    for index, line in enumerate(lines):
+        raw = line.strip()
+        if in_html_comment:
+            if "-->" in raw:
+                in_html_comment = False
+            active_owner = None
+            continue
+        if raw.startswith("<!--"):
+            in_html_comment = "-->" not in raw
+            active_owner = None
+            continue
+        if (
+            index not in top_level_indexes
+            or not raw
+            or index in setext_lines
+            or raw.startswith(";")
+            or _HEADING_RE.fullmatch(raw)
+            or _is_trailer(raw)
+        ):
+            active_owner = None
+            continue
+
+        if line.startswith("- "):
+            active_owner = index
+            owners[index] = index
+            continue
+
+        if active_owner is not None:
+            owners[index] = active_owner
+
+    return owners
 
 
 def _is_placeholder(line: str) -> bool:
@@ -396,7 +449,7 @@ def _validation_blocks(
             continue
 
         starts_record = bool(
-            _BULLET_RE.match(line)
+            _MARKDOWN_LIST_ITEM_RE.match(line)
             or _VALIDATION_LABEL_RE.match(visible)
             or _VALIDATION_COMMAND_RE.match(visible)
         )
@@ -510,30 +563,150 @@ def _classify_validation_block(
     return False, block
 
 
+def _validation_result_indexes(
+    parts: Sequence[str],
+    block_indexes: Sequence[int],
+    *,
+    explicit_context: bool,
+) -> tuple[int, ...]:
+    """Return high-confidence concrete result locations in one block."""
+    if not explicit_context:
+        return ()
+
+    def without_label(candidate: str) -> str:
+        if label_match := _VALIDATION_LABEL_RE.match(candidate):
+            return candidate[label_match.end() :].strip()
+        return candidate
+
+    def has_result_subject(candidate: str) -> bool:
+        if _VALIDATION_LABEL_RE.match(candidate):
+            return True
+        candidate = without_label(candidate)
+        if _VALIDATION_COMMAND_RE.match(candidate):
+            return True
+        result_matches = tuple(
+            match
+            for pattern in (
+                _VALIDATION_NOT_RUN_RE,
+                _VALIDATION_SKIPPED_RE,
+                _VALIDATION_COUNT_RESULT_RE,
+                _VALIDATION_OUTCOME_TRAIL_RE,
+                _VALIDATION_EXPLICIT_OUTCOME_TRAIL_RE,
+            )
+            if (match := pattern.search(candidate)) is not None
+        )
+        if not result_matches:
+            return False
+        first_result = min(result_matches, key=lambda match: match.start())
+        return bool(candidate[: first_result.start()].strip(" :=-\N{EM DASH}"))
+
+    def is_explicit_generic_result(candidate: str) -> bool:
+        candidate = without_label(candidate)
+        for result_pattern in (
+            _VALIDATION_COUNT_RESULT_RE,
+            _VALIDATION_OUTCOME_TRAIL_RE,
+            _VALIDATION_EXPLICIT_OUTCOME_TRAIL_RE,
+        ):
+            if result := result_pattern.search(candidate):
+                subject = candidate[: result.start()].strip(" :=-\N{EM DASH}")
+                return bool(
+                    subject
+                    and _GENERIC_VALIDATION_SUBJECT_RE.fullmatch(
+                        " ".join(subject.casefold().split())
+                    )
+                )
+        return False
+
+    def is_concrete_result(candidate: str) -> bool:
+        unlabeled = without_label(candidate)
+        is_command = _VALIDATION_COMMAND_RE.match(unlabeled) is not None
+        return bool(
+            candidate
+            and (
+                is_command
+                or not (
+                    _VALIDATION_NARRATIVE_RE.search(candidate)
+                    or _VALIDATION_LAYOUT_NARRATIVE_RE.search(candidate)
+                )
+            )
+            and (
+                _is_validation_record(candidate, validation_section=True)
+                or is_explicit_generic_result(candidate)
+            )
+        )
+
+    results: list[int] = []
+    has_prior_result = False
+    for part, index in zip(parts, block_indexes, strict=True):
+        for candidate in _VALIDATION_SENTENCE_BOUNDARY_RE.split(part):
+            candidate = candidate.strip()
+            if is_concrete_result(candidate) and not (
+                has_prior_result and not has_result_subject(candidate)
+            ):
+                results.append(index)
+                has_prior_result = True
+    if results:
+        return tuple(results)
+
+    block = " ".join(parts)
+    if is_concrete_result(block):
+        return (block_indexes[0],)
+    return ()
+
+
 def _analyze_validation(
     lines: Sequence[str],
     *,
     metadata_candidate_bounds: tuple[int, int] | None,
-) -> tuple[bool, set[int], list[str]]:
-    """Return evidence state, excluded lines, and mixed-block context."""
+) -> tuple[bool, set[int], list[str], list[bool]]:
+    """Return evidence state, excluded lines, context, and list-item layout."""
     has_evidence = False
     indexes: set[int] = set()
     context_prefixes: list[str] = []
+    list_item_records: list[bool] = []
+    list_item_owners = _validation_list_item_owners(lines)
+    claimed_list_items: set[int] = set()
+    previous_block_end: int | None = None
+    previous_block_explicit = False
     for parts, validation_section, block_indexes in _validation_blocks(
         lines,
         metadata_candidate_bounds=metadata_candidate_bounds,
     ):
+        first = parts[0]
+        directly_explicit = bool(
+            validation_section
+            or _VALIDATION_LABEL_RE.match(first)
+            or _VALIDATION_COMMAND_RE.match(first)
+        )
+        continues_previous_block = bool(
+            previous_block_end is not None and block_indexes[0] == previous_block_end + 1
+        )
+        continues_explicit_block = bool(previous_block_explicit and continues_previous_block)
+        explicit_context = directly_explicit or continues_explicit_block
+        result_indexes = _validation_result_indexes(
+            parts,
+            block_indexes,
+            explicit_context=explicit_context,
+        )
+        for result_index in result_indexes:
+            owner = list_item_owners.get(result_index)
+            owns_distinct_item = owner is not None and owner not in claimed_list_items
+            list_item_records.append(owns_distinct_item)
+            if owner is not None:
+                claimed_list_items.add(owner)
+
         is_validation, context_prefix = _classify_validation_block(
             parts,
             validation_section=validation_section,
         )
-        if not is_validation:
-            continue
-        has_evidence = True
-        indexes.update(block_indexes)
-        if context_prefix:
-            context_prefixes.append(context_prefix)
-    return has_evidence, indexes, context_prefixes
+        if is_validation:
+            has_evidence = True
+            indexes.update(block_indexes)
+            if context_prefix:
+                context_prefixes.append(context_prefix)
+        previous_block_end = block_indexes[-1]
+        previous_block_explicit = explicit_context
+    return has_evidence, indexes, context_prefixes, list_item_records
 
 
 def _word_count(lines: Sequence[str]) -> int:
@@ -914,10 +1087,12 @@ def validate_message(message: str, *, label: str) -> list[str]:
     metadata_candidate_bounds = _generated_metadata_candidate_bounds(lines)
     metadata_bounds = _generated_metadata_bounds(lines)
     metadata_records = _generated_metadata_records(lines, metadata_bounds)
-    validation_evidence, validation_indexes, validation_context_prefixes = _analyze_validation(
-        lines,
-        metadata_candidate_bounds=metadata_candidate_bounds,
-    )
+    (
+        validation_evidence,
+        validation_indexes,
+        validation_context_prefixes,
+        validation_list_item_records,
+    ) = _analyze_validation(lines, metadata_candidate_bounds=metadata_candidate_bounds)
     generated_dependency_message = metadata_bounds is not None and _has_generated_dependency_header(
         lines[0], metadata_records
     )
@@ -945,6 +1120,16 @@ def validate_message(message: str, *, label: str) -> list[str]:
             f"{label} must record validation evidence or a specific reason validation "
             "was not run. Include a result such as `uv run make ci: passed` or "
             "`Validation: not run because this changes documentation only`."
+        )
+    if (
+        not generated_dependency_message
+        and len(validation_list_item_records) > 1
+        and not all(validation_list_item_records)
+    ):
+        errors.append(
+            f"{label} records multiple validation results outside separate top-level "
+            "`- ` list items. Put each result in its own item under a `## Validation` "
+            "heading so rendered history keeps the results separate."
         )
     errors.extend(
         _line_length_errors(

--- a/tests/unit/test_conventional_commits.py
+++ b/tests/unit/test_conventional_commits.py
@@ -1,4 +1,255 @@
-from scripts.check_conventional_commits import validate_message
+import re
+from pathlib import Path
+
+from scripts.check_conventional_commits import _ALLOWED_TYPES, validate_header, validate_message
+
+ROOT = Path(__file__).parents[2]
+LAYOUT_ERROR = [
+    "Commit records multiple validation results outside separate top-level "
+    "`- ` list items. Put each result in its own item under a `## Validation` "
+    "heading so rendered history keeps the results separate."
+]
+
+
+def _policy_message(validation: str) -> str:
+    return f"""\
+refactor: preserve validation evidence structure
+
+Keep commit history readable across Git and rendered GitHub views while
+retaining durable compatibility context for every logical change.
+
+{validation}
+"""
+
+
+def test_documented_commit_types_match_the_checker() -> None:
+    guide = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    documented_section = guide.split("Common types are ", maxsplit=1)[1].split(
+        ". Keep the summary", maxsplit=1
+    )[0]
+
+    assert frozenset(re.findall(r"`([^`]+)`", documented_section)) == _ALLOWED_TYPES
+
+
+def test_release_is_an_accepted_commit_type() -> None:
+    assert validate_header("release: publish stable package", label="Commit") is None
+
+
+def test_single_inline_validation_result_remains_valid() -> None:
+    message = """\
+docs: clarify commit validation policy
+
+Explain how durable commit messages should present validation evidence.
+Keep the complete template optional for small documentation changes.
+
+Validation: uv run pytest: 4 passed.
+"""
+
+    assert validate_message(message, label="Commit") == []
+
+
+def test_generic_result_does_not_satisfy_the_existing_evidence_gate() -> None:
+    candidates = (
+        "Validation: Tests passed.",
+        "## Validation\n\nTests passed.",
+    )
+
+    for validation in candidates:
+        errors = validate_message(_policy_message(validation), label="Commit")
+        assert any("must record validation evidence" in error for error in errors)
+
+
+def test_repeated_inline_validation_results_are_rejected() -> None:
+    message = """\
+refactor: preserve validation evidence structure
+
+Keep commit history readable when a material change records results from
+multiple independent quality gates and compatibility environments.
+
+Validation: 859 tests passed on Pydantic 2.13.4.
+Validation: 859 tests passed on Pydantic 2.12.3.
+Validation: strict docs and package build passed.
+"""
+
+    assert validate_message(message, label="Commit") == LAYOUT_ERROR
+
+
+def test_multiple_results_cannot_hide_inside_one_explicit_block() -> None:
+    candidates = (
+        """\
+## Validation
+
+Pydantic 2.13.4 tests: passed.
+Pydantic 2.12.3 tests: passed.
+""",
+        """\
+## Validation
+
+`uv run pytest`: 859 passed.
+Strict docs and package build: passed.
+""",
+        "`uv run pytest`: 859 passed.\n`uv run make docs`: passed.",
+        "Validation: Python tests passed. Strict docs passed.",
+        "Validation: Python tests passed; strict docs passed.",
+        "Validation: Python tests passed; Validation: 0 failed.",
+        "Validation: Python tests passed. Tests: 0 failed.",
+        "Validation: Python tests passed; Validation: not run because docs only.",
+        """\
+## Validation
+
+- Python tests passed. Strict docs passed.
+""",
+        """\
+## Validation
+
+- Python tests passed; strict docs passed.
+""",
+        """\
+## Validation
+
+Tests passed.
+Docs passed.
+""",
+    )
+
+    for validation in candidates:
+        assert validate_message(_policy_message(validation), label="Commit") == LAYOUT_ERROR
+
+
+def test_template_validation_list_is_valid() -> None:
+    message = """\
+refactor: preserve validation evidence structure
+
+## Summary
+
+- Keep durable commit history readable across Git and rendered GitHub
+  views.
+
+## Boundaries and compatibility
+
+- Preserve concise unstructured messages for genuinely small changes.
+
+## Validation
+
+- `uv run pytest`: 4 passed.
+- Strict docs and package build: passed.
+"""
+
+    assert validate_message(message, label="Commit") == []
+
+
+def test_wrapped_validation_results_keep_their_list_item_owner() -> None:
+    validation = """\
+## Validation
+
+- Python lower-bound environment:
+  `uv run pytest`: 859 passed.
+- Static quality gates:
+  `uv run make check`: passed.
+"""
+
+    assert validate_message(_policy_message(validation), label="Commit") == []
+
+
+def test_render_unsafe_list_markers_are_rejected() -> None:
+    candidates = (
+        """\
+## Validation
+
+1234567890. Python tests: passed.
+1234567891. Strict docs: passed.
+""",
+        "## Validation\n\n \t- Python tests: passed.\n \t- Strict docs: passed.",
+        "## Validation\n\n-\N{NO-BREAK SPACE}Python tests: passed.\n"
+        "-\N{NO-BREAK SPACE}Strict docs: passed.",
+        "Validation: Python tests passed.\n2. Strict docs passed.\n3. Package build passed.",
+        "## Validation\n\n- Python tests: passed.\n  - Strict docs: passed.",
+        "## Validation\n\n1. Python tests: passed.\n   2. Strict docs: passed.",
+        "## Validation\n\n* Python tests: passed.\n* Strict docs: passed.",
+        "## Validation\n\n - Python tests: passed.\n - Strict docs: passed.",
+        "* Validation: Python tests passed.\n* Validation: Strict docs passed.",
+        "1. Validation: Python tests passed.\n2. Validation: Strict docs passed.",
+        "1. uv run pytest: 4 passed.\n2. uv run make docs: passed.",
+        "1) uv run pytest: 4 passed.\n2) uv run make docs: passed.",
+        """\
+## Validation
+
+<!--
+- hidden owner one
+-->
+`uv run pytest`: 859 passed.
+<!--
+- hidden owner two
+-->
+`uv run make docs`: passed.
+""",
+    )
+
+    for validation in candidates:
+        assert validate_message(_policy_message(validation), label="Commit") == LAYOUT_ERROR
+
+
+def test_indented_code_is_not_accepted_as_a_validation_list() -> None:
+    validation = """\
+## Validation
+
+    - Python tests: passed.
+    - Strict docs: passed.
+"""
+
+    errors = validate_message(_policy_message(validation), label="Commit")
+    assert any("must record validation evidence" in error for error in errors)
+
+
+def test_normative_summary_prose_does_not_count_as_an_executed_result() -> None:
+    message = """\
+refactor: preserve validation evidence structure
+
+## Summary
+
+- Keep the compatibility test suite green.
+- Keep the release build clean.
+- Make the release build clean.
+- Set the compatibility test suite green.
+- Stabilize the compatibility test suite green.
+- Turn the release build green.
+* Add an example showing Python tests: 4 passed.
+* Quote an example showing strict docs suite: 1 passed.
+
+Explain the durable parser boundary and retain enough historical context
+for readers who inspect the logical change outside its pull request.
+
+Validation: uv run pytest: 859 passed.
+"""
+
+    assert validate_message(message, label="Commit") == []
+
+
+def test_validation_narrative_does_not_create_an_extra_result() -> None:
+    candidates = (
+        "Validation: pytest: 859 passed. This keeps the build clean.",
+        "Validation: pytest: 859 passed; this keeps the build clean.",
+        """\
+## Validation
+
+- `pytest`: 859 passed. This keeps the build clean.
+""",
+    )
+
+    for validation in candidates:
+        assert validate_message(_policy_message(validation), label="Commit") == []
+
+
+def test_one_command_summary_remains_one_validation_result() -> None:
+    candidates = (
+        "Validation: uv run pytest: 859 passed; 0 failed.",
+        "Validation: uv run pytest: 859 passed; 2 skipped; 0 failed.",
+        "Validation: uv run pytest documents: 4 passed.",
+        "## Validation\n\n- `make docs`: passed; 0 warnings.",
+    )
+
+    for validation in candidates:
+        assert validate_message(_policy_message(validation), label="Commit") == []
 
 
 def test_valid_dependabot_message_keeps_generated_summary_lines() -> None:


### PR DESCRIPTION
## Summary

- Enforces the tracked commit-message convention when a logical commit records multiple validation results: use a `## Validation` section with one column-zero `- ` item per result.
- Keeps a single concise inline result valid and aligns the checker with the documented `release` commit type.
- Documents worktree-scoped template configuration so linked checkouts cannot inherit another worktree's `.gitmessage` path.

## Compatibility

- Preserves the existing evidence and descriptive-body requirements.
- Keeps generated Dependabot messages exempt.
- Limits broad result inference to explicit validation contexts so ordinary Summary prose is not mistaken for an executed check.
- Does not rewrite already-merged history or require every optional template section.

## Validation

- `uv run make ci`: 872 tests passed at 95.89% coverage; Ruff, ty, strict mypy, and Vulture passed.
- `uv run make docs-build-strict`: passed with no issues.
- `uv run python tests/compatibility/v0_3_0_contract.py --check`: passed.
- `uv build`: source and wheel distributions built.
- Two independent adversarial reviews found no blockers on the retained candidate.

Closes #126