### PR TITLE
perf(runtime): index decorator reconciliation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,33 @@
+# Decorator runtime benchmarks
+
+`decorator_runtime.py` measures the two scaling shapes tracked by issue #100:
+
+- reconciliation after a callback reorders 100, 500, and 1,000 decorator
+  occurrences;
+- authoritative route selection for a 16-arm decorator-child union.
+
+The harness uses fixed inputs, verifies every selected location and family, and
+emits raw nanosecond samples plus their median as JSON. It does not enforce a
+speed threshold, because timings vary by machine and ordinary CI remains a
+correctness gate.
+
+Run the candidate from the repository root:
+
+```console
+uv run python benchmarks/decorator_runtime.py --label candidate
+```
+
+To compare another checkout without installing it, point at that checkout's
+`src` directory. Use the same Python environment, repeat count, and command for
+both runs:
+
+```console
+uv run python benchmarks/decorator_runtime.py \
+  --source-root ../pydantic-versions-baseline/src \
+  --label origin-main
+```
+
+The report records the imported source root, Git revision and dirty state,
+Python, Pydantic, platform, warm-up count, repeat count, and every raw sample.
+Compare the three `reconcile_reordered_occurrences` medians as both absolute
+times and ratios, then compare `select_multi_route_union` on the same machine.

--- a/benchmarks/decorator_runtime.py
+++ b/benchmarks/decorator_runtime.py
@@ -1,0 +1,409 @@
+"""Reproduce the decorator-runtime scaling cases tracked by issue #100.
+
+The script emits only JSON on stdout so results can be retained or compared by
+another tool.  It intentionally records timings without enforcing thresholds;
+ordinary CI should prove correctness, not make machine-speed claims.
+
+Run against the current checkout:
+
+    uv run python benchmarks/decorator_runtime.py --label candidate
+
+Run the same harness against an isolated checkout:
+
+    uv run python benchmarks/decorator_runtime.py \
+        --source-root ../pydantic-versions-baseline/src \
+        --label origin-main
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import platform
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import reduce
+from operator import or_
+from pathlib import Path
+from statistics import median
+from time import perf_counter_ns
+from types import GenericAlias
+from typing import Any
+
+DEFAULT_COUNTS = (100, 500, 1_000)
+DEFAULT_UNION_ROUTES = 16
+DEFAULT_UNION_VALUES_PER_ROUTE = 8
+REPORT_SCHEMA = "pydantic-versions.decorator-runtime.v1"
+
+
+@dataclass(frozen=True)
+class _BenchmarkCase:
+    name: str
+    parameters: dict[str, int]
+    operation: Callable[[], Any]
+    verify: Callable[[Any], dict[str, Any]]
+
+
+def _activate_source_root(source_root: Path | None) -> Path:
+    selected = (
+        Path(__file__).resolve().parents[1] / "src"
+        if source_root is None
+        else source_root.resolve()
+    )
+    if not (selected / "pydantic_versions").is_dir():
+        msg = f"Source root does not contain pydantic_versions: {selected}"
+        raise ValueError(msg)
+    if any(
+        name == "pydantic_versions" or name.startswith("pydantic_versions.") for name in sys.modules
+    ):
+        msg = "Select --source-root before importing pydantic_versions"
+        raise RuntimeError(msg)
+    sys.path.insert(0, str(selected))
+    return selected
+
+
+def _repository_state(source_root: Path) -> dict[str, Any]:
+    repository = source_root.parent if source_root.name == "src" else source_root
+
+    def git(*arguments: str) -> str | None:
+        completed = subprocess.run(
+            ("git", "-C", str(repository), *arguments),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            return None
+        return completed.stdout.strip()
+
+    revision = git("rev-parse", "HEAD")
+    status = git("status", "--porcelain", "--untracked-files=no")
+    return {
+        "revision": revision,
+        "tracked_files_dirty": None if status is None else bool(status),
+    }
+
+
+def _build_occurrence_case(count: int) -> _BenchmarkCase:
+    from pydantic import create_model
+
+    from pydantic_versions import VersionTransition, versioned_schema
+    from pydantic_versions._runtime import _validated_current_render_payload
+    from pydantic_versions._runtime_decorators import _reconcile_decorator_selections
+    from pydantic_versions.family import _family_for
+
+    child = create_model("BenchmarkOccurrenceChild", value=(int, ...))
+    child = versioned_schema(
+        name="benchmark_occurrence_child",
+        versions=("1", "2"),
+        current="2",
+    )(child)
+
+    def reverse_items(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "items": list(reversed(data["items"]))}
+
+    parent = create_model(
+        "BenchmarkOccurrenceParent",
+        items=(GenericAlias(list, child), ...),
+    )
+    parent = versioned_schema(
+        name="benchmark_occurrence_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=reverse_items,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )(parent)
+    family = _family_for(parent)
+    compiled = family._compiled_family()
+    current_model = parent.model_validate(
+        {
+            "items": [child.model_validate({"value": index}) for index in range(count)],
+        }
+    )
+    payload, selections = _validated_current_render_payload(
+        family=family,
+        compiled=compiled,
+        data=current_model,
+    )
+    payload = reverse_items(payload)
+
+    def operation() -> Any:
+        nonlocal selections
+        selections = _reconcile_decorator_selections(
+            payload=payload,
+            selections=selections,
+            compiled=compiled,
+            discover_new=True,
+        )
+        return selections
+
+    def verify(result: Any) -> dict[str, Any]:
+        if len(result) != count:
+            msg = f"Expected {count} selections, received {len(result)}"
+            raise AssertionError(msg)
+        items = payload["items"]
+        expected_locations = {("items", index) for index in range(count)}
+        locations = {selection.location for selection in result}
+        if locations != expected_locations:
+            raise AssertionError("Reconciliation did not preserve every occurrence location")
+        for selection in result:
+            _, index = selection.location
+            if selection.value_identity != id(items[index]):
+                raise AssertionError("Reconciliation attached an occurrence to the wrong value")
+        values = [item["value"] for item in items]
+        expected_values = list(reversed(range(count)))
+        if values != expected_values:
+            raise AssertionError("The benchmark callback did not preserve reversed values")
+        return {
+            "locations": len(locations),
+            "payload_first": values[0],
+            "payload_last": values[-1],
+            "unique_value_identities": len({selection.value_identity for selection in result}),
+        }
+
+    return _BenchmarkCase(
+        name="reconcile_reordered_occurrences",
+        parameters={"occurrences": count},
+        operation=operation,
+        verify=verify,
+    )
+
+
+def _build_union_case(route_count: int, values_per_route: int) -> _BenchmarkCase:
+    from pydantic import create_model
+
+    from pydantic_versions import versioned_schema
+    from pydantic_versions._runtime_decorators import _select_decorator_routes
+    from pydantic_versions.family import _family_for
+
+    children: list[type[Any]] = []
+    for route_index in range(route_count):
+        child = create_model(
+            f"BenchmarkUnionChild{route_index}",
+            value=(int, ...),
+        )
+        child = versioned_schema(
+            name=f"benchmark_union_child_{route_index}",
+            versions=("1",),
+            current="1",
+        )(child)
+        children.append(child)
+
+    union_annotation = reduce(or_, children)
+    parent = create_model(
+        "BenchmarkUnionParent",
+        items=(GenericAlias(list, union_annotation), ...),
+    )
+    parent = versioned_schema(
+        name="benchmark_union_parent",
+        versions=("1",),
+        current="1",
+    )(parent)
+    family = _family_for(parent)
+    compiled = family._compiled_family()
+    values = [
+        child.model_validate({"value": route_index * values_per_route + ordinal})
+        for route_index, child in enumerate(children)
+        for ordinal in range(values_per_route)
+    ]
+    current_model = parent.model_validate({"items": values})
+
+    def operation() -> Any:
+        return _select_decorator_routes(
+            current_model,
+            compiled=compiled,
+            parent_label=compiled.current_version,
+            source_version=None,
+        )
+
+    def verify(result: Any) -> dict[str, Any]:
+        occurrence_count = route_count * values_per_route
+        if len(result) != occurrence_count:
+            msg = f"Expected {occurrence_count} selections, received {len(result)}"
+            raise AssertionError(msg)
+        locations = {selection.location for selection in result}
+        expected_locations = {("items", index) for index in range(occurrence_count)}
+        if locations != expected_locations:
+            raise AssertionError("Union selection did not visit every occurrence exactly once")
+        selected_families: set[type[Any]] = set()
+        for selection in result:
+            _, index = selection.location
+            value = values[index]
+            if selection.route.family.model is not type(value):
+                raise AssertionError("Union selection resolved an occurrence to the wrong route")
+            if len(selection.site_routes) != route_count:
+                raise AssertionError("Union dispatch site does not retain all route choices")
+            selected_families.add(selection.route.family.model)
+        if selected_families != set(children):
+            raise AssertionError("Union selection omitted one or more child families")
+        return {
+            "locations": len(locations),
+            "selected_families": len(selected_families),
+            "site_routes": route_count,
+        }
+
+    return _BenchmarkCase(
+        name="select_multi_route_union",
+        parameters={
+            "occurrences": route_count * values_per_route,
+            "routes": route_count,
+            "values_per_route": values_per_route,
+        },
+        operation=operation,
+        verify=verify,
+    )
+
+
+def _measure(case: _BenchmarkCase, *, repeats: int, warmups: int) -> dict[str, Any]:
+    first = case.operation()
+    correctness = case.verify(first)
+    for _ in range(warmups):
+        case.operation()
+
+    samples: list[int] = []
+    final: Any = first
+    for _ in range(repeats):
+        gc.collect()
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            started = perf_counter_ns()
+            final = case.operation()
+            samples.append(perf_counter_ns() - started)
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+
+    if case.verify(final) != correctness:
+        raise AssertionError("Benchmark correctness observations changed between runs")
+    middle = int(median(samples))
+    return {
+        "case": case.name,
+        "correctness": correctness,
+        "max_ns": max(samples),
+        "median_ns": middle,
+        "min_ns": min(samples),
+        "parameters": case.parameters,
+        "samples_ns": samples,
+    }
+
+
+def run_benchmarks(
+    *,
+    counts: Sequence[int] = DEFAULT_COUNTS,
+    union_routes: int = DEFAULT_UNION_ROUTES,
+    union_values_per_route: int = DEFAULT_UNION_VALUES_PER_ROUTE,
+    repeats: int = 7,
+    warmups: int = 1,
+    label: str = "working-tree",
+    source_root: Path,
+) -> dict[str, Any]:
+    if not counts or any(count < 1 for count in counts):
+        raise ValueError("counts must contain positive integers")
+    if union_routes < 2:
+        raise ValueError("union_routes must be at least 2")
+    if union_values_per_route < 1:
+        raise ValueError("union_values_per_route must be positive")
+    if repeats < 1:
+        raise ValueError("repeats must be positive")
+    if warmups < 0:
+        raise ValueError("warmups cannot be negative")
+
+    cases = [*(_build_occurrence_case(count) for count in counts)]
+    cases.append(_build_union_case(union_routes, union_values_per_route))
+    results = [_measure(case, repeats=repeats, warmups=warmups) for case in cases]
+
+    from pydantic import __version__ as pydantic_version
+
+    import pydantic_versions
+
+    package_file = pydantic_versions.__file__
+    if package_file is None:
+        raise RuntimeError("Imported pydantic_versions package has no source file")
+    package_path = Path(package_file).resolve()
+    if not package_path.is_relative_to(source_root.resolve()):
+        msg = (
+            f"Imported pydantic_versions from {package_path}, outside requested "
+            f"source root {source_root.resolve()}"
+        )
+        raise RuntimeError(msg)
+
+    return {
+        "benchmark_schema": REPORT_SCHEMA,
+        "configuration": {
+            "counts": list(counts),
+            "repeats": repeats,
+            "union_routes": union_routes,
+            "union_values_per_route": union_values_per_route,
+            "warmups": warmups,
+        },
+        "environment": {
+            "executable": sys.executable,
+            "implementation": platform.python_implementation(),
+            "platform": platform.platform(),
+            "pydantic": pydantic_version,
+            "pydantic_versions": pydantic_versions.__version__,
+            "pydantic_versions_module": str(package_path),
+            "python": platform.python_version(),
+            "source_root": str(source_root),
+            "timer": "perf_counter_ns",
+        },
+        "label": label,
+        "repository": _repository_state(source_root),
+        "results": results,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--counts",
+        nargs="+",
+        type=int,
+        default=list(DEFAULT_COUNTS),
+        help="Decorator occurrence counts (default: 100 500 1000)",
+    )
+    parser.add_argument("--label", default="working-tree")
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        help="Checkout src directory to import instead of this checkout",
+    )
+    parser.add_argument("--union-routes", type=int, default=DEFAULT_UNION_ROUTES)
+    parser.add_argument(
+        "--union-values-per-route",
+        type=int,
+        default=DEFAULT_UNION_VALUES_PER_ROUTE,
+    )
+    parser.add_argument("--warmups", type=int, default=1)
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    options = _parser().parse_args(arguments)
+    source_root = _activate_source_root(options.source_root)
+    report = run_benchmarks(
+        counts=options.counts,
+        union_routes=options.union_routes,
+        union_values_per_route=options.union_values_per_route,
+        repeats=options.repeats,
+        warmups=options.warmups,
+        label=options.label,
+        source_root=source_root,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -571,6 +571,8 @@ def _prune_serialized_decorator_metadata(
     selections: tuple[_DecoratorRouteSelection, ...],
     by_alias: Any,
 ) -> None:
+    if not selections:
+        return
     source_payload = _extract_declared_fields(source_model)
     for selection in _decorator_selections_child_first(selections):
         location = _serialized_decorator_selection_location(

--- a/src/pydantic_versions/_runtime_decorators.py
+++ b/src/pydantic_versions/_runtime_decorators.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from functools import partial
@@ -28,12 +29,22 @@ from pydantic_versions._runtime_versioning import (
 )
 from pydantic_versions.exceptions import InvalidMigrationError
 
+type _DecoratorDispatchSite = tuple[tuple[str, str], ...]
+type _DecoratorLocation = tuple[str | int, ...]
+type _DecoratorCandidate = tuple[Any, _DecoratorLocation, _DecoratorLocation]
+type _DecoratorUnionArmCache = dict[tuple[int, int], Any]
+type _DecoratorRouteGroups = dict[
+    _DecoratorDispatchSite,
+    tuple[_CompiledDecoratorNestedFamily, ...],
+]
+type _DecoratorRouteGroupCache = dict[int, _DecoratorRouteGroups]
+
 
 @dataclass
 class _DecoratorRouteSelection:
     route: _CompiledDecoratorNestedFamily
-    location: tuple[str | int, ...]
-    relative_location: tuple[str | int, ...]
+    location: _DecoratorLocation
+    relative_location: _DecoratorLocation
     site_routes: tuple[_CompiledDecoratorNestedFamily, ...]
     label: str
     parent: _DecoratorRouteSelection | None = None
@@ -48,9 +59,15 @@ def _select_decorator_routes(
     source_version: _CompiledVersion | None,
     location_prefix: tuple[str | int, ...] = (),
     parent_selection: _DecoratorRouteSelection | None = None,
+    _union_arm_cache: _DecoratorUnionArmCache | None = None,
+    _route_group_cache: _DecoratorRouteGroupCache | None = None,
 ) -> tuple[_DecoratorRouteSelection, ...]:
     if not compiled.decorator_nested:
         return ()
+    if _union_arm_cache is None:
+        _union_arm_cache = {}
+    if _route_group_cache is None:
+        _route_group_cache = {}
     root_names = {
         route.path[0]: (
             route.path[0]
@@ -60,6 +77,10 @@ def _select_decorator_routes(
         for route in compiled.decorator_nested
     }
     selected: list[_DecoratorRouteSelection] = []
+    route_groups = _decorator_route_groups(
+        compiled,
+        cache=_route_group_cache,
+    )
     for route in compiled.decorator_nested:
         if root_names[route.path[0]] is None:
             continue
@@ -68,19 +89,15 @@ def _select_decorator_routes(
             annotation=type(value),
             route=route,
             root_names=root_names,
+            union_arm_cache=_union_arm_cache,
         ):
             expected = (route.family.model, route.family.model_for(parent_label))
             if isinstance(nested_value, expected):
-                site = _decorator_dispatch_site(route)
                 selection = _DecoratorRouteSelection(
                     route=route,
                     location=(*location_prefix, *location),
                     relative_location=location,
-                    site_routes=tuple(
-                        candidate
-                        for candidate in compiled.decorator_nested
-                        if _decorator_dispatch_site(candidate) == site
-                    ),
+                    site_routes=route_groups[_decorator_dispatch_site(route)],
                     label=route.child_label(parent_label),
                     parent=parent_selection,
                 )
@@ -99,6 +116,8 @@ def _select_decorator_routes(
                         source_version=child_source,
                         location_prefix=selection.location,
                         parent_selection=selection,
+                        _union_arm_cache=_union_arm_cache,
+                        _route_group_cache=_route_group_cache,
                     )
                 )
     return tuple(selected)
@@ -110,6 +129,7 @@ def _walk_authoritative_decorator_route(
     annotation: Any,
     route: _CompiledDecoratorNestedFamily,
     root_names: Mapping[str, str | None],
+    union_arm_cache: _DecoratorUnionArmCache,
 ) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
     states: list[tuple[Any, Any, tuple[str | int, ...]]] = [(value, annotation, ())]
     for step_index, step in enumerate(route.traversal):
@@ -141,7 +161,13 @@ def _walk_authoritative_decorator_route(
                 ordinal = int(step.value)
                 if ordinal >= len(arguments):
                     continue
-                selected = _matching_declared_annotation(normalized_annotation, current)
+                cache_key = (id(normalized_annotation), id(current))
+                if cache_key not in union_arm_cache:
+                    union_arm_cache[cache_key] = _matching_declared_annotation(
+                        normalized_annotation,
+                        current,
+                    )
+                selected = union_arm_cache[cache_key]
                 candidate = _strip_annotated(arguments[ordinal])
                 if _strip_annotated(selected) != candidate:
                     continue
@@ -461,11 +487,34 @@ def _decorator_selections_parent_first(
 
 def _decorator_dispatch_site(
     route: _CompiledDecoratorNestedFamily,
-) -> tuple[tuple[str, str], ...]:
+) -> _DecoratorDispatchSite:
     return tuple(
         (step.kind, "*") if step.kind == "union_arm" else (step.kind, step.value)
         for step in route.traversal
     )
+
+
+def _decorator_route_groups(
+    compiled: _CompiledFamily,
+    *,
+    cache: _DecoratorRouteGroupCache,
+) -> _DecoratorRouteGroups:
+    cache_key = id(compiled)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    mutable_groups: dict[
+        _DecoratorDispatchSite,
+        list[_CompiledDecoratorNestedFamily],
+    ] = {}
+    for route in compiled.decorator_nested:
+        site = _decorator_dispatch_site(route)
+        mutable_groups.setdefault(site, []).append(route)
+
+    groups = {site: tuple(routes) for site, routes in mutable_groups.items()}
+    cache[cache_key] = groups
+    return groups
 
 
 def _walk_decorator_payload_candidates(
@@ -550,7 +599,7 @@ def _reconcile_decorator_selections(
         )
 
     selected_by_site: dict[
-        tuple[int, tuple[tuple[str, str], ...]],
+        tuple[int, _DecoratorDispatchSite],
         list[_DecoratorRouteSelection],
     ] = {}
     for selection in selections:
@@ -590,16 +639,17 @@ def _reconcile_decorator_selections(
                 )
                 raise InvalidMigrationError(msg)
             location_prefix = parent.location
-        candidates = [
+        candidates = tuple(
             (value, (*location_prefix, *relative_location), relative_location)
             for value, relative_location in _walk_decorator_payload_candidates(
                 base_payload,
                 declarations[0],
             )
-        ]
+        )
+        candidate_identities = tuple(id(value) for value, _, _ in candidates)
         if any(
-            id(value) in identity_sites and identity_sites[id(value)] != site_key
-            for value, _, _ in candidates
+            identity in identity_sites and identity_sites[identity] != site_key
+            for identity in candidate_identities
         ):
             msg = (
                 "Parent migration moved a decorator nested occurrence across dispatch "
@@ -613,44 +663,78 @@ def _reconcile_decorator_selections(
             )
             raise InvalidMigrationError(msg)
 
-        remaining_candidates = list(enumerate(candidates))
-        remaining_previous = list(previous)
+        candidate_indexes_by_identity: dict[int, list[int]] = {}
+        for candidate_index, identity in enumerate(candidate_identities):
+            candidate_indexes_by_identity.setdefault(identity, []).append(candidate_index)
+        claimed_candidate_indexes: set[int] = set()
+        available_previous_indexes = set(range(len(previous)))
 
         # Object identity is the authoritative occurrence token. It permits a
         # heterogeneous list to reorder without rediscovering its union branch.
-        for selection in tuple(remaining_previous):
-            if selection.value_identity is None:
+        for previous_index, selection in enumerate(previous):
+            identity = selection.value_identity
+            if identity is None:
                 continue
-            matches = [
-                (index, candidate)
-                for index, candidate in remaining_candidates
-                if id(candidate[0]) == selection.value_identity
-            ]
-            if len(matches) > 1:
+            candidate_indexes = candidate_indexes_by_identity.get(identity, ())
+            if len(candidate_indexes) > 1:
                 msg = (
                     "Parent migration reused one decorator nested occurrence at "
                     f"path {selection.route.path!r}"
                 )
                 raise InvalidMigrationError(msg)
-            if not matches:
+            if not candidate_indexes:
                 continue
-            candidate_index, (value, location, relative_location) = matches[0]
+            candidate_index = candidate_indexes[0]
+            if candidate_index in claimed_candidate_indexes:
+                continue
+            value, location, relative_location = candidates[candidate_index]
             selection.location = location
             selection.relative_location = relative_location
-            selection.value_identity = id(value)
-            remaining_previous.remove(selection)
-            remaining_candidates = [
-                item for item in remaining_candidates if item[0] != candidate_index
-            ]
+            selection.value_identity = candidate_identities[candidate_index]
+            available_previous_indexes.remove(previous_index)
+            claimed_candidate_indexes.add(candidate_index)
+
+        previous_indexes_by_location: dict[
+            _DecoratorLocation,
+            deque[int],
+        ] = {}
+        for previous_index in range(len(previous)):
+            if previous_index not in available_previous_indexes:
+                continue
+            selection = previous[previous_index]
+            previous_indexes_by_location.setdefault(
+                selection.location,
+                deque(),
+            ).append(previous_index)
+
+        routes_by_exact_model: dict[
+            type[BaseModel],
+            list[_CompiledDecoratorNestedFamily],
+        ] = {}
+        for declaration in declarations:
+            routes_by_exact_model.setdefault(
+                declaration.family.model,
+                [],
+            ).append(declaration)
 
         # An exact current-model instance is an explicit, authoritative branch
         # replacement and may establish a new route without validation.
-        for candidate_index, (value, location, relative_location) in tuple(remaining_candidates):
-            if not remaining_previous:
+        remaining_candidates: list[_DecoratorCandidate] = []
+        fallback_previous_index = 0
+        for candidate_index, (value, location, relative_location) in enumerate(candidates):
+            if candidate_index in claimed_candidate_indexes:
+                continue
+            if not available_previous_indexes:
+                remaining_candidates.extend(
+                    candidates[index]
+                    for index in range(candidate_index, len(candidates))
+                    if index not in claimed_candidate_indexes
+                )
                 break
             if not isinstance(value, BaseModel):
+                remaining_candidates.append((value, location, relative_location))
                 continue
-            matching = tuple(route for route in declarations if type(value) is route.family.model)
+            matching = routes_by_exact_model.get(type(value), ())
             if len(matching) != 1:
                 msg = (
                     "Parent migration supplied a typed decorator nested replacement "
@@ -658,26 +742,36 @@ def _reconcile_decorator_selections(
                 )
                 raise InvalidMigrationError(msg)
             route = matching[0]
-            replaced = next(
-                (selection for selection in remaining_previous if selection.location == location),
-                remaining_previous[0],
-            )
+            location_indexes = previous_indexes_by_location.get(location)
+            while location_indexes and location_indexes[0] not in available_previous_indexes:
+                location_indexes.popleft()
+            if location_indexes:
+                previous_index = location_indexes.popleft()
+            else:
+                while fallback_previous_index not in available_previous_indexes:
+                    fallback_previous_index += 1
+                previous_index = fallback_previous_index
+                fallback_previous_index += 1
+            available_previous_indexes.remove(previous_index)
+            replaced = previous[previous_index]
             replaced.route = route
             replaced.location = location
             replaced.relative_location = relative_location
             replaced.label = route.family.current_version
             replaced.value_identity = id(value)
             replaced_owner_ids.add(id(replaced))
-            remaining_previous.remove(replaced)
-            remaining_candidates = [
-                item for item in remaining_candidates if item[0] != candidate_index
-            ]
+            claimed_candidate_indexes.add(candidate_index)
+
+        remaining_previous = [
+            selection
+            for previous_index, selection in enumerate(previous)
+            if previous_index in available_previous_indexes
+        ]
 
         if not remaining_previous:
             if remaining_candidates and not all(
-                len(tuple(route for route in declarations if type(value) is route.family.model))
-                == 1
-                for _, (value, _, _) in remaining_candidates
+                len(routes_by_exact_model.get(type(value), ())) == 1
+                for value, _, _ in remaining_candidates
             ):
                 msg = (
                     "Parent migration changed decorator nested occurrence cardinality at "
@@ -692,9 +786,9 @@ def _reconcile_decorator_selections(
         if all(_route_has_mapping_anchor(selection.route) for selection in remaining_previous):
             anchored = {selection.location: selection for selection in remaining_previous}
             if len(anchored) == len(remaining_previous) and all(
-                location in anchored for _, (_, location, _) in remaining_candidates
+                location in anchored for _, location, _ in remaining_candidates
             ):
-                for _, (value, location, relative_location) in remaining_candidates:
+                for value, location, relative_location in remaining_candidates:
                     selection = anchored[location]
                     selection.relative_location = relative_location
                     selection.value_identity = id(value)
@@ -710,7 +804,7 @@ def _reconcile_decorator_selections(
                     "one-to-one"
                 )
                 raise InvalidMigrationError(msg)
-            for selection, (_, (value, location, relative_location)) in zip(
+            for selection, (value, location, relative_location) in zip(
                 remaining_previous,
                 remaining_candidates,
                 strict=True,
@@ -781,6 +875,16 @@ def _discover_typed_decorator_selections(
     selections: tuple[_DecoratorRouteSelection, ...],
 ) -> tuple[_DecoratorRouteSelection, ...]:
     discovered = list(selections)
+    occupied_locations = {(id(selection.parent), selection.location) for selection in selections}
+    locations_by_identity: dict[int, set[tuple[str | int, ...]]] = {}
+    children_by_parent: dict[int, list[_DecoratorRouteSelection]] = {}
+    for selection in selections:
+        children_by_parent.setdefault(id(selection.parent), []).append(selection)
+        if selection.value_identity is not None:
+            locations_by_identity.setdefault(selection.value_identity, set()).add(
+                selection.location
+            )
+    route_group_cache: _DecoratorRouteGroupCache = {}
 
     def visit_owner(
         owner_payload: Any,
@@ -789,28 +893,29 @@ def _discover_typed_decorator_selections(
         location_prefix: tuple[str | int, ...],
         parent: _DecoratorRouteSelection | None,
     ) -> None:
-        sites: dict[
-            tuple[tuple[str, str], ...],
-            list[_CompiledDecoratorNestedFamily],
-        ] = {}
-        for route in owner_compiled.decorator_nested:
-            sites.setdefault(_decorator_dispatch_site(route), []).append(route)
-
-        for routes in sites.values():
-            declarations = tuple(routes)
+        parent_identity = id(parent)
+        route_groups = _decorator_route_groups(
+            owner_compiled,
+            cache=route_group_cache,
+        )
+        for declarations in route_groups.values():
+            routes_by_exact_model: dict[
+                type[BaseModel],
+                list[_CompiledDecoratorNestedFamily],
+            ] = {}
+            for declaration in declarations:
+                routes_by_exact_model.setdefault(
+                    declaration.family.model,
+                    [],
+                ).append(declaration)
             for value, relative_location in _walk_decorator_payload_candidates(
                 owner_payload,
                 declarations[0],
             ):
                 location = (*location_prefix, *relative_location)
-                if any(
-                    selection.parent is parent and selection.location == location
-                    for selection in discovered
-                ):
+                if (parent_identity, location) in occupied_locations:
                     continue
-                matches = tuple(
-                    route for route in declarations if type(value) is route.family.model
-                )
+                matches = routes_by_exact_model.get(type(value), ())
                 if len(matches) != 1:
                     if isinstance(value, Mapping) and not _route_has_non_child_mapping_arm(
                         owner_compiled.model,
@@ -824,28 +929,31 @@ def _discover_typed_decorator_selections(
                         raise InvalidMigrationError(msg)
                     continue
                 route = matches[0]
-                if any(
-                    selection.value_identity == id(value) and selection.location != location
-                    for selection in discovered
+                value_identity = id(value)
+                existing_locations = locations_by_identity.get(value_identity)
+                if existing_locations is not None and (
+                    len(existing_locations) != 1 or location not in existing_locations
                 ):
                     msg = (
                         "Parent migration reused one decorator nested occurrence at "
                         f"path {route.path!r}"
                     )
                     raise InvalidMigrationError(msg)
-                discovered.append(
-                    _DecoratorRouteSelection(
-                        route=route,
-                        location=location,
-                        relative_location=relative_location,
-                        site_routes=declarations,
-                        label=route.family.current_version,
-                        parent=parent,
-                        value_identity=id(value),
-                    )
+                selection = _DecoratorRouteSelection(
+                    route=route,
+                    location=location,
+                    relative_location=relative_location,
+                    site_routes=declarations,
+                    label=route.family.current_version,
+                    parent=parent,
+                    value_identity=value_identity,
                 )
+                discovered.append(selection)
+                occupied_locations.add((parent_identity, location))
+                locations_by_identity.setdefault(value_identity, set()).add(location)
+                children_by_parent.setdefault(parent_identity, []).append(selection)
 
-        children = tuple(selection for selection in discovered if selection.parent is parent)
+        children = tuple(children_by_parent.get(parent_identity, ()))
         for child in children:
             found, child_payload = _payload_at_location(payload, child.location)
             if not found:

--- a/src/pydantic_versions/_runtime_nested.py
+++ b/src/pydantic_versions/_runtime_nested.py
@@ -652,8 +652,10 @@ def _nested_family_collection_kind(
 
 def _has_duplicate_payload(payload: list[Any]) -> bool:
     for index, item in enumerate(payload):
-        if item in payload[:index]:
-            return True
+        for previous_index in range(index):
+            previous = payload[previous_index]
+            if previous is item or previous == item:
+                return True
     return False
 
 

--- a/src/pydantic_versions/_runtime_payload.py
+++ b/src/pydantic_versions/_runtime_payload.py
@@ -174,8 +174,17 @@ def _is_runtime_base_model_type(annotation: Any) -> bool:
 
 
 def _runtime_value_matches_annotation(value: Any, annotation: Any) -> bool:
+    supertype = getattr(annotation, "__supertype__", None)
+    if (
+        isinstance(annotation, type)
+        and type(value) is annotation
+        and (supertype is None or supertype is annotation)
+    ):
+        return True
     normalized = _runtime_annotation_value(annotation)
     if normalized is Any:
+        return True
+    if isinstance(normalized, type) and type(value) is normalized:
         return True
     if isinstance(normalized, TypeVar):
         candidates = _runtime_type_parameter_values(normalized)
@@ -627,6 +636,15 @@ def _field_crosses_wire_boundary(field_info: Any) -> bool:
 
 
 def _jsonable_declared_scalar(value: Any, *, config: Mapping[str, Any]) -> Any:
+    value_type = type(value)
+    if (
+        value_type is NoneType
+        or value_type is bool
+        or value_type is int
+        or value_type is float
+        or value_type is str
+    ):
+        return value
     try:
         if isinstance(value, bytes):
             return to_jsonable_python(

--- a/tests/unit/test_decorator_runtime_benchmark.py
+++ b/tests/unit/test_decorator_runtime_benchmark.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchmarks.decorator_runtime import REPORT_SCHEMA, run_benchmarks
+
+
+def test_decorator_runtime_benchmark_proves_correctness_without_speed_thresholds() -> None:
+    source_root = Path(__file__).resolve().parents[2] / "src"
+    report = run_benchmarks(
+        counts=(7,),
+        union_routes=4,
+        union_values_per_route=2,
+        repeats=1,
+        warmups=0,
+        label="unit-test",
+        source_root=source_root,
+    )
+
+    assert report["benchmark_schema"] == REPORT_SCHEMA
+    assert report["configuration"] == {
+        "counts": [7],
+        "repeats": 1,
+        "union_routes": 4,
+        "union_values_per_route": 2,
+        "warmups": 0,
+    }
+    assert [result["case"] for result in report["results"]] == [
+        "reconcile_reordered_occurrences",
+        "select_multi_route_union",
+    ]
+    assert report["results"][0]["correctness"] == {
+        "locations": 7,
+        "payload_first": 6,
+        "payload_last": 0,
+        "unique_value_identities": 7,
+    }
+    assert report["results"][1]["correctness"] == {
+        "locations": 8,
+        "selected_families": 4,
+        "site_routes": 4,
+    }
+    assert len(report["results"][0]["samples_ns"]) == 1
+    assert len(report["results"][1]["samples_ns"]) == 1
+    assert json.loads(json.dumps(report)) == report

--- a/tests/unit/test_decorator_runtime_indexes.py
+++ b/tests/unit/test_decorator_runtime_indexes.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import builtins
+from typing import Any, ClassVar
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_versions import _runtime_decorators as runtime_decorators
+from pydantic_versions import versioned_schema
+from pydantic_versions.family import _family_for
+
+
+@versioned_schema(name="runtime_index_child_a", versions=("1",), current="1")
+class _IndexedChildA(BaseModel):
+    value: int
+
+
+@versioned_schema(name="runtime_index_child_b", versions=("1",), current="1")
+class _IndexedChildB(BaseModel):
+    value: int
+
+
+@versioned_schema(name="runtime_index_union_parent", versions=("1",), current="1")
+class _IndexedUnionParent(BaseModel):
+    items: list[_IndexedChildA | _IndexedChildB]
+
+
+@versioned_schema(name="runtime_index_parent", versions=("1",), current="1")
+class _IndexedParent(BaseModel):
+    items: list[_IndexedChildA]
+
+
+@versioned_schema(name="runtime_index_mapping_parent", versions=("1",), current="1")
+class _IndexedMappingParent(BaseModel):
+    items: dict[str, _IndexedChildA]
+
+
+class _TrackedLocationPart(str):
+    comparisons: ClassVar[int] = 0
+
+    def __eq__(self, other: object) -> bool:
+        type(self).comparisons += 1
+        return super().__eq__(other)
+
+    __hash__ = str.__hash__
+
+
+def test_selection_resolves_each_union_value_once_and_shares_site_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiled = _family_for(_IndexedUnionParent)._compiled_family()
+    values = [
+        _IndexedChildA(value=1),
+        _IndexedChildB(value=2),
+        _IndexedChildA(value=3),
+        _IndexedChildB(value=4),
+    ]
+    original_matcher = runtime_decorators._matching_declared_annotation
+    matcher_calls = 0
+
+    def counted_matcher(annotation: Any, value: Any) -> Any:
+        nonlocal matcher_calls
+        matcher_calls += 1
+        return original_matcher(annotation, value)
+
+    monkeypatch.setattr(
+        runtime_decorators,
+        "_matching_declared_annotation",
+        counted_matcher,
+    )
+    selections = runtime_decorators._select_decorator_routes(
+        _IndexedUnionParent(items=values),
+        compiled=compiled,
+        parent_label="1",
+        source_version=None,
+    )
+
+    assert matcher_calls == len(values)
+    assert {selection.location for selection in selections} == {
+        ("items", index) for index in range(len(values))
+    }
+    shared_routes = selections[0].site_routes
+    assert len(shared_routes) == 2
+    assert all(selection.site_routes is shared_routes for selection in selections)
+
+
+def test_reconciliation_identity_lookups_scale_linearly_for_reorders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiled = _family_for(_IndexedParent)._compiled_family()
+    identity_count = 64
+    items = [_IndexedChildA(value=index) for index in range(identity_count)]
+    selections = runtime_decorators._select_decorator_routes(
+        _IndexedParent(items=items),
+        compiled=compiled,
+        parent_label="1",
+        source_version=None,
+    )
+    runtime_decorators._refresh_decorator_selection_identities(
+        {"items": items},
+        selections,
+    )
+    identity_calls = 0
+
+    def counted_identity(value: object) -> int:
+        nonlocal identity_calls
+        identity_calls += 1
+        return builtins.id(value)
+
+    payload: dict[str, Any] = {"items": list(reversed(items))}
+    with monkeypatch.context() as context:
+        context.setattr(runtime_decorators, "id", counted_identity, raising=False)
+        reconciled = runtime_decorators._reconcile_decorator_selections(
+            payload=payload,
+            selections=selections,
+            compiled=compiled,
+            discover_new=True,
+        )
+
+    assert [selection.location[-1] for selection in reconciled] == list(
+        reversed(range(identity_count))
+    )
+    assert identity_calls <= 7 * identity_count
+
+
+def test_typed_replacements_use_location_indexes_and_preserve_anchors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compiled = _family_for(_IndexedParent)._compiled_family()
+    replacement_count = 64
+    original = [_IndexedChildA(value=index) for index in range(replacement_count)]
+    selections = runtime_decorators._select_decorator_routes(
+        _IndexedParent(items=original),
+        compiled=compiled,
+        parent_label="1",
+        source_version=None,
+    )
+    for index, selection in enumerate(selections):
+        location = (_TrackedLocationPart("items"), index)
+        selection.location = location
+        selection.relative_location = location
+        selection.value_identity = builtins.id(original[index])
+
+    replacements = [_IndexedChildA(value=1_000 + index) for index in range(replacement_count)]
+    candidates = tuple(
+        (replacements[index], (_TrackedLocationPart("items"), index))
+        for index in reversed(range(replacement_count))
+    )
+
+    def walk_candidates(
+        payload: Any,
+        route: Any,
+    ) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
+        del payload, route
+        return candidates
+
+    _TrackedLocationPart.comparisons = 0
+    with monkeypatch.context() as context:
+        context.setattr(
+            runtime_decorators,
+            "_walk_decorator_payload_candidates",
+            walk_candidates,
+        )
+        reconciled = runtime_decorators._reconcile_decorator_selections(
+            payload={"items": replacements},
+            selections=selections,
+            compiled=compiled,
+            discover_new=True,
+        )
+
+    assert [selection.location[-1] for selection in reconciled] == list(range(replacement_count))
+    assert [selection.value_identity for selection in reconciled] == [
+        builtins.id(value) for value in replacements
+    ]
+    assert _TrackedLocationPart.comparisons <= 4 * replacement_count
+
+
+def test_typed_mapping_replacements_preserve_location_and_fallback_order() -> None:
+    compiled = _family_for(_IndexedMappingParent)._compiled_family()
+    original = {key: _IndexedChildA(value=index) for index, key in enumerate(("a", "b", "c", "d"))}
+    selections = runtime_decorators._select_decorator_routes(
+        _IndexedMappingParent(items=original),
+        compiled=compiled,
+        parent_label="1",
+        source_version=None,
+    )
+    runtime_decorators._refresh_decorator_selection_identities(
+        {"items": original},
+        selections,
+    )
+    replacements = {
+        key: _IndexedChildA(value=1_000 + index) for index, key in enumerate(("a", "x", "b", "y"))
+    }
+    payload: dict[str, Any] = {"items": replacements}
+
+    reconciled = runtime_decorators._reconcile_decorator_selections(
+        payload=payload,
+        selections=selections,
+        compiled=compiled,
+        discover_new=True,
+    )
+
+    expected_locations = [("items", key) for key in replacements]
+    assert [selection.location for selection in reconciled] == expected_locations
+    assert [selection.value_identity for selection in reconciled] == [
+        id(replacements[key]) for key in replacements
+    ]

--- a/tests/unit/test_runtime_fast_paths.py
+++ b/tests/unit/test_runtime_fast_paths.py
@@ -1,0 +1,237 @@
+"""Behavior and mechanism coverage for bounded runtime fast paths."""
+
+from __future__ import annotations
+
+import datetime as dt
+from enum import Enum
+from typing import Annotated, Any, NewType
+from uuid import UUID
+
+import pytest
+from pydantic import BaseModel
+from pydantic_core import to_jsonable_python as core_to_jsonable_python
+
+import pydantic_versions._runtime as runtime
+import pydantic_versions._runtime_nested as runtime_nested
+import pydantic_versions._runtime_payload as runtime_payload
+from pydantic_versions import SchemaFamily, SchemaVersion
+
+
+def test_empty_decorator_selection_skips_declared_tree_extraction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Source(BaseModel):
+        value: int
+
+    family = SchemaFamily(
+        model=Source,
+        name="runtime_fast_path_empty_selection",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    compiled = family._compiled_family()
+    source = Source(value=1)
+
+    def unexpected_extraction(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("empty selections must not extract the source tree")
+
+    monkeypatch.setattr(runtime, "_extract_declared_fields", unexpected_extraction)
+
+    runtime._prune_serialized_decorator_metadata(
+        dumped={},
+        source_model=source,
+        compiled=compiled,
+        parent_label="1",
+        selections=(),
+        by_alias=False,
+    )
+
+
+def test_exact_class_annotation_skips_annotation_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Ordinary:
+        pass
+
+    value = Ordinary()
+
+    def unexpected_normalization(_annotation: Any) -> Any:
+        raise AssertionError("exact class matches must not normalize the annotation")
+
+    monkeypatch.setattr(
+        runtime_payload,
+        "_runtime_annotation_value",
+        unexpected_normalization,
+    )
+
+    assert runtime_payload._runtime_value_matches_annotation(value, Ordinary)
+
+
+def test_class_annotation_subclass_retains_runtime_instance_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Ordinary:
+        pass
+
+    class Specialized(Ordinary):
+        pass
+
+    calls: list[tuple[Any, Any]] = []
+    normalized: list[Any] = []
+    real_probe = runtime_payload._safe_annotation_instance
+    real_normalization = runtime_payload._runtime_annotation_value
+
+    def tracking_probe(value: Any, annotation: Any) -> bool:
+        calls.append((value, annotation))
+        return real_probe(value, annotation)
+
+    def tracking_normalization(annotation: Any) -> Any:
+        normalized.append(annotation)
+        return real_normalization(annotation)
+
+    value = Specialized()
+    monkeypatch.setattr(runtime_payload, "_safe_annotation_instance", tracking_probe)
+    monkeypatch.setattr(
+        runtime_payload,
+        "_runtime_annotation_value",
+        tracking_normalization,
+    )
+
+    assert runtime_payload._runtime_value_matches_annotation(value, Ordinary)
+    assert calls == [(value, Ordinary)]
+    assert normalized == [Ordinary]
+
+
+def test_class_with_a_supertype_retains_annotation_normalization() -> None:
+    class SupertypeCarrier:
+        __supertype__ = int
+
+    assert not runtime_payload._runtime_value_matches_annotation(
+        SupertypeCarrier(),
+        SupertypeCarrier,
+    )
+
+
+def test_aliases_and_new_types_retain_annotation_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Ordinary:
+        pass
+
+    type alias = Ordinary
+    new_type = NewType("new_type", Ordinary)
+    annotated = Annotated[Ordinary, "metadata"]
+    normalized: list[Any] = []
+    real_normalization = runtime_payload._runtime_annotation_value
+
+    def tracking_normalization(annotation: Any) -> Any:
+        normalized.append(annotation)
+        return real_normalization(annotation)
+
+    monkeypatch.setattr(
+        runtime_payload,
+        "_runtime_annotation_value",
+        tracking_normalization,
+    )
+    value = Ordinary()
+
+    assert runtime_payload._runtime_value_matches_annotation(value, alias)
+    assert runtime_payload._runtime_value_matches_annotation(value, new_type)
+    assert runtime_payload._runtime_value_matches_annotation(value, annotated)
+    assert normalized == [alias, new_type, annotated]
+
+
+def test_exact_json_scalars_skip_general_conversion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_conversion(_value: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("exact JSON-native scalars must not enter pydantic-core")
+
+    monkeypatch.setattr(runtime_payload, "to_jsonable_python", unexpected_conversion)
+
+    values = (None, False, True, 0, 1, -1, 1.5, "payload")
+    assert (
+        tuple(runtime_payload._jsonable_declared_scalar(value, config={}) for value in values)
+        == values
+    )
+
+
+def test_non_exact_json_scalars_retain_general_conversion_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Text(str):
+        pass
+
+    class Mode(Enum):
+        READY = "ready"
+
+    class Opaque:
+        pass
+
+    calls: list[Any] = []
+
+    def tracking_conversion(value: Any, **kwargs: Any) -> Any:
+        calls.append(value)
+        return core_to_jsonable_python(value, **kwargs)
+
+    monkeypatch.setattr(runtime_payload, "to_jsonable_python", tracking_conversion)
+
+    opaque = Opaque()
+    values = (
+        Text("text"),
+        b"bytes",
+        dt.datetime(2020, 1, 2, 3, 4, 5, tzinfo=dt.UTC),
+        dt.date(2020, 1, 2),
+        dt.time(3, 4, 5),
+        dt.timedelta(seconds=1.5),
+        Mode.READY,
+        UUID("12345678-1234-5678-1234-567812345678"),
+        opaque,
+    )
+    converted = tuple(
+        runtime_payload._jsonable_declared_scalar(value, config={}) for value in values
+    )
+
+    assert calls == list(values)
+    assert converted == (
+        "text",
+        "bytes",
+        "2020-01-02T03:04:05Z",
+        "2020-01-02",
+        "03:04:05",
+        "PT1.5S",
+        "ready",
+        "12345678-1234-5678-1234-567812345678",
+        opaque,
+    )
+
+
+def test_duplicate_payload_detection_does_not_slice() -> None:
+    class NoSliceList(list[Any]):
+        def __getitem__(self, key: Any) -> Any:
+            if isinstance(key, slice):
+                raise AssertionError("duplicate detection must not allocate a prefix slice")
+            return super().__getitem__(key)
+
+    assert runtime_nested._has_duplicate_payload(NoSliceList([{"value": 1}, {"value": 1}]))
+
+
+def test_duplicate_payload_detection_preserves_membership_equality_semantics() -> None:
+    class Earlier:
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, Later)
+
+    class Later:
+        def __eq__(self, _other: object) -> bool:
+            return False
+
+    class NeverEqual:
+        def __eq__(self, _other: object) -> bool:
+            return False
+
+    repeated = NeverEqual()
+
+    assert runtime_nested._has_duplicate_payload([Earlier(), Later()])
+    assert not runtime_nested._has_duplicate_payload([Later(), Earlier()])
+    assert runtime_nested._has_duplicate_payload([repeated, repeated])
+    assert not runtime_nested._has_duplicate_payload([[1], [2]])


### PR DESCRIPTION
## Summary

- Index decorator union selection, route grouping, reconciliation, and typed discovery so repeated work scales with the visited occurrences instead of rescanning whole collections.
- Add bounded fast paths for empty decorator metadata, exact runtime annotations, JSON-native scalars, and duplicate detection without prefix slices.
- Add a reproducible JSON benchmark and mechanism-specific regressions for the optimized paths.

## Compatibility

- All caches are call-local; no public API or retained cross-call state changes.
- Callback order, route order, occurrence identity, mapping anchors, typed replacement fallback, cardinality errors, recursive discovery, and asymmetric equality behavior remain unchanged.
- The immutable v0.3.0 contract remains green. `Field(exclude=True)` and false-returning `exclude_if` fields remain app-visible where appropriate but structurally absent from every generated wire projection.
- Independent semantic review found a custom `__supertype__` normalization regression before commit; the guard and regression test now match `origin/main`.

## Performance evidence

Paired seven-sample medians used clean candidate `1af311a` and clean baseline `228d4b2` in the same Python and Pydantic environment:

| Case | Baseline | Candidate | Speedup |
| --- | ---: | ---: | ---: |
| 100 reordered occurrences | 1.648 ms | 0.539 ms | 3.06x |
| 500 reordered occurrences | 30.435 ms | 2.582 ms | 11.79x |
| 1,000 reordered occurrences | 124.417 ms | 5.178 ms | 24.03x |
| 16 routes / 128 union values | 146.476 ms | 10.166 ms | 14.41x |

A separate 4/8/16-route series improved each point by 1.63x, 6.36x, and 6.76x. The benchmark verifies identities, locations, families, and route cardinality, emits raw samples, and deliberately sets no timing threshold in CI.

## Validation

- `uv run make ci`: 887 tests passed with 95.93% coverage on Pydantic 2.13.4.
- Isolated Python 3.12.12 / Pydantic 2.12.3 run: 887 tests passed with 95.84% coverage.
- Added-line coverage: 122/122 executable source lines covered.
- `uv run make docs-build-strict`: passed.
- `uv run python tests/compatibility/v0_3_0_contract.py --check`: passed.
- `uv build`: source distribution and wheel built.
- Three independent algorithm, semantic, and test/benchmark reviews found no remaining blockers.

Closes #100