### PR TITLE
refactor(wire): remove proven duplicate paths

### DIFF
--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -461,7 +461,7 @@ def _nested_container_element(
     return first
 
 
-def _model_display(model: type[BaseModel]) -> str:
+def _model_display(model: type[Any]) -> str:
     return f"{model.__module__}.{model.__qualname__}"
 
 

--- a/src/pydantic_versions/_wire.py
+++ b/src/pydantic_versions/_wire.py
@@ -202,9 +202,7 @@ def _build_model_for_projection_unchecked(
 ) -> type[BaseModel]:
     model_metadata_field = _model_metadata_field(family)
     used_nested: set[tuple[str, ...]] = set()
-    nested_projection_cache: dict[
-        tuple[int, tuple[str, ...], str, bool], type[BaseModel] | None
-    ] = {}
+    nested_projection_cache: dict[tuple[int, tuple[str, ...], str, bool], type[BaseModel]] = {}
     fields: dict[str, Any] = {}
     for compiled_field in projection.fields:
         if compiled_field.version_name is None:

--- a/src/pydantic_versions/_wire_contract.py
+++ b/src/pydantic_versions/_wire_contract.py
@@ -24,8 +24,6 @@ from typing import (
 
 from annotated_types import GroupedMetadata, Not, Predicate
 from pydantic import (
-    AliasChoices,
-    AliasPath,
     BaseModel,
     ConfigDict,
     Discriminator,
@@ -49,9 +47,11 @@ from typing_extensions import is_typeddict as extensions_is_typeddict
 from pydantic_versions._compiler import (
     _generated_model_name,
     _identifier_component,
+    _model_display,
     _stable_digest,
     _VersionProjection,
 )
+from pydantic_versions._runtime_versioning import _alias_paths
 from pydantic_versions.exceptions import UnsupportedWireModelError
 
 if TYPE_CHECKING:
@@ -1345,16 +1345,6 @@ def _bound_annotation_parameters(
     return bindings
 
 
-def _alias_paths(alias: Any) -> tuple[tuple[str | int, ...], ...]:
-    if isinstance(alias, str):
-        return ((alias,),)
-    if isinstance(alias, AliasPath):
-        return (tuple(alias.path),)
-    if isinstance(alias, AliasChoices):
-        return tuple(path for choice in alias.choices for path in _alias_paths(choice))
-    return ()
-
-
 def _add_family_metadata_field(
     family: SchemaFamily[Any],
     version: str,
@@ -1424,13 +1414,15 @@ def _add_nested_family_metadata_field(
         field_definitions: dict[str, Any] = {field_name: Annotated[annotation, field]}
         child_model = create_model(
             _metadata_model_name(family, version, path, index),
-            __config__=_metadata_wrapper_config(family),
+            __config__=_metadata_wrapper_config(),
             __module__=family.model.__module__,
             **field_definitions,
         )
 
-    if child_model is None:  # pragma: no cover - paths are non-empty and handled above
-        _raise_unsupported(family, "family-owned metadata path cannot be empty")
+    # VersionMetadata rejects empty paths and the single-component case returns
+    # above, so the wrapper loop always produces this model. Keep that invariant
+    # visible to static analysis without a second runtime error path.
+    assert child_model is not None
     root_name = path[0]
     fields[root_name] = Annotated[
         child_model,
@@ -1444,8 +1436,7 @@ def _add_nested_family_metadata_field(
     ]
 
 
-def _metadata_wrapper_config(family: SchemaFamily[Any]) -> ConfigDict:
-    del family
+def _metadata_wrapper_config() -> ConfigDict:
     return ConfigDict(extra="forbid", frozen=True)
 
 
@@ -1575,10 +1566,6 @@ def _raise_projection_unsupported(
         f"is unsupported: {detail}"
     )
     raise UnsupportedWireModelError(msg)
-
-
-def _model_display(model: type[Any]) -> str:
-    return f"{model.__module__}.{model.__qualname__}"
 
 
 def _validate_type_alias(

--- a/src/pydantic_versions/_wire_document.py
+++ b/src/pydantic_versions/_wire_document.py
@@ -41,7 +41,6 @@ def _build_family_document_adapter(
     metadata = cast(Any, family.version_metadata)
     label = projection.label
     metadata_path = metadata.path
-    _validate_family_document_adapter_schema_hooks(family, projection, body_model)
     adapter_config = dict(body_model.model_config)
     # The exact body schema remains the sole owner of materialized aliases and
     # JSON Schema callbacks. Replaying these while create_model builds the

--- a/src/pydantic_versions/_wire_nested.py
+++ b/src/pydantic_versions/_wire_nested.py
@@ -666,7 +666,7 @@ def _rewrite_annotation(
     used_nested: set[tuple[str, ...]],
     field_name: str,
     allow_child_projection: bool,
-    nested_projection_cache: dict[tuple[int, tuple[str, ...], str, bool], type[BaseModel] | None],
+    nested_projection_cache: dict[tuple[int, tuple[str, ...], str, bool], type[BaseModel]],
     in_set_element: bool = False,
 ) -> Any:
     child = _find_nested_family_for_path(nested, field_path)
@@ -718,7 +718,6 @@ def _rewrite_annotation(
                 version,
                 family,
                 compilation=compilation,
-                field_name=field_name,
                 field_path=field_path,
                 nested=nested_families,
                 decorator_nested=decorator_families,
@@ -805,11 +804,10 @@ def _rewrite_nested_model(
     owner: SchemaFamily[Any],
     *,
     compilation: _WireCompilationContext,
-    field_name: str,
     field_path: tuple[str, ...],
     nested: tuple[_CompiledNestedFamily, ...],
     decorator_nested: tuple[_CompiledDecoratorNestedFamily, ...],
-    nested_projection_cache: dict[tuple[int, tuple[str, ...], str, bool], type[BaseModel] | None],
+    nested_projection_cache: dict[tuple[int, tuple[str, ...], str, bool], type[BaseModel]],
     used_nested: set[tuple[str, ...]],
     in_set_element: bool = False,
 ) -> type[BaseModel]:

--- a/tests/unit/test_decorator_nested_compilation.py
+++ b/tests/unit/test_decorator_nested_compilation.py
@@ -63,6 +63,37 @@ def test_decorator_child_with_different_labels_requires_an_explicit_mapping() ->
         model_for_version(Parent, "1")
 
 
+def test_excluded_decorator_children_do_not_create_incompatible_routes() -> None:
+    @versioned_schema(
+        name="compilation_excluded_mismatched_child_123",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Child(BaseModel):
+        value: int
+
+    @versioned_schema(
+        name="compilation_excluded_mismatched_parent_123",
+        versions=("1",),
+        current="1",
+    )
+    class Parent(BaseModel):
+        excluded_child: Child = Field(exclude=True)
+        conditional_child: Child = Field(exclude_if=lambda _value: False)
+
+    current = Parent(
+        excluded_child=Child(value=1),
+        conditional_child=Child(value=2),
+    )
+    assert current.model_dump() == {"conditional_child": {"value": 2}}
+
+    historical = model_for_version(Parent, "1")
+
+    assert set(historical.model_fields) == {"schema_version"}
+    assert historical().model_dump() == {"schema_version": "1"}
+    assert dump_versioned(Parent, version="1", data=current) == {"schema_version": "1"}
+
+
 def test_decorator_child_in_an_unsupported_generic_wrapper_fails_closed() -> None:
     @versioned_schema(
         name="compilation_generic_wrapper_child_77",

--- a/tests/unit/test_schema_family.py
+++ b/tests/unit/test_schema_family.py
@@ -304,6 +304,12 @@ def test_declaration_records_reject_malformed_values() -> None:
     assert str(raised.value) == "VersionMetadata.path cannot be empty"
 
     with pytest.raises(SchemaCompilationError) as raised:
+        VersionMetadata(path=())
+    assert str(raised.value) == (
+        "VersionMetadata.path must be a non-empty string or tuple of strings"
+    )
+
+    with pytest.raises(SchemaCompilationError) as raised:
         VersionMetadata(path=("meta", ""))
     assert str(raised.value) == "VersionMetadata.path must contain only non-empty strings"
 

--- a/tests/unit/test_wire_coverage_contract.py
+++ b/tests/unit/test_wire_coverage_contract.py
@@ -1510,6 +1510,10 @@ def test_projected_wrapper_default_omits_non_wire_fields() -> None:
     class Wrapper(BaseModel):
         child: Child
         cache: str = Field("application-only", exclude=True)
+        conditional_cache: str = Field(
+            "application-only",
+            exclude_if=lambda _value: False,
+        )
 
     class Parent(BaseModel):
         wrapper: Wrapper = Wrapper(child=Child(value=5))
@@ -1523,6 +1527,8 @@ def test_projected_wrapper_default_omits_non_wire_fields() -> None:
     )
     historical = family.model_for("1")
 
+    wrapper_wire = historical.model_fields["wrapper"].annotation
+    assert set(wrapper_wire.model_fields) == {"child"}
     assert historical().model_dump() == {"wrapper": {"child": {"legacy_value": 5}}}
 
 


### PR DESCRIPTION
## Summary

- Remove duplicate wire-schema checks and reuse established internal helpers.
- Delete stale parameters and compile-proven unreachable nullable states.
- Add focused regressions before removing each dead or duplicate path.

## Compatibility boundaries

- Preserve structural omission of `Field(exclude=True)` and `exclude_if` across current, historical, nested, and decorator-discovered wire projections.
- Explicitly retain false-returning `exclude_if` values in application models while omitting those fields from generated wire schemas.
- Preserve facade validation order, error precedence, generated defaults, phase-specific checks, the public API, and the immutable 0.3.0 contract.

## Validation

- `uv run make ci`: 873 tests passed at 95.89% coverage.
- Pydantic 2.12.3 focused regressions: 12 tests passed.
- `uv run make docs-build-strict`: passed with no issues.
- `uv run python tests/compatibility/v0_3_0_contract.py --check`: passed.
- `uv build`: source and wheel distributions built successfully.
- Two independent read-only reviews found no blockers.

Closes #123
Refs #95