### PR TITLE
docs(api): complete stable reference coverage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dynamic Pydantic hooks and externally consumed public methods.
 
 ### Changed
+- Improved decorator-heavy nested migration scaling with call-local route
+  selection and reconciliation indexes while preserving callback order and
+  wire behavior; added a reproducible, correctness-checked benchmark without a
+  CI timing threshold.
 - Raised the enforced statement-coverage floor from 90% to 95% and report the
   measured result to two decimal places.
 - Replaced the broad private-helper coverage scaffold with cohesive public

--- a/docs/guide/adoption-guidance.md
+++ b/docs/guide/adoption-guidance.md
@@ -40,13 +40,10 @@ Patches are best when the historical payload can still be expressed as a
 generated Pydantic model.
 
 ```python
-@schema_version(
-    "1",
-    patches=[
-        field_default("timeout", 5.0),
-        field_removed("new_feature"),
-        field_renamed("retries", "attempts"),
-    ],
+V1_PATCHES = (
+    field_default("timeout", 5.0),
+    field_removed("new_feature"),
+    field_renamed("retries", "attempts"),
 )
 ```
 
@@ -166,17 +163,32 @@ timeout: 10
 
 Use `apiVersion` for CRD-like resources:
 
+<!-- pv-doc-test: adoption-version-fields -->
 ```python
+from pydantic import BaseModel
+from pydantic_versions import validate_versioned, versioned_schema
+
+
 @versioned_schema(
     name="resource",
     versions=["example.com/v1", "example.com/v2"],
     current="example.com/v2",
     version_field="apiVersion",
 )
+class Resource(BaseModel):
+    name: str
+
+
+resource = validate_versioned(
+    Resource,
+    {"apiVersion": "example.com/v1", "name": "worker"},
+)
+assert resource.current_model == Resource(name="worker")
 ```
 
 Use a tuple path when the version belongs under metadata:
 
+<!-- pv-doc-test: adoption-version-fields -->
 ```python
 @versioned_schema(
     name="document",
@@ -184,6 +196,15 @@ Use a tuple path when the version belongs under metadata:
     current="2",
     version_field=("metadata", "schema_version"),
 )
+class Document(BaseModel):
+    title: str
+
+
+document = validate_versioned(
+    Document,
+    {"metadata": {"schema_version": "1"}, "title": "Runbook"},
+)
+assert document.current_model == Document(title="Runbook")
 ```
 
 Do not rely on implicit fallback searches across several fields unless the API

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,5 +1,14 @@
 # API Reference
 
+## Package metadata
+
+### `__version__`
+
+`__version__: str` reports the version of the installed
+`pydantic-versions` distribution. It is diagnostic library metadata, not an
+application schema label. Use a family's declared version labels and configured
+version metadata for application payloads.
+
 ## External declarations
 
 ### `SchemaFamily`

--- a/tests/integration/test_documentation_examples.py
+++ b/tests/integration/test_documentation_examples.py
@@ -26,6 +26,7 @@ _API_SIGNATURE_BLOCK = re.compile(
     r"```python\n(?P<source>.*?)\n```",
     re.DOTALL,
 )
+_FENCE_OPEN = re.compile(r"^ {0,3}(?P<delimiter>`{3,}|~{3,})(?P<info>.*)$")
 _EXCEPTION_ITEM = re.compile(
     r"^(?P<indent> *)- `(?P<name>[A-Za-z][A-Za-z0-9]*)`$",
     re.MULTILINE,
@@ -36,6 +37,10 @@ _CANONICAL_DOCUMENTS = (
     (Path("docs/guide/getting-started.md"), {"getting-started": 6}),
     (Path("docs/guide/external-families.md"), {"external-families": 6}),
     (Path("docs/guide/rendering.md"), {"rendering": 4}),
+    (
+        Path("docs/guide/adoption-guidance.md"),
+        {"adoption-version-fields": 2},
+    ),
     (
         Path("docs/guide/complex-config-example.md"),
         {"complex-plain": 1, "complex-versioned": 6},
@@ -50,6 +55,49 @@ def _executable_sessions(path: Path) -> dict[str, list[str]]:
     return dict(sessions)
 
 
+def _python_fences(text: str) -> tuple[tuple[int, str], ...]:
+    blocks: list[tuple[int, str]] = []
+    active_delimiter: str | None = None
+    active_language = ""
+    source_line = 0
+    source_lines: list[str] = []
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if active_delimiter is None:
+            match = _FENCE_OPEN.fullmatch(line)
+            if match is None:
+                continue
+            active_delimiter = match.group("delimiter")
+            info = match.group("info").strip()
+            active_language = info.split(maxsplit=1)[0] if info else ""
+            source_line = line_number + 1
+            source_lines = []
+            continue
+
+        stripped = line.lstrip(" ")
+        indentation = len(line) - len(stripped)
+        candidate = stripped.rstrip(" \t")
+        is_closing = (
+            indentation <= 3
+            and len(candidate) >= len(active_delimiter)
+            and set(candidate) == {active_delimiter[0]}
+        )
+        if not is_closing:
+            if active_language == "python":
+                source_lines.append(line)
+            continue
+
+        if active_language == "python":
+            blocks.append((source_line, "\n".join(source_lines)))
+        active_delimiter = None
+        active_language = ""
+        source_lines = []
+
+    if active_delimiter is not None and active_language == "python":
+        raise ValueError(f"unclosed Python fence at line {source_line - 1}")
+    return tuple(blocks)
+
+
 @pytest.mark.parametrize(
     ("relative_path", "expected_counts"),
     _CANONICAL_DOCUMENTS,
@@ -58,6 +106,7 @@ def _executable_sessions(path: Path) -> dict[str, list[str]]:
         "getting-started",
         "external-families",
         "rendering",
+        "adoption-guidance",
         "complex-config",
     ),
 )
@@ -197,6 +246,64 @@ def test_documented_decorator_signatures_match_the_public_api() -> None:
         runtime = getattr(public_api, name)
         assert signature == _runtime_signature_shape(runtime)
         assert return_annotation == _annotation_source(inspect.signature(runtime).return_annotation)
+
+
+def test_documented_package_version_is_a_single_typed_api_entry() -> None:
+    reference = API_REFERENCE.read_text(encoding="utf-8")
+    section = reference.split("## Package metadata", maxsplit=1)[1].split(
+        "\n## ",
+        maxsplit=1,
+    )[0]
+
+    assert section.count("`__version__: str`") == 1
+
+
+def test_python_fence_scanner_handles_rendered_variants() -> None:
+    document = """```text
+```python
+ignored =
+```
+```python title="Example"
+first = 1
+````
+~~~python linenums="1"
+second = 2
+~~~
+"""
+
+    assert _python_fences(document) == (
+        (6, "first = 1"),
+        (9, "second = 2"),
+    )
+    with pytest.raises(ValueError, match="unclosed Python fence at line 1"):
+        _python_fences("~~~python\nvalue = 1")
+
+
+def test_all_rendered_python_fences_are_syntactically_valid() -> None:
+    documents = (
+        REPOSITORY / "README.md",
+        *sorted((REPOSITORY / "docs").rglob("*.md")),
+    )
+    failures: list[str] = []
+    for document in documents:
+        text = document.read_text(encoding="utf-8")
+        relative_path = document.relative_to(REPOSITORY).as_posix()
+        try:
+            blocks = _python_fences(text)
+        except ValueError as exc:
+            failures.append(f"{relative_path}: {exc}")
+            continue
+        for line_number, source in blocks:
+            try:
+                ast.parse(
+                    source,
+                    filename=relative_path,
+                )
+            except SyntaxError as exc:
+                failure_line = line_number + (exc.lineno or 1) - 1
+                failures.append(f"{relative_path}:{failure_line}: {exc.msg}")
+
+    assert not failures, "Invalid Python documentation fences:\n" + "\n".join(failures)
 
 
 def test_documented_exception_hierarchy_matches_the_public_api() -> None:

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
 
 import pydantic_versions
 
 
 def test_package_exports_version() -> None:
-    assert isinstance(pydantic_versions.__version__, str)
+    assert pydantic_versions.__version__ == distribution_version("pydantic-versions")
 
 
 def test_package_version_falls_back_when_distribution_is_missing(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- document public `__version__` as installed distribution metadata rather than an application schema label
- repair the three incomplete adoption-guide snippets and execute both version-field examples as one installed-package session
- parse every rendered Python fence, including supported delimiter and info-string variants, so syntax drift fails with an exact source line
- record the decorator-runtime indexing improvement under `Unreleased / Changed` without a timing SLO

## Boundaries

This changes documentation and documentation/import contract tests only. Runtime code, release metadata, the immutable v0.3.0 fixture, and wire behavior are unchanged. The v0.3.0 exclusion invariant remains explicit: `Field(exclude=True)` and `exclude_if` fields stay absent from generated wire projections.

## Validation

- `uv run make ci`: 891 tests passed; 95.93% coverage
- Python 3.12.12 with exact Pydantic 2.12.3: 13 focused tests passed
- `uv run make docs-build-strict`: passed
- `uv run python tests/compatibility/v0_3_0_contract.py --check`: passed
- `uv build`: source distribution and wheel built
- two independent reviews found no blocker

Closes #135