### PR TITLE
docs(api): complete stable record reference

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forcibly rebuilt after compilation.
 - Kept the repository-root and rendered contributor guides synchronized and
   aligned their type-check instructions with the enforced `ty` and mypy gate.
+- Completed the stable API reference for every exported frozen record and
+  public helper signature, added executable drift checks, and replaced stale
+  pre-1.0 contract wording in the migrations guide.
 - Preserved opaque `Any` values and mapping keys through canonical rendering
   when Pydantic cannot serialize them directly, without recursive fallback.
 - Kept callback-supplied nested wrapper models hashable when projected through

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -229,5 +229,6 @@ must return a dictionary. Returning any other type raises
 `InvalidMigrationError`.
 
 Downgrade declarations and historical rendering across value-changing upgrades
-are executed natively by the 0.2 conversion contract. A missing downgrade across
-a value-changing upgrade makes historical rendering irreversible and raises an error.
+are executed natively by the active conversion contract. A missing downgrade
+across a value-changing upgrade makes historical rendering irreversible and
+raises an error.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -186,13 +186,33 @@ The generated plan inventory and plans are the preferred compatibility artifacts
 
 ### Nested declarations
 
-`NestedFamily`, `MatchingLabels`, and `matching_labels()` are exported as frozen
-declaration types so the final constructor remains stable. These allow complex
-nested schema execution and graph compilation to handle tree-structured data safely.
-An explicit mapping may select child labels independently for historical parent
-versions, but the current parent label must map to the child's current label.
-Compilation rejects a different current mapping because application models hold
-authoritative current child data.
+```python
+@dataclass(frozen=True)
+class MatchingLabels:
+    pass
+
+
+@dataclass(frozen=True)
+class NestedFamily:
+    path: VersionPath
+    family: SchemaFamily[Any] | Callable[[], SchemaFamily[Any]]
+    versions: Mapping[str, str] | MatchingLabels
+```
+
+<!-- pv-api-signature: matching_labels -->
+```python
+def matching_labels() -> MatchingLabels: ...
+```
+
+`NestedFamily` declares the path to a child family and the child label selected
+for each parent label. `family` accepts either the family itself or a
+zero-argument callable that resolves it lazily. An explicit `versions` mapping
+may select child labels independently for historical parent versions;
+`matching_labels()` returns the fieldless `MatchingLabels` sentinel for the
+common case where parent and child labels match exactly. The current parent
+label must map to the child's current label. Compilation rejects a different
+current mapping because application models hold authoritative current child
+data.
 
 ## Compiled inventory and plans
 
@@ -406,15 +426,52 @@ duplicate registrations fail.
 
 ## Patch helpers and records
 
-`field_default(name, default)` or `field_default(name, default_factory=callable)`
+```python
+@dataclass(frozen=True)
+class FieldDefault:
+    name: str
+    default: Any = None
+    default_factory: Callable[[], Any] | None = None
+    has_default: bool = True
+
+
+@dataclass(frozen=True)
+class FieldRemoved:
+    name: str
+
+
+@dataclass(frozen=True)
+class FieldRenamed:
+    current_name: str
+    version_name: str
+```
+
+<!-- pv-api-signature: field_default -->
+```python
+def field_default(
+    name: str,
+    default: Any = ...,
+    *,
+    default_factory: Callable[[], Any] | None = None,
+) -> FieldDefault: ...
+```
 
 Changes a field default for a historical version and returns `FieldDefault`.
+Exactly one of `default` or `default_factory` is required. The ellipsis above
+represents the helper's private missing-value sentinel, not a supported default
+value.
 
-`field_removed(name)`
+<!-- pv-api-signature: field_removed -->
+```python
+def field_removed(name: str) -> FieldRemoved: ...
+```
 
 Removes a field from a historical version and returns `FieldRemoved`.
 
-`field_renamed(current_name, version_name)`
+<!-- pv-api-signature: field_renamed -->
+```python
+def field_renamed(current_name: str, version_name: str) -> FieldRenamed: ...
+```
 
 Uses `version_name` in the historical schema and maps it back to `current_name`
 during upgrade validation. Returns `FieldRenamed`.
@@ -423,17 +480,41 @@ during upgrade validation. Returns `FieldRenamed`.
 
 ## Runtime compatibility helpers
 
-`model_for_version(subject, version)`
+<!-- pv-api-signature: model_for_version -->
+```python
+def model_for_version(
+    subject: type[T] | SchemaFamily[T],
+    version: str,
+) -> type[BaseModel]: ...
+```
 
 Returns the generated object-shaped Pydantic wire contract for a declared
 version. `subject` may be a family or a model with an explicit default family.
 
-`validate_versioned(subject, data, *, version=None)`
+<!-- pv-api-signature: validate_versioned -->
+```python
+def validate_versioned(
+    subject: type[T] | SchemaFamily[T],
+    data: Any,
+    *,
+    version: str | None = None,
+) -> VersionedValidation[T]: ...
+```
 
 Validates `data` against the discovered source version, applies adjacent
 forward upgrades, and validates the current model.
 
-`dump_versioned(subject, *, version, data=None, include_version=True, **dump_kwargs)`
+<!-- pv-api-signature: dump_versioned -->
+```python
+def dump_versioned(
+    subject: type[T] | SchemaFamily[T],
+    *,
+    version: str,
+    data: T | Mapping[str, Any] | None = None,
+    include_version: bool = True,
+    **dump_kwargs: Any,
+) -> dict[str, Any]: ...
+```
 
 With `data=None`, delegates to target-direct `defaults_for()` and does not
 require a render route. With model or mapping data, converts current data using

--- a/tests/integration/test_documentation_examples.py
+++ b/tests/integration/test_documentation_examples.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
+from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -155,10 +156,18 @@ def _runtime_signature_shape(
             name,
             parameter.kind.name,
             _annotation_source(parameter.annotation),
-            None if parameter.default is inspect.Parameter.empty else repr(parameter.default),
+            _runtime_default_source(parameter.default),
         )
         for name, parameter in inspect.signature(callable_).parameters.items()
     )
+
+
+def _runtime_default_source(default: Any) -> str | None:
+    if default is inspect.Parameter.empty:
+        return None
+    if type(default) is object:
+        return "..."
+    return repr(default)
 
 
 def _documented_signature_shape(
@@ -223,13 +232,10 @@ def _documented_signature_shape(
     return function.name, tuple(shape), ast.unparse(function.returns)
 
 
-def test_documented_decorator_signatures_match_the_public_api() -> None:
+def test_every_public_helper_has_one_exact_documented_signature() -> None:
     reference = API_REFERENCE.read_text(encoding="utf-8")
     expected_names = {
-        "migration",
-        "schema_version",
-        "schema_versions",
-        "versioned_schema",
+        name for name in public_api.__all__ if inspect.isfunction(getattr(public_api, name))
     }
     blocks: defaultdict[str, list[str]] = defaultdict(list)
     for match in _API_SIGNATURE_BLOCK.finditer(reference):
@@ -246,6 +252,51 @@ def test_documented_decorator_signatures_match_the_public_api() -> None:
         runtime = getattr(public_api, name)
         assert signature == _runtime_signature_shape(runtime)
         assert return_annotation == _annotation_source(inspect.signature(runtime).return_annotation)
+
+
+def _is_frozen_dataclass_definition(node: ast.ClassDef) -> bool:
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        if not isinstance(decorator.func, ast.Name) or decorator.func.id != "dataclass":
+            continue
+        return any(
+            keyword.arg == "frozen"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in decorator.keywords
+        )
+    return False
+
+
+def test_every_exported_frozen_record_has_one_exact_documented_definition() -> None:
+    reference = API_REFERENCE.read_text(encoding="utf-8")
+    documented: defaultdict[str, list[tuple[str, ...]]] = defaultdict(list)
+    for _, source in _python_fences(reference):
+        for node in ast.parse(source).body:
+            if not isinstance(node, ast.ClassDef) or not _is_frozen_dataclass_definition(node):
+                continue
+            documented[node.name].append(
+                tuple(
+                    statement.target.id
+                    for statement in node.body
+                    if isinstance(statement, ast.AnnAssign)
+                    and isinstance(statement.target, ast.Name)
+                )
+            )
+
+    expected = {
+        name: tuple(field.name for field in fields(record))
+        for name in public_api.__all__
+        if isinstance((record := getattr(public_api, name)), type)
+        and is_dataclass(record)
+        and record.__dataclass_params__.frozen
+    }
+    assert {name: len(definitions) for name, definitions in documented.items()} == dict.fromkeys(
+        expected,
+        1,
+    )
+    assert {name: definitions[0] for name, definitions in documented.items()} == expected
 
 
 def test_documented_package_version_is_a_single_typed_api_entry() -> None:


### PR DESCRIPTION
## Summary

Completes the stable API reference before 1.0 by documenting every exported frozen record and every public helper with an exact checked signature.

- Adds the missing `NestedFamily`, `MatchingLabels`, and patch-record definitions.
- Adds exact signatures for `matching_labels()`, patch helpers, and runtime compatibility helpers.
- Replaces the stale "0.2 conversion contract" wording with version-neutral active-contract language.
- Makes documentation tests compare the rendered record fields and helper signatures against the installed public API.

## Compatibility

This changes documentation and its executable drift checks only. Runtime behavior, the immutable v0.3.0 contract, and the separation of ADRs from rendered docs remain unchanged.

## Validation

- Full CI gate: 921 tests passed at 95.93% coverage; Ruff, ty, strict mypy, and Vulture passed.
- Strict Zensical build passed with no warnings and no rendered ADR matches.
- Immutable v0.3.0 contract and release metadata validation passed.
- Wheel and source distribution builds passed `twine check --strict`.

Closes #141