### PR TITLE
fix(family): make default selection lifecycle-safe

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `InvalidMigrationError`.
 
 ### Fixed
+- Stored deliberate default-family selection on the exact model class instead
+  of in a permanent process-global registry, so dynamic model/family cycles are
+  collectable, subclasses do not inherit defaults, and a rebuilt replacement
+  can atomically take over only after the selected family graph contains an
+  invalid compiled component.
 - Scoped generated set-element models and cached render validators to their
   owning compiled family, preventing temporary families from accumulating in
   process-global caches while preserving stable identities and thread-safe

--- a/docs/guide/external-families.md
+++ b/docs/guide/external-families.md
@@ -122,8 +122,8 @@ INTERNAL_CONFIG = SchemaFamily(
 )
 ```
 
-Constructing either family does not select it globally. A model-only call has no
-basis for choosing and raises `SchemaFamilySelectionError`.
+Constructing either family does not select it for model-only calls. A model-only
+call has no basis for choosing and raises `SchemaFamilySelectionError`.
 
 ## Select one compatibility default deliberately
 
@@ -137,8 +137,19 @@ PUBLIC_CONFIG.as_default()
 
 After that call, `validate_versioned(AppConfig, data)` delegates to
 `PUBLIC_CONFIG`. Repeating `as_default()` on the same family is safe. Selecting a
-different second default raises `SchemaFamilySelectionError` and leaves the
-first selection unchanged.
+different second default while that selection is valid raises
+`SchemaFamilySelectionError` and leaves the first selection unchanged. The
+selection belongs to the exact `AppConfig` class: subclasses neither inherit it
+nor become defaults accidentally. Because the model owns the selection, no
+process-global registry keeps discarded dynamic model and family cycles alive.
+
+A forced `model_rebuild()` after compilation invalidates both the selected
+family and every compiled parent graph that embeds it. Recreate the complete
+affected family graph from the rebuilt models, then call `as_default()` on the
+replacement to atomically redirect model-only calls. Replacement is accepted
+only after a compiled component of the existing family graph has become
+invalid. A graph with no compiled component, or whose compiled components all
+remain valid, cannot be displaced.
 
 The `@versioned_schema` compatibility decorator performs this selection for its
 own family automatically. External family construction never does.

--- a/docs/guide/generated-wire-contracts.md
+++ b/docs/guide/generated-wire-contracts.md
@@ -222,9 +222,11 @@ invalidated transitively because their wire models embed the child projection.
 Discard the affected family graph and recreate its declarations from fully
 rebuilt models. An ordinary no-op `model_rebuild()` remains safe.
 Do not race a forced rebuild with compilation or runtime family operations.
-For decorator-managed default families, redeclare the affected model classes
-and reinitialize the application, or switch callers to a newly constructed
-explicit `SchemaFamily` graph.
+When the invalid graph was selected for model-only calls, call `as_default()` on
+the recreated replacement. The replacement is accepted only because the
+selected family graph contains an invalid compiled component. A graph with no
+compiled component, or whose compiled components all remain valid, still
+rejects a different second default.
 
 An excluded field is also absent from the generated wire model. This is the
 supported way to keep server-internal state on the authoritative model while

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -35,7 +35,8 @@ declaration sequence and has no default-selection side effect.
   `missing_version`: read-only copies of the family declarations.
 - `current_version`: the final declared version label.
 - `compile()`: lazily and atomically compile the immutable family state; returns the family.
-- `as_default()`: deliberately select this family for model-only compatibility calls; returns the family.
+- `as_default()`: deliberately select this family on its exact model class for
+  model-only compatibility calls; returns the family.
 - `describe()`: return the frozen compiled `SchemaInventory`.
 - `plan_validation(source_version)`: return the cached source-to-current `ConversionPlan`.
 - `plan_render(target_version)`: return the cached current-to-target `ConversionPlan`, or raise `IrreversibleTransitionError` if no complete reverse route exists.
@@ -56,9 +57,11 @@ forced `model_rebuild()` after compilation invalidates the compiled family;
 dependent parent families are invalidated transitively. Discard the affected
 family graph and recreate its declarations from fully rebuilt models rather
 than mixing stale projections with replacement Pydantic core schemas.
-Forced rebuilds must not race family operations. A decorator-managed default
-cannot be rebound on the same model class; redeclare and reinitialize those
-models, or use a new explicit family graph.
+Forced rebuilds must not race family operations. Once a compiled component of a
+selected family graph has been invalidated directly or through a nested family,
+calling `as_default()` on its recreated replacement atomically rebinds
+model-only calls. A graph with no compiled component, or whose compiled
+components all remain valid, still rejects a different second default.
 
 ### `SchemaVersion`
 

--- a/src/pydantic_versions/family.py
+++ b/src/pydantic_versions/family.py
@@ -50,7 +50,8 @@ from pydantic_versions.exceptions import (
 )
 from pydantic_versions.inspection import ConversionPlan, SchemaInventory
 
-_DEFAULT_FAMILIES: dict[type[BaseModel], SchemaFamily[Any]] = {}
+_DEFAULT_FAMILY_ATTRIBUTE = "__pydantic_versions_default_family__"
+_DEFAULT_FAMILY_MISSING = object()
 _FAMILY_LOCK = RLock()
 
 
@@ -229,15 +230,17 @@ class SchemaFamily[T: BaseModel]:
 
     def as_default(self) -> Self:
         with _FAMILY_LOCK:
-            existing = _DEFAULT_FAMILIES.get(self.model)
+            existing = _model_owned_default_family(self.model)
             if existing is None:
-                _DEFAULT_FAMILIES[self.model] = self
-            elif existing is not self:
+                setattr(self.model, _DEFAULT_FAMILY_ATTRIBUTE, self)
+            elif existing is not self and not existing._family_graph_was_rebuilt():
                 msg = (
                     f"{self.model.__name__!r} already has explicit default family "
                     f"{existing.name!r}; cannot attach {self.name!r}"
                 )
                 raise SchemaFamilySelectionError(msg)
+            elif existing is not self:
+                setattr(self.model, _DEFAULT_FAMILY_ATTRIBUTE, self)
         return self
 
     def describe(self) -> SchemaInventory:  # noqa: V105 - public consumer API
@@ -349,8 +352,9 @@ class SchemaFamily[T: BaseModel]:
         if self.model.__pydantic_core_schema__ is not compiled._model_core_schema:
             msg = (
                 f"Authoritative model {self.model.__name__!r} for schema family {self.name!r} "
-                "was rebuilt after compilation; discard this family and recreate the "
-                "schema-family declaration from the rebuilt model"
+                "was rebuilt after compilation; discard and recreate every affected "
+                "schema-family declaration, then call as_default() on the replacement "
+                "when model-only helpers use this graph"
             )
             raise SchemaCompilationError(msg)
         for nested in (*compiled.nested, *compiled.decorator_nested):
@@ -362,6 +366,24 @@ class SchemaFamily[T: BaseModel]:
                 child_compiled,
                 visited=checked,
             )
+
+    def _family_graph_was_rebuilt(self, *, visited: set[int] | None = None) -> bool:
+        checked = set() if visited is None else visited
+        if id(self) in checked:
+            return False
+        checked.add(id(self))
+        compiled = self._compiled
+        if compiled is None:
+            return any(
+                child._family_graph_was_rebuilt(visited=checked)
+                for declaration in self.nested
+                if isinstance((child := declaration.family), SchemaFamily)
+            )
+        try:
+            self._ensure_compiled_graph_unchanged(compiled)
+        except SchemaCompilationError:
+            return True
+        return False
 
     def _validate_declarations(self) -> None:
         _validate_family_declarations(
@@ -410,15 +432,30 @@ class SchemaFamily[T: BaseModel]:
                 raise DuplicateSchemaVersionError(msg)
 
 
+def _model_owned_default_family(model: type[BaseModel]) -> SchemaFamily[Any] | None:
+    selected = model.__dict__.get(_DEFAULT_FAMILY_ATTRIBUTE, _DEFAULT_FAMILY_MISSING)
+    if selected is _DEFAULT_FAMILY_MISSING:
+        return None
+    if not isinstance(selected, SchemaFamily) or selected.model is not model:
+        msg = (
+            f"{model.__name__!r} defines reserved default-family attribute "
+            f"{_DEFAULT_FAMILY_ATTRIBUTE!r} with a value that is not a SchemaFamily "
+            "owned by that exact model; rename or remove the conflicting attribute"
+        )
+        raise SchemaFamilySelectionError(msg)
+    return selected
+
+
 def _default_family_for_model(model: type[BaseModel]) -> SchemaFamily[Any] | None:
-    return _DEFAULT_FAMILIES.get(model)
+    with _FAMILY_LOCK:
+        return _model_owned_default_family(model)
 
 
 def _family_for[T: BaseModel](subject: type[T] | SchemaFamily[T]) -> SchemaFamily[T]:
     if isinstance(subject, SchemaFamily):
         return subject
     _ensure_pydantic_v2_model(subject)
-    family = _DEFAULT_FAMILIES.get(subject)
+    family = _default_family_for_model(subject)
     if family is None:
         msg = (
             f"{subject.__name__!r} has no explicit default schema family; pass a "

--- a/tests/unit/test_cache_lifecycle.py
+++ b/tests/unit/test_cache_lifecycle.py
@@ -12,7 +12,15 @@ from pydantic import BaseModel, create_model
 
 import pydantic_versions._runtime_render as runtime_render
 import pydantic_versions.family as family_module
-from pydantic_versions import NestedFamily, SchemaCompilationError, SchemaFamily, SchemaVersion
+from pydantic_versions import (
+    NestedFamily,
+    SchemaCompilationError,
+    SchemaFamily,
+    SchemaFamilySelectionError,
+    SchemaVersion,
+    model_for_version,
+    versioned_schema,
+)
 
 type _ModelRef = weakref.ReferenceType[type[BaseModel]]
 
@@ -123,6 +131,112 @@ def test_discarded_families_do_not_accumulate_in_a_global_model_cache() -> None:
     assert all(wrapper() is None and child() is None for wrapper, child in first_batch)
 
 
+def _discarded_default_model_refs(count: int) -> tuple[_ModelRef, ...]:
+    references = []
+    for index in range(count):
+        model = create_model(
+            f"DefaultLifecycleModel{index}",
+            __module__=__name__,
+            value=(int, ...),
+        )
+        family = SchemaFamily(
+            model=model,
+            name=f"default_lifecycle_{index}",
+            versions=(SchemaVersion("stable"),),
+            version_metadata=None,
+        ).as_default()
+        family.compile()
+        references.append(weakref.ref(model))
+    return tuple(references)
+
+
+def test_discarded_model_owned_default_families_are_collectable() -> None:
+    references = _discarded_default_model_refs(32)
+
+    gc.collect()
+
+    assert all(reference() is None for reference in references)
+
+
+def test_default_family_selection_is_isolated_to_the_exact_model_class() -> None:
+    class Parent(BaseModel):
+        value: int
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="exact_parent_default",
+        versions=(SchemaVersion("parent"),),
+        version_metadata=None,
+    ).as_default()
+
+    class Child(Parent):
+        pass
+
+    with pytest.raises(SchemaFamilySelectionError, match="no explicit default"):
+        model_for_version(Child, "parent")
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="exact_child_default",
+        versions=(SchemaVersion("child"),),
+        version_metadata=None,
+    ).as_default()
+
+    assert model_for_version(Parent, "parent") is parent_family.model_for("parent")
+    assert model_for_version(Child, "child") is child_family.model_for("child")
+
+
+@pytest.mark.parametrize("collision", [None, "application-owned", property(lambda _: None)])
+def test_reserved_default_family_attribute_collision_fails_closed(collision: object) -> None:
+    class Payload(BaseModel):
+        value: int
+
+    setattr(Payload, family_module._DEFAULT_FAMILY_ATTRIBUTE, collision)
+    candidate = SchemaFamily(
+        model=Payload,
+        name="reserved_attribute_collision",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaFamilySelectionError, match="reserved default-family attribute"):
+        candidate.as_default()
+    with pytest.raises(SchemaFamilySelectionError, match="rename or remove"):
+        model_for_version(Payload, "1")
+
+    assert Payload.__dict__[family_module._DEFAULT_FAMILY_ATTRIBUTE] is collision
+
+
+def test_foreign_model_default_family_attribute_collision_fails_closed() -> None:
+    class Foreign(BaseModel):
+        value: int
+
+    foreign_family = SchemaFamily(
+        model=Foreign,
+        name="foreign_reserved_attribute_owner",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    class Payload(BaseModel):
+        value: int
+
+    setattr(Payload, family_module._DEFAULT_FAMILY_ATTRIBUTE, foreign_family)
+    candidate = SchemaFamily(
+        model=Payload,
+        name="wrong_reserved_attribute_owner",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaFamilySelectionError, match="owned by that exact model"):
+        model_for_version(Payload, "1")
+    with pytest.raises(SchemaFamilySelectionError, match="owned by that exact model"):
+        candidate.as_default()
+
+    assert Payload.__dict__[family_module._DEFAULT_FAMILY_ATTRIBUTE] is foreign_family
+
+
 def test_current_wire_validator_is_built_once_under_concurrent_use(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -198,6 +312,71 @@ def test_forced_model_rebuild_invalidates_an_existing_family() -> None:
     assert replacement.validate({"value": 2}, version="1").current_model == Payload(value=2)
 
 
+def test_forced_model_rebuild_allows_default_family_replacement() -> None:
+    class Payload(BaseModel):
+        value: int
+
+    selected = SchemaFamily(
+        model=Payload,
+        name="selected_before_rebuild",
+        versions=(SchemaVersion("before"),),
+        version_metadata=None,
+    ).as_default()
+    selected.compile()
+    premature = SchemaFamily(
+        model=Payload,
+        name="premature_replacement",
+        versions=(SchemaVersion("premature"),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(SchemaFamilySelectionError, match="already has explicit default"):
+        premature.as_default()
+
+    assert Payload.model_rebuild(force=True) is True
+    with pytest.raises(SchemaCompilationError, match=r"call as_default\(\)"):
+        model_for_version(Payload, "before")
+
+    replacement = SchemaFamily(
+        model=Payload,
+        name="selected_after_rebuild",
+        versions=(SchemaVersion("after"),),
+        version_metadata=None,
+    ).as_default()
+
+    assert model_for_version(Payload, "after") is replacement.model_for("after")
+    with pytest.raises(SchemaFamilySelectionError, match="already has explicit default"):
+        selected.as_default()
+
+
+def test_forced_model_rebuild_allows_decorator_default_replacement() -> None:
+    @versioned_schema(
+        name="decorator_selected_before_rebuild",
+        versions=("before",),
+        current="before",
+        metadata_owner="family",
+    )
+    class Payload(BaseModel):
+        value: int
+
+    selected = family_module._default_family_for_model(Payload)
+    assert selected is not None
+    selected.compile()
+
+    assert Payload.model_rebuild(force=True) is True
+    replacement_model = versioned_schema(
+        name="decorator_selected_after_rebuild",
+        versions=("after",),
+        current="after",
+        metadata_owner="family",
+    )(Payload)
+
+    replacement = family_module._default_family_for_model(Payload)
+    assert replacement_model is Payload
+    assert replacement is not None and replacement is not selected
+    assert model_for_version(Payload, "after") is replacement.model_for("after")
+
+
 def test_nested_model_rebuild_invalidates_dependent_families() -> None:
     class Child(BaseModel):
         value: int
@@ -224,6 +403,155 @@ def test_nested_model_rebuild_invalidates_dependent_families() -> None:
     assert Child.model_rebuild(force=True) is True
     with pytest.raises(SchemaCompilationError, match="schema family 'rebuilt_child'"):
         parent_family.model_for("1")
+
+
+def test_nested_model_rebuild_allows_dependent_default_family_replacement() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="selected_nested_child",
+        versions=(SchemaVersion("before"),),
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    parent_family = SchemaFamily(
+        model=Parent,
+        name="selected_nested_parent",
+        versions=(SchemaVersion("before"),),
+        nested=(NestedFamily("child", child_family, {"before": "before"}),),
+        version_metadata=None,
+    ).as_default()
+    parent_family.compile()
+
+    assert Child.model_rebuild(force=True) is True
+    with pytest.raises(SchemaCompilationError, match="schema family 'selected_nested_child'"):
+        model_for_version(Parent, "before")
+
+    replacement_child = SchemaFamily(
+        model=Child,
+        name="replacement_nested_child",
+        versions=(SchemaVersion("after"),),
+        version_metadata=None,
+    )
+    replacement_parent = SchemaFamily(
+        model=Parent,
+        name="replacement_nested_parent",
+        versions=(SchemaVersion("after"),),
+        nested=(NestedFamily("child", replacement_child, {"after": "after"}),),
+        version_metadata=None,
+    ).as_default()
+
+    assert model_for_version(Parent, "after") is replacement_parent.model_for("after")
+
+
+def test_compiled_nested_rebuild_allows_uncompiled_default_parent_replacement() -> None:
+    class Child(BaseModel):
+        value: int
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="compiled_nested_child",
+        versions=(SchemaVersion("before"),),
+        version_metadata=None,
+    )
+    child_family.compile()
+
+    class Parent(BaseModel):
+        child: Child
+
+    selected_parent = SchemaFamily(
+        model=Parent,
+        name="uncompiled_selected_parent",
+        versions=(SchemaVersion("before"),),
+        nested=(NestedFamily("child", child_family, {"before": "before"}),),
+        version_metadata=None,
+    ).as_default()
+    replacement_child = SchemaFamily(
+        model=Child,
+        name="replacement_compiled_nested_child",
+        versions=(SchemaVersion("after"),),
+        version_metadata=None,
+    )
+    replacement_parent = SchemaFamily(
+        model=Parent,
+        name="replacement_uncompiled_parent",
+        versions=(SchemaVersion("after"),),
+        nested=(NestedFamily("child", replacement_child, {"after": "after"}),),
+        version_metadata=None,
+    )
+
+    assert selected_parent._compiled is None
+    with pytest.raises(SchemaFamilySelectionError, match="already has explicit default"):
+        replacement_parent.as_default()
+
+    assert Child.model_rebuild(force=True) is True
+    with pytest.raises(SchemaCompilationError, match="schema family 'compiled_nested_child'"):
+        model_for_version(Parent, "before")
+
+    assert replacement_parent.as_default() is replacement_parent
+    assert model_for_version(Parent, "after") is replacement_parent.model_for("after")
+
+
+def _race_default_selection(
+    candidates: tuple[SchemaFamily[Any], ...],
+) -> tuple[bool, ...]:
+    barrier = Barrier(len(candidates))
+
+    def select(family: SchemaFamily[Any]) -> bool:
+        barrier.wait()
+        try:
+            family.as_default()
+        except SchemaFamilySelectionError:
+            return False
+        return True
+
+    with ThreadPoolExecutor(max_workers=len(candidates)) as executor:
+        return tuple(executor.map(select, candidates))
+
+
+def test_concurrent_default_selection_and_rebuild_replacement_choose_one_family() -> None:
+    class Payload(BaseModel):
+        value: int
+
+    initial = tuple(
+        SchemaFamily(
+            model=Payload,
+            name=f"concurrent_initial_{index}",
+            versions=(SchemaVersion(f"initial-{index}"),),
+            version_metadata=None,
+        )
+        for index in range(8)
+    )
+    initial_results = _race_default_selection(initial)
+
+    assert sum(initial_results) == 1
+    initial_winner = initial[initial_results.index(True)]
+    assert family_module._default_family_for_model(Payload) is initial_winner
+    initial_winner.compile()
+
+    assert Payload.model_rebuild(force=True) is True
+    replacements = tuple(
+        SchemaFamily(
+            model=Payload,
+            name=f"concurrent_replacement_{index}",
+            versions=(SchemaVersion(f"replacement-{index}"),),
+            version_metadata=None,
+        )
+        for index in range(8)
+    )
+    replacement_results = _race_default_selection(replacements)
+
+    assert sum(replacement_results) == 1
+    replacement_winner = replacements[replacement_results.index(True)]
+    assert family_module._default_family_for_model(Payload) is replacement_winner
+    assert model_for_version(Payload, replacement_winner.current_version) is (
+        replacement_winner.model_for(replacement_winner.current_version)
+    )
 
 
 def test_rebuild_detected_during_compilation_does_not_publish_state(


### PR DESCRIPTION
## Summary

Moves deliberate default-family selection from a permanent process-global strong registry onto the exact authoritative model class. Dynamic model/family cycles can now be collected, subclasses do not inherit defaults accidentally, and model-only helpers can be redirected to a recreated graph after a forced Pydantic rebuild invalidates a compiled component.

## Compatibility boundaries

- Keeps one valid default per exact model class, repeated selection of the same family, decorator-created defaults, and serialized selection/compilation behavior.
- Rejects a different family while the selected graph remains valid or contains no invalid compiled component.
- Fails closed without overwriting application values when the reserved internal class attribute collides or points at another model's family.
- Changes no public signatures or wire projection behavior, including excluded-field handling.

## Review findings closed before push

- Handles an uncompiled selected parent whose directly declared compiled child was rebuilt, avoiding a permanently stranded model-only helper.
- Covers root, nested, decorator, subclass, collection, collision, ownership, and concurrent-selection lifecycle paths.

## Validation

- Full CI gate: 932 tests passed at 95.93% coverage; Ruff, ty, strict mypy, and Vulture passed.
- Exact dependency floors: 932 tests passed at 95.85% coverage.
- Strict documentation build, lock check, and 1.0.0 release validation passed.
- Immutable v0.3.0 compatibility contract passed without regeneration.

Closes #140