### PR TITLE
test(release): honor installed benchmark package

### DIFF
--- a/tests/unit/test_decorator_runtime_benchmark.py
+++ b/tests/unit/test_decorator_runtime_benchmark.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pydantic_versions
 from benchmarks.decorator_runtime import REPORT_SCHEMA, run_benchmarks
 
 
 def test_decorator_runtime_benchmark_proves_correctness_without_speed_thresholds() -> None:
-    source_root = Path(__file__).resolve().parents[2] / "src"
+    assert pydantic_versions.__file__ is not None
+    package_file = Path(pydantic_versions.__file__).resolve()
+    source_root = package_file.parent.parent
     report = run_benchmarks(
         counts=(7,),
         union_routes=4,
@@ -19,6 +22,8 @@ def test_decorator_runtime_benchmark_proves_correctness_without_speed_thresholds
     )
 
     assert report["benchmark_schema"] == REPORT_SCHEMA
+    assert report["environment"]["pydantic_versions_module"] == str(package_file)
+    assert report["environment"]["source_root"] == str(source_root)
     assert report["configuration"] == {
         "counts": [7],
         "repeats": 1,


### PR DESCRIPTION
## Summary

- derive the benchmark source root from the active installed `pydantic_versions` package
- assert the benchmark report records the same package module and source roots

## Release impact

The nonpublishing release rehearsal failed because the test assumed a checkout `src` directory while the workflow correctly imported a noneditable installation. This keeps the benchmark checks strict in editable and installed-package contexts without changing runtime code, benchmark behavior, release workflow, or package metadata.

Failed rehearsal: https://github.com/dariuszpanas/pydantic-versions/actions/runs/32658733204

## Validation

- `uv run make ci`: 887 tests passed; 95.93% coverage
- full noneditable release-quality sequence: 887 tests passed; 95.93% coverage
- Python 3.12.12 with exact Pydantic 2.12.3: focused regression passed
- `uv run make docs-build-strict`: passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check`: passed
- `uv build`: source distribution and wheel built

Closes #133