### PR TITLE
fix(ci): enforce durable commit records

### DIFF
--- a/.github/workflows/commit-messages.yml
+++ b/.github/workflows/commit-messages.yml
@@ -33,10 +33,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           PUSH_SHA: ${{ github.sha }}
+          PUSH_ACTOR: ${{ github.actor }}
         run: |
+          generated_dependency_flag=()
           if [ "${GITHUB_EVENT_NAME}" = "pull_request_target" ]; then
+            if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+              generated_dependency_flag+=(--allow-generated-dependency)
+            fi
             pr_ref="refs/remotes/pull/${PR_NUMBER}/head"
             git fetch --no-tags --force origin \
               "refs/pull/${PR_NUMBER}/head:${pr_ref}"
@@ -50,13 +56,19 @@ jobs:
 
             python scripts/check_conventional_commits.py \
               --title "$PR_TITLE" \
-              --range "${PR_BASE_SHA}..${pr_ref}"
+              --range "${PR_BASE_SHA}..${pr_ref}" \
+              "${generated_dependency_flag[@]}"
           else
+            if [ "$PUSH_ACTOR" = "dependabot[bot]" ]; then
+              generated_dependency_flag+=(--allow-generated-dependency)
+            fi
             if git cat-file -e "${PUSH_BEFORE_SHA}^{commit}" 2>/dev/null; then
               python scripts/check_conventional_commits.py \
-                --range "${PUSH_BEFORE_SHA}..${PUSH_SHA}"
+                --range "${PUSH_BEFORE_SHA}..${PUSH_SHA}" \
+                "${generated_dependency_flag[@]}"
             else
               python scripts/check_conventional_commits.py \
-                --commit "$(git log -1 --pretty=%B "$PUSH_SHA")"
+                --commit "$(git log -1 --pretty=%B "$PUSH_SHA")" \
+                "${generated_dependency_flag[@]}"
             fi
           fi

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,8 +1,10 @@
 <type>[optional scope][!]: <imperative summary>
 
 ; A retained logical commit is the portable change record for Git-only readers.
-; Headings are optional, and one large atomic commit is valid. Keep detail
-; proportional to the change.
+; Keep these four column-zero headings exactly once and in this order. One
+; large atomic commit is valid; keep detail proportional to the change.
+; Begin the body here without a nonblank preamble. Raw HTML is not accepted;
+; put literal HTML or comment examples in a fenced code block.
 ## Summary
 
 - <Describe the observable change and why it is needed.>
@@ -20,9 +22,10 @@
 
 - `<command>`: <result>
 
-; Keep multiple results as top-level `- ` list items under this heading. For
-; one result, you may use: Validation: not run because <specific reason>.
-; Delete optional sections that do not apply and remove every template token.
+; Keep multiple independent commands or results as separate top-level `- `
+; list items. One clean aggregate from one command remains one result. If it
+; was not run, give a specific reason.
+; Keep every section and remove every template token.
 ; PR metadata supplements this body. Wrap commit prose at about 72 columns;
 ; use natural Markdown without artificial hard wrapping in PR descriptions.
 ; Add `BREAKING CHANGE: <impact and migration>` below Validation when useful.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ enough to scan in `git log --oneline`. Use `!` for an intentional breaking
 change and add a `BREAKING CHANGE:` footer when the history needs migration
 detail.
 
-For a material change, treat each retained logical commit as a portable,
-PR-grade change record. Its message must stand on its own in `git log`, mirrors,
+Treat each retained human-authored logical commit as a portable, PR-grade
+change record. Its message must stand on its own in `git log`, mirrors,
 archives, and changelog tooling without relying on GitHub metadata. Record:
 
 - the observable change and why it is needed;
@@ -52,7 +52,7 @@ One large atomic commit is valid. Use proportional detail for small mechanical
 changes and keep unrelated changes in separate logical commits.
 
 The tracked [`.gitmessage`](https://github.com/dariuszpanas/pydantic-versions/blob/main/.gitmessage)
-template suggests this layout:
+template requires this layout:
 
 ```text
 <type>[optional scope][!]: <imperative summary>
@@ -74,11 +74,20 @@ template suggests this layout:
 - `<command>`: result
 ```
 
-The headings are guidance, not a required format. Unstructured prose is equally
-valid when it provides the same durable context. A single validation result can
-use a concise `Validation: ...` sentence. Put multiple results in separate
-top-level `- ` Markdown list items under `## Validation`, so rendered history
-does not collapse them into one paragraph. Do not retain template tokens,
+Human-authored commits must contain those exact column-zero, second-level
+headings once each, in that order, and begin with `## Summary` without a
+nonblank preamble. Every section needs rendered alphanumeric prose or nonempty
+fenced or indented code; punctuation, empty links, and invisible markup are not
+content. Raw HTML tags, comments, and declarations are rejected outside code
+blocks, so put literal HTML examples in fenced code.
+
+Canonical generated Dependabot headers, metadata, and sign-off are the only
+format exception, and the protected workflow enables it only for an event
+authenticated as `dependabot[bot]`; local and ordinary human checks default to
+the four-section policy. Put multiple independent validation commands or
+results in separate top-level `- ` Markdown list items under `## Validation`,
+so rendered history does not collapse them into one paragraph. One clean
+aggregate from one command remains one result. Do not retain template tokens,
 development-only notes such as "address review feedback," a body that merely
 repeats the subject, or validation commands without their result. For work that
 cannot be run locally, state a concrete reason instead of writing a placeholder.
@@ -96,7 +105,7 @@ git config --worktree commit.template "$(git rev-parse --show-toplevel)/.gitmess
 git config --worktree core.commentChar ";"
 ```
 
-The comment-character setting preserves optional `##` headings when Git opens
+The comment-character setting preserves required `##` headings when Git opens
 the template; instructional comments begin with `;` and are removed by Git.
 Keep these settings worktree-scoped: `--local` writes shared repository config
 and can make one linked checkout use another checkout's template path.
@@ -112,6 +121,7 @@ Before pushing, fetch and inspect the exact history the PR would retain:
 ```bash
 git fetch origin
 git log --format=fuller origin/main..HEAD
+uvx --from "uv==0.12.5" uv run --no-sync python scripts/check_conventional_commits.py --range origin/main..HEAD
 ```
 
 Compare every material commit body with the PR description. Fold `fixup!` and
@@ -134,12 +144,18 @@ Example:
 ```text
 feat: add versioned schema API
 
-Register ordered schema versions and generate historical wire models from the
-current Pydantic model. Historical validation upgrades values through explicit
-migrations before the authoritative current-model validation boundary.
+## Summary
 
-Keep schema labels opaque and leave YAML parsing to callers. Document the
-legacy unversioned fallback and Django Ninja inspection boundary.
+- Register ordered schema versions and generate historical wire models from
+  the current Pydantic model.
+
+## Boundaries and compatibility
+
+- Keep schema labels opaque and leave YAML parsing to callers.
+
+## Investigation
+
+- Document the legacy fallback and Django Ninja inspection boundary.
 
 ## Validation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,8 +38,8 @@ enough to scan in `git log --oneline`. Use `!` for an intentional breaking
 change and add a `BREAKING CHANGE:` footer when the history needs migration
 detail.
 
-For a material change, treat each retained logical commit as a portable,
-PR-grade change record. Its message must stand on its own in `git log`, mirrors,
+Treat each retained human-authored logical commit as a portable, PR-grade
+change record. Its message must stand on its own in `git log`, mirrors,
 archives, and changelog tooling without relying on GitHub metadata. Record:
 
 - the observable change and why it is needed;
@@ -52,7 +52,7 @@ One large atomic commit is valid. Use proportional detail for small mechanical
 changes and keep unrelated changes in separate logical commits.
 
 The tracked [`.gitmessage`](https://github.com/dariuszpanas/pydantic-versions/blob/main/.gitmessage)
-template suggests this layout:
+template requires this layout:
 
 ```text
 <type>[optional scope][!]: <imperative summary>
@@ -74,11 +74,20 @@ template suggests this layout:
 - `<command>`: result
 ```
 
-The headings are guidance, not a required format. Unstructured prose is equally
-valid when it provides the same durable context. A single validation result can
-use a concise `Validation: ...` sentence. Put multiple results in separate
-top-level `- ` Markdown list items under `## Validation`, so rendered history
-does not collapse them into one paragraph. Do not retain template tokens,
+Human-authored commits must contain those exact column-zero, second-level
+headings once each, in that order, and begin with `## Summary` without a
+nonblank preamble. Every section needs rendered alphanumeric prose or nonempty
+fenced or indented code; punctuation, empty links, and invisible markup are not
+content. Raw HTML tags, comments, and declarations are rejected outside code
+blocks, so put literal HTML examples in fenced code.
+
+Canonical generated Dependabot headers, metadata, and sign-off are the only
+format exception, and the protected workflow enables it only for an event
+authenticated as `dependabot[bot]`; local and ordinary human checks default to
+the four-section policy. Put multiple independent validation commands or
+results in separate top-level `- ` Markdown list items under `## Validation`,
+so rendered history does not collapse them into one paragraph. One clean
+aggregate from one command remains one result. Do not retain template tokens,
 development-only notes such as "address review feedback," a body that merely
 repeats the subject, or validation commands without their result. For work that
 cannot be run locally, state a concrete reason instead of writing a placeholder.
@@ -96,7 +105,7 @@ git config --worktree commit.template "$(git rev-parse --show-toplevel)/.gitmess
 git config --worktree core.commentChar ";"
 ```
 
-The comment-character setting preserves optional `##` headings when Git opens
+The comment-character setting preserves required `##` headings when Git opens
 the template; instructional comments begin with `;` and are removed by Git.
 Keep these settings worktree-scoped: `--local` writes shared repository config
 and can make one linked checkout use another checkout's template path.
@@ -112,6 +121,7 @@ Before pushing, fetch and inspect the exact history the PR would retain:
 ```bash
 git fetch origin
 git log --format=fuller origin/main..HEAD
+uvx --from "uv==0.12.5" uv run --no-sync python scripts/check_conventional_commits.py --range origin/main..HEAD
 ```
 
 Compare every material commit body with the PR description. Fold `fixup!` and
@@ -134,12 +144,18 @@ Example:
 ```text
 feat: add versioned schema API
 
-Register ordered schema versions and generate historical wire models from the
-current Pydantic model. Historical validation upgrades values through explicit
-migrations before the authoritative current-model validation boundary.
+## Summary
 
-Keep schema labels opaque and leave YAML parsing to callers. Document the
-legacy unversioned fallback and Django Ninja inspection boundary.
+- Register ordered schema versions and generate historical wire models from
+  the current Pydantic model.
+
+## Boundaries and compatibility
+
+- Keep schema labels opaque and leave YAML parsing to callers.
+
+## Investigation
+
+- Document the legacy fallback and Django Ninja inspection boundary.
 
 ## Validation
 

--- a/scripts/check_conventional_commits.py
+++ b/scripts/check_conventional_commits.py
@@ -37,7 +37,18 @@ _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 _MARKDOWN_TABLE_DELIMITER_CELL_RE = re.compile(r"^:?-{3,}:?$")
 _HEADING_RE = re.compile(r"^#{1,6}\s+(?P<name>\S.*?)(?:\s+#+)?$")
 _SETEXT_UNDERLINE_RE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
-_FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})")
+_SETEXT_H2_UNDERLINE_RE = re.compile(r"^ {0,3}-+[ \t]*$")
+_ATX_HEADING_RE = re.compile(r"^ {0,3}#{1,6}(?=$|[ \t])(?:[ \t]+.*)?$")
+_ATX_H2_RE = re.compile(r"^ {0,3}##(?=$|[ \t])(?:[ \t]+.*)?$")
+_FENCE_RE = re.compile(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<rest>.*)$")
+_THEMATIC_BREAK_RE = re.compile(r"^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$")
+_LINK_REFERENCE_DEFINITION_RE = re.compile(r"^ {0,3}\[[^]\r\n]+\]:[ \t]*\S.*$")
+_HTML_ENTITY_RE = re.compile(r"&(?:#[0-9]+|#x[0-9a-f]+|[a-z][a-z0-9]+);", re.IGNORECASE)
+_RAW_HTML_RE = re.compile(
+    r"<!--|--!?>|</?[A-Za-z][A-Za-z0-9-]*(?:[ \t/>]|$)|"
+    r"<![A-Za-z][A-Za-z0-9-]*(?:[ \t>]|$)|<!\[CDATA\[|<\?",
+    re.IGNORECASE,
+)
 _BLOCK_STRUCTURE_RE = re.compile(
     r"^(?: {4}|\t| {0,3}(?:>|#{1,6}\s|[-+*]\s+|\d+[.)]\s+|`{3,}|~{3,}))"
 )
@@ -68,6 +79,12 @@ _VALIDATION_STATUS_RE = re.compile(
     re.IGNORECASE,
 )
 _VALIDATION_SECTION_NAMES = frozenset({"checks", "testing", "tests", "validation", "verification"})
+_REQUIRED_SECTION_HEADINGS = (
+    "## Summary",
+    "## Boundaries and compatibility",
+    "## Investigation",
+    "## Validation",
+)
 _VALIDATION_OUTCOME_TRAIL_RE = re.compile(
     r"(?:\b(?:clean|completed|failed|green|ok|passed|succeeded|"
     r"successful(?:ly)?)\b|"
@@ -160,10 +177,6 @@ _DEPENDABOT_METADATA_PREFIXES = tuple(
     ["- dependency-name:"] + [f"  {field}:" for field in sorted(_DEPENDABOT_ALLOWED_FIELDS)]
 )
 _DEPENDABOT_SIGNOFF = "Signed-off-by: dependabot[bot] <support@github.com>"
-_DEPENDABOT_BUMP_RE = re.compile(
-    r"^Bumps (?P<dependency>\S+) from (?P<old>\S+) to (?P<new>\S+?)\.?$",
-    re.IGNORECASE,
-)
 _DEPENDABOT_SINGLE_SUMMARY_RE = re.compile(
     r"^bump (?P<dependency>\S+) from (?P<old>\S+) to (?P<new>\S+)$",
     re.IGNORECASE,
@@ -258,25 +271,70 @@ def _strip_markup(line: str) -> str:
     return re.sub(r"[`*_~]+", "", stripped).strip()
 
 
+def _markdown_structure(
+    lines: Sequence[str],
+) -> tuple[set[int], set[int], set[int], set[int]]:
+    """Return visible, top-level, code-content, and raw-HTML indexes."""
+    visible_indexes: set[int] = set()
+    top_level_indexes: set[int] = set()
+    code_content_indexes: set[int] = set()
+    raw_html_indexes: set[int] = set()
+    fence_character: str | None = None
+    fence_length = 0
+
+    for index, line in enumerate(lines):
+        fence_match = _FENCE_RE.match(line)
+        if fence_character is not None:
+            if fence_match is not None:
+                marker = fence_match.group("marker")
+                rest = fence_match.group("rest")
+                if (
+                    marker[0] == fence_character
+                    and len(marker) >= fence_length
+                    and not rest.strip(" \t")
+                ):
+                    fence_character = None
+                    fence_length = 0
+                    continue
+            visible_indexes.add(index)
+            code_content_indexes.add(index)
+            continue
+
+        if fence_match is not None:
+            marker = fence_match.group("marker")
+            rest = fence_match.group("rest")
+            if marker[0] != "`" or "`" not in rest:
+                fence_character = marker[0]
+                fence_length = len(marker)
+                continue
+
+        indented_code = line.startswith("    ") or re.match(r"^ {0,3}\t", line)
+        if indented_code:
+            visible_indexes.add(index)
+            code_content_indexes.add(index)
+            continue
+
+        if _RAW_HTML_RE.search(line):
+            raw_html_indexes.add(index)
+            continue
+
+        visible_indexes.add(index)
+        if re.match(r"^ {0,3}>", line):
+            continue
+        top_level_indexes.add(index)
+
+    return visible_indexes, top_level_indexes, code_content_indexes, raw_html_indexes
+
+
 def _validation_list_item_owners(lines: Sequence[str]) -> dict[int, int]:
     """Map canonical top-level validation items and their continuations."""
     owners: dict[int, int] = {}
     active_owner: int | None = None
-    in_html_comment = False
     setext_lines = _setext_heading_lines(lines)
     top_level_indexes = _top_level_line_indexes(lines)
 
     for index, line in enumerate(lines):
         raw = line.strip()
-        if in_html_comment:
-            if "-->" in raw:
-                in_html_comment = False
-            active_owner = None
-            continue
-        if raw.startswith("<!--"):
-            in_html_comment = "-->" not in raw
-            active_owner = None
-            continue
         if (
             index not in top_level_indexes
             or not raw
@@ -312,28 +370,32 @@ def _is_trailer(line: str) -> bool:
 
 
 def _meaningful_lines(lines: Sequence[str]) -> list[str]:
-    """Return visible body lines, excluding headings, comments, and trailers."""
+    """Return rendered body content, excluding structure-only constructs."""
     meaningful: list[str] = []
-    in_html_comment = False
+    visible_indexes, _, code_content_indexes, _ = _markdown_structure(lines)
     setext_lines = _setext_heading_lines(lines)
     for index, line in enumerate(lines):
+        if index not in visible_indexes:
+            continue
+        if index in code_content_indexes:
+            if code := line.strip():
+                meaningful.append(code)
+            continue
+
         stripped = _strip_markup(line)
-        if in_html_comment:
-            if "-->" in stripped:
-                in_html_comment = False
-            continue
-        if stripped.startswith("<!--"):
-            in_html_comment = "-->" not in stripped
-            continue
         if (
             not stripped
             or index in setext_lines
             or stripped.startswith(";")
             or _HEADING_RE.fullmatch(stripped)
             or _is_trailer(stripped)
+            or _THEMATIC_BREAK_RE.fullmatch(line)
+            or _LINK_REFERENCE_DEFINITION_RE.fullmatch(line)
         ):
             continue
-        meaningful.append(stripped)
+        rendered = _RAW_HTML_RE.sub("", _HTML_ENTITY_RE.sub("", stripped))
+        if re.search(r"[A-Za-z0-9]", rendered):
+            meaningful.append(stripped)
     return meaningful
 
 
@@ -341,22 +403,17 @@ def _context_lines(lines: Sequence[str]) -> list[str]:
     """Return change-context prose, excluding mechanical validation evidence."""
     context: list[str] = []
     validation_section = False
-    in_html_comment = False
+    visible_indexes, top_level_indexes, _, _ = _markdown_structure(lines)
     setext_lines = _setext_heading_lines(lines)
     for index, line in enumerate(lines):
+        if index not in visible_indexes:
+            continue
         raw = line.strip()
-        if in_html_comment:
-            if "-->" in raw:
-                in_html_comment = False
-            continue
-        if raw.startswith("<!--"):
-            in_html_comment = "-->" not in raw
-            continue
         if index in setext_lines:
             if index + 1 < len(lines) and _SETEXT_UNDERLINE_RE.fullmatch(lines[index + 1]):
                 validation_section = _strip_markup(raw).casefold() in _VALIDATION_SECTION_NAMES
             continue
-        if heading := _HEADING_RE.fullmatch(raw):
+        if index in top_level_indexes and (heading := _HEADING_RE.fullmatch(raw)):
             section_name = _strip_markup(heading.group("name")).casefold()
             validation_section = section_name in _VALIDATION_SECTION_NAMES
             continue
@@ -401,7 +458,6 @@ def _validation_blocks(
     part_indexes: list[int] = []
     parts_are_validation = False
     validation_section = False
-    in_html_comment = False
     setext_lines = _setext_heading_lines(lines)
     top_level_indexes = _top_level_line_indexes(lines)
     body_start = 2 if len(lines) >= 2 and lines[1] == "" else 1
@@ -416,14 +472,6 @@ def _validation_blocks(
     for index, line in enumerate(lines):
         raw = line.strip()
         if index < body_start:
-            continue
-        if in_html_comment:
-            if "-->" in raw:
-                in_html_comment = False
-            continue
-        if raw.startswith("<!--"):
-            flush()
-            in_html_comment = "-->" not in raw
             continue
         if index not in top_level_indexes or (
             metadata_candidate_bounds is not None
@@ -721,11 +769,23 @@ def _normalized_prose(lines: Sequence[str]) -> str:
 def _setext_heading_lines(lines: Sequence[str]) -> set[int]:
     """Return text and underline indexes for Setext-style headings."""
     headings: set[int] = set()
+    _, top_level_indexes, _, _ = _markdown_structure(lines)
     for index in range(1, len(lines)):
-        if not _SETEXT_UNDERLINE_RE.fullmatch(lines[index]):
+        if (
+            index not in top_level_indexes
+            or index - 1 not in top_level_indexes
+            or not _SETEXT_UNDERLINE_RE.fullmatch(lines[index])
+        ):
             continue
-        heading = lines[index - 1].strip()
-        if heading and not heading.startswith(("- ", "* ", "+ ", ">", "    ")):
+        heading_line = lines[index - 1]
+        heading = heading_line.strip()
+        if (
+            heading
+            and not _ATX_HEADING_RE.fullmatch(heading_line)
+            and not _BLOCK_STRUCTURE_RE.match(heading_line)
+            and not _THEMATIC_BREAK_RE.fullmatch(heading_line)
+            and not _LINK_REFERENCE_DEFINITION_RE.fullmatch(heading_line)
+        ):
             headings.update({index - 1, index})
     return headings
 
@@ -824,28 +884,66 @@ def _generated_metadata_bounds(lines: Sequence[str]) -> tuple[int, int] | None:
     if _generated_metadata_records(lines, bounds) is None:
         return None
     assert bounds is not None
-    trailers = [line.strip() for line in lines[bounds[1] + 1 :] if line.strip()]
+    trailers = [line for line in lines[bounds[1] + 1 :] if line.strip()]
     return bounds if trailers == [_DEPENDABOT_SIGNOFF] else None
 
 
 def _top_level_line_indexes(lines: Sequence[str]) -> set[int]:
     """Return lines outside fenced, quoted, and indented code examples."""
-    indexes: set[int] = set()
-    fence_marker: str | None = None
-    for index, line in enumerate(lines):
-        if fence_match := _FENCE_RE.match(line):
-            marker = fence_match.group("marker")[0]
-            if fence_marker is None:
-                fence_marker = marker
-            elif marker == fence_marker:
-                fence_marker = None
+    return _markdown_structure(lines)[1]
+
+
+def _raw_html_errors(lines: Sequence[str], *, label: str) -> list[str]:
+    """Reject ambiguous raw HTML in the body except inside code blocks."""
+    body_start = 2 if len(lines) >= 2 and lines[1] == "" else 1
+    *_, raw_html_indexes = _markdown_structure(lines)
+    body_html_indexes = raw_html_indexes & set(range(body_start, len(lines)))
+    if not body_html_indexes:
+        return []
+    line_number = min(body_html_indexes) + 1
+    return [
+        f"{label} line {line_number} contains raw HTML outside a fenced or "
+        "indented code block. Put literal HTML examples in fenced code."
+    ]
+
+
+def _required_section_errors(lines: Sequence[str], *, label: str) -> list[str]:
+    """Require the repository's durable four-section commit record."""
+    body_start = 2 if len(lines) >= 2 and lines[1] == "" else 1
+    _, top_level_indexes, _, _ = _markdown_structure(lines)
+    setext_lines = _setext_heading_lines(lines)
+    headings: list[tuple[int, str]] = []
+    for index in range(body_start, len(lines)):
+        if index not in top_level_indexes:
             continue
-        if fence_marker is not None or line.startswith(("    ", "\t")):
-            continue
-        if re.match(r"^ {0,3}>", line):
-            continue
-        indexes.add(index)
-    return indexes
+        if _ATX_H2_RE.fullmatch(lines[index]):
+            headings.append((index, lines[index]))
+        elif (
+            index in setext_lines
+            and index + 1 in setext_lines
+            and _SETEXT_H2_UNDERLINE_RE.fullmatch(lines[index + 1])
+        ):
+            headings.append((index, f"{lines[index].strip()}\n{lines[index + 1].strip()}"))
+    heading_text = tuple(heading for _, heading in headings)
+    if heading_text != _REQUIRED_SECTION_HEADINGS:
+        expected = ", ".join(repr(heading) for heading in _REQUIRED_SECTION_HEADINGS)
+        found = ", ".join(repr(heading) for heading in heading_text) or "none"
+        return [
+            f"{label} must contain exactly these second-level headings once each "
+            f"and in order: {expected}. Found: {found}."
+        ]
+
+    errors: list[str] = []
+    if any(line.strip() for line in lines[body_start : headings[0][0]]):
+        errors.append(f"{label} body must begin with '## Summary'; remove the nonblank preamble.")
+    for position, (start, heading) in enumerate(headings):
+        end = headings[position + 1][0] if position + 1 < len(headings) else len(lines)
+        if not _meaningful_lines(lines[start + 1 : end]):
+            errors.append(
+                f"{label} section {heading!r} must contain rendered alphanumeric "
+                "prose or nonempty fenced or indented code."
+            )
+    return errors
 
 
 def _contains_generated_metadata_shape(lines: Sequence[str]) -> bool:
@@ -916,32 +1014,17 @@ def _markdown_table_lines(lines: Sequence[str]) -> set[int]:
     return table_lines
 
 
-def _has_generated_dependency_context(
-    context: Sequence[str], records: Sequence[dict[str, str]] | None
-) -> bool:
-    """Recognize Dependabot's complete short-name prose and links."""
-    if records is None or len(records) != 1 or not context:
-        return False
-    bump = _DEPENDABOT_BUMP_RE.fullmatch(context[0])
-    if bump is None:
-        return False
-    record = records[0]
-    if (
-        _normalized_prose([bump.group("dependency")])
-        != _normalized_prose([record["dependency-name"]])
-        or bump.group("new").casefold() != record["dependency-version"].casefold()
-    ):
-        return False
-    labels = {line.casefold().rstrip(":") for line in context[1:]}
-    return "commits" in labels and ("release notes" in labels or "changelog" in labels)
-
-
 def _has_generated_dependency_header(header: str, records: Sequence[dict[str, str]] | None) -> bool:
     """Recognize a canonical Dependabot header backed by validated metadata."""
     if records is None or not records:
         return False
     header_match = _HEADER_RE.fullmatch(header.strip())
-    if header_match is None:
+    if (
+        header_match is None
+        or header_match.group("type") != "chore"
+        or header_match.group("scope") not in {"actions", "deps"}
+        or header_match.group("breaking") is not None
+    ):
         return False
     summary = header_match.group("summary")
 
@@ -969,8 +1052,6 @@ def _validate_descriptive_body(
     label: str,
     summary: str | None,
     metadata_candidate_bounds: tuple[int, int] | None,
-    metadata_bounds: tuple[int, int] | None,
-    metadata_records: Sequence[dict[str, str]] | None,
     validation_indexes: set[int],
     validation_context_prefixes: Sequence[str],
 ) -> list[str]:
@@ -1026,9 +1107,7 @@ def _validate_descriptive_body(
             f"{label} body repeats the header summary without enough additional context. "
             "Explain enough context to understand the change without reading its diff."
         )
-    elif descriptive_word_count < _MIN_BODY_WORDS and not (
-        metadata_bounds is not None and _has_generated_dependency_context(context, metadata_records)
-    ):
+    elif descriptive_word_count < _MIN_BODY_WORDS:
         errors.append(
             f"{label} body must contain meaningful context "
             f"({_MIN_BODY_WORDS} or more prose words outside headings, validation, "
@@ -1042,20 +1121,12 @@ def _line_length_errors(
     *,
     label: str,
     metadata_bounds: tuple[int, int] | None = None,
-    generated_header: bool = False,
 ) -> list[str]:
     """Validate wrappable prose while tolerating mechanical Markdown structures."""
-    if generated_header:
-        # Dependabot's signed, metadata-backed messages are generated records;
-        # preserve their canonical summaries and release links verbatim.
-        return []
-
     errors: list[str] = []
     table_lines = _markdown_table_lines(lines)
     for index, line in enumerate(lines):
         line_number = index + 1
-        if index == 0 and generated_header:
-            continue
         if metadata_bounds is not None and metadata_bounds[0] <= index <= metadata_bounds[1]:
             continue
 
@@ -1073,7 +1144,12 @@ def _line_length_errors(
     return errors
 
 
-def validate_message(message: str, *, label: str) -> list[str]:
+def validate_message(
+    message: str,
+    *,
+    label: str,
+    allow_generated_dependency: bool = False,
+) -> list[str]:
     """Validate a full commit message, including its explanatory body."""
     lines = message.strip().splitlines()
     if not lines:
@@ -1087,14 +1163,10 @@ def validate_message(message: str, *, label: str) -> list[str]:
     metadata_candidate_bounds = _generated_metadata_candidate_bounds(lines)
     metadata_bounds = _generated_metadata_bounds(lines)
     metadata_records = _generated_metadata_records(lines, metadata_bounds)
-    (
-        validation_evidence,
-        validation_indexes,
-        validation_context_prefixes,
-        validation_list_item_records,
-    ) = _analyze_validation(lines, metadata_candidate_bounds=metadata_candidate_bounds)
-    generated_dependency_message = metadata_bounds is not None and _has_generated_dependency_header(
-        lines[0], metadata_records
+    generated_dependency_message = (
+        allow_generated_dependency
+        and metadata_bounds is not None
+        and _has_generated_dependency_header(lines[0], metadata_records)
     )
     if (metadata_candidate_bounds is not None and metadata_bounds is None) or (
         metadata_candidate_bounds is None and _contains_generated_metadata_shape(lines)
@@ -1103,40 +1175,45 @@ def validate_message(message: str, *, label: str) -> list[str]:
             f"{label} contains an unrecognized generated dependency metadata block. "
             "Use complete Dependabot fields with single-token values and its signed-off trailer."
         )
+    if generated_dependency_message:
+        return errors
+
+    (
+        validation_evidence,
+        validation_indexes,
+        validation_context_prefixes,
+        validation_list_item_records,
+    ) = _analyze_validation(lines, metadata_candidate_bounds=metadata_candidate_bounds)
+    errors.extend(_raw_html_errors(lines, label=label))
+    errors.extend(_required_section_errors(lines, label=label))
     errors.extend(
         _validate_descriptive_body(
             lines,
             label=label,
             summary=summary,
             metadata_candidate_bounds=metadata_candidate_bounds,
-            metadata_bounds=metadata_bounds,
-            metadata_records=metadata_records,
             validation_indexes=validation_indexes,
             validation_context_prefixes=validation_context_prefixes,
         )
     )
-    if not generated_dependency_message and not validation_evidence:
+    if not validation_evidence:
         errors.append(
             f"{label} must record validation evidence or a specific reason validation "
             "was not run. Include a result such as `uv run make ci: passed` or "
             "`Validation: not run because this changes documentation only`."
         )
-    if (
-        not generated_dependency_message
-        and len(validation_list_item_records) > 1
-        and not all(validation_list_item_records)
-    ):
+    if len(validation_list_item_records) > 1 and not all(validation_list_item_records):
         errors.append(
-            f"{label} records multiple validation results outside separate top-level "
-            "`- ` list items. Put each result in its own item under a `## Validation` "
-            "heading so rendered history keeps the results separate."
+            f"{label} records multiple independent validation commands or results "
+            "outside separate top-level `- ` list items. Put each independent result "
+            "in its own item under a `## Validation` heading so rendered history "
+            "keeps the results separate."
         )
     errors.extend(
         _line_length_errors(
             lines,
             label=label,
             metadata_bounds=metadata_bounds,
-            generated_header=generated_dependency_message,
         )
     )
     return errors
@@ -1184,6 +1261,7 @@ def validate(
     commit_range: str | None,
     commit_file: str | None = None,
     commit_json_file: str | None = None,
+    allow_generated_dependency: bool = False,
 ) -> list[str]:
     """Validate a PR title and/or commit headers and return all errors."""
     messages = list(commits)
@@ -1201,7 +1279,13 @@ def validate(
     if not messages:
         errors.append("No commit headers were found to validate.")
     for index, message in enumerate(messages, start=1):
-        errors.extend(validate_message(message, label=f"Commit {index}"))
+        errors.extend(
+            validate_message(
+                message,
+                label=f"Commit {index}",
+                allow_generated_dependency=allow_generated_dependency,
+            )
+        )
     return errors
 
 
@@ -1227,6 +1311,11 @@ def _parser() -> argparse.ArgumentParser:
         "--commit-json-file",
         help="JSON file containing an array of full commit messages.",
     )
+    parser.add_argument(
+        "--allow-generated-dependency",
+        action="store_true",
+        help="Trust metadata-backed dependency messages from an authenticated bot event.",
+    )
     return parser
 
 
@@ -1239,6 +1328,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             commit_range=args.commit_range,
             commit_file=args.commit_file,
             commit_json_file=args.commit_json_file,
+            allow_generated_dependency=args.allow_generated_dependency,
         )
     except RuntimeError as exc:
         print(f"::error::{exc}", file=sys.stderr)

--- a/tests/unit/test_conventional_commits.py
+++ b/tests/unit/test_conventional_commits.py
@@ -1,25 +1,77 @@
 import re
 from pathlib import Path
 
-from scripts.check_conventional_commits import _ALLOWED_TYPES, validate_header, validate_message
+import pytest
+
+from scripts.check_conventional_commits import (
+    _ALLOWED_TYPES,
+    main,
+    validate_header,
+    validate_message,
+)
 
 ROOT = Path(__file__).parents[2]
 LAYOUT_ERROR = [
-    "Commit records multiple validation results outside separate top-level "
-    "`- ` list items. Put each result in its own item under a `## Validation` "
-    "heading so rendered history keeps the results separate."
+    "Commit records multiple independent validation commands or results outside "
+    "separate top-level `- ` list items. Put each independent result in its own item "
+    "under a `## Validation` heading so rendered history keeps the results separate."
 ]
 
 
 def _policy_message(validation: str) -> str:
+    validation_section = (
+        validation if validation.startswith("## Validation") else f"## Validation\n\n{validation}"
+    )
     return f"""\
 refactor: preserve validation evidence structure
 
-Keep commit history readable across Git and rendered GitHub views while
-retaining durable compatibility context for every logical change.
+## Summary
 
-{validation}
+- Keep commit history readable across Git and rendered GitHub views.
+
+## Boundaries and compatibility
+
+- Retain durable compatibility context for every logical change.
+
+## Investigation
+
+- Exercise the commit-message checker independently of pull requests.
+
+{validation_section}
 """
+
+
+def _single_dependabot_message(body: str | None = None) -> str:
+    generated_body = (
+        body
+        or """\
+Bumps [example-package](https://example.com/package) from 1.0.0 to 1.0.1.
+- [Release notes](https://example.com/package/releases)
+- [Commits](https://example.com/package/compare/1.0.0...1.0.1)"""
+    )
+    return f"""\
+chore(deps): bump example-package from 1.0.0 to 1.0.1
+
+{generated_body}
+
+---
+updated-dependencies:
+- dependency-name: example-package
+  dependency-version: 1.0.1
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+"""
+
+
+def _dependabot_errors(message: str, *, trusted: bool = False) -> list[str]:
+    return validate_message(
+        message,
+        label="Dependabot commit",
+        allow_generated_dependency=trusted,
+    )
 
 
 def test_documented_commit_types_match_the_checker() -> None:
@@ -36,14 +88,7 @@ def test_release_is_an_accepted_commit_type() -> None:
 
 
 def test_single_inline_validation_result_remains_valid() -> None:
-    message = """\
-docs: clarify commit validation policy
-
-Explain how durable commit messages should present validation evidence.
-Keep the complete template optional for small documentation changes.
-
-Validation: uv run pytest: 4 passed.
-"""
+    message = _policy_message("uv run pytest: 4 passed.")
 
     assert validate_message(message, label="Commit") == []
 
@@ -63,8 +108,19 @@ def test_repeated_inline_validation_results_are_rejected() -> None:
     message = """\
 refactor: preserve validation evidence structure
 
-Keep commit history readable when a material change records results from
-multiple independent quality gates and compatibility environments.
+## Summary
+
+- Keep commit history readable across rendered GitHub views.
+
+## Boundaries and compatibility
+
+- Record independent quality gates without collapsing their results.
+
+## Investigation
+
+- Exercise repeated validation records in the commit-message checker.
+
+## Validation
 
 Validation: 859 tests passed on Pydantic 2.13.4.
 Validation: 859 tests passed on Pydantic 2.12.3.
@@ -127,7 +183,11 @@ refactor: preserve validation evidence structure
 
 ## Boundaries and compatibility
 
-- Preserve concise unstructured messages for genuinely small changes.
+- Preserve proportional detail for genuinely small changes.
+
+## Investigation
+
+- Exercise the canonical tracked commit layout.
 
 ## Validation
 
@@ -159,7 +219,6 @@ def test_render_unsafe_list_markers_are_rejected() -> None:
 1234567890. Python tests: passed.
 1234567891. Strict docs: passed.
 """,
-        "## Validation\n\n \t- Python tests: passed.\n \t- Strict docs: passed.",
         "## Validation\n\n-\N{NO-BREAK SPACE}Python tests: passed.\n"
         "-\N{NO-BREAK SPACE}Strict docs: passed.",
         "Validation: Python tests passed.\n2. Strict docs passed.\n3. Package build passed.",
@@ -171,18 +230,6 @@ def test_render_unsafe_list_markers_are_rejected() -> None:
         "1. Validation: Python tests passed.\n2. Validation: Strict docs passed.",
         "1. uv run pytest: 4 passed.\n2. uv run make docs: passed.",
         "1) uv run pytest: 4 passed.\n2) uv run make docs: passed.",
-        """\
-## Validation
-
-<!--
-- hidden owner one
--->
-`uv run pytest`: 859 passed.
-<!--
-- hidden owner two
--->
-`uv run make docs`: passed.
-""",
     )
 
     for validation in candidates:
@@ -190,15 +237,14 @@ def test_render_unsafe_list_markers_are_rejected() -> None:
 
 
 def test_indented_code_is_not_accepted_as_a_validation_list() -> None:
-    validation = """\
-## Validation
+    candidates = (
+        "## Validation\n\n    - Python tests: passed.\n    - Strict docs: passed.",
+        "## Validation\n\n \t- Python tests: passed.\n \t- Strict docs: passed.",
+    )
 
-    - Python tests: passed.
-    - Strict docs: passed.
-"""
-
-    errors = validate_message(_policy_message(validation), label="Commit")
-    assert any("must record validation evidence" in error for error in errors)
+    for validation in candidates:
+        errors = validate_message(_policy_message(validation), label="Commit")
+        assert any("must record validation evidence" in error for error in errors)
 
 
 def test_normative_summary_prose_does_not_count_as_an_executed_result() -> None:
@@ -219,7 +265,17 @@ refactor: preserve validation evidence structure
 Explain the durable parser boundary and retain enough historical context
 for readers who inspect the logical change outside its pull request.
 
-Validation: uv run pytest: 859 passed.
+## Boundaries and compatibility
+
+- Keep normative prose separate from executed validation evidence.
+
+## Investigation
+
+- Exercise validation-like words in the summary section.
+
+## Validation
+
+uv run pytest: 859 passed.
 """
 
     assert validate_message(message, label="Commit") == []
@@ -252,7 +308,7 @@ def test_one_command_summary_remains_one_validation_result() -> None:
         assert validate_message(_policy_message(validation), label="Commit") == []
 
 
-def test_valid_dependabot_message_keeps_generated_summary_lines() -> None:
+def test_authenticated_grouped_dependabot_message_skips_human_body_policy() -> None:
     message = """\
 chore(actions): bump the github-actions group with 3 updates
 
@@ -262,6 +318,14 @@ Updates `actions/checkout` from 7.0.0 to 7.0.1
 - [Release notes](https://github.com/actions/checkout/releases)
 - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
 - [Commits](https://github.com/actions/checkout/compare/v7...3d3c42e5aac5ba805825da76410c181273ba90b1)
+
+Updates `astral-sh/setup-uv` from 9.0.0 to 10.0.1
+- [Release notes](https://github.com/astral-sh/setup-uv/releases)
+- [Commits](https://github.com/astral-sh/setup-uv/compare/9...10)
+
+Updates `pypa/gh-action-pypi-publish` from 1.14.1 to 1.14.2
+- [Release notes](https://github.com/pypa/gh-action-pypi-publish/releases)
+- [Commits](https://github.com/pypa/gh-action-pypi-publish/compare/1.14.1...1.14.2)
 
 ---
 updated-dependencies:
@@ -285,4 +349,244 @@ updated-dependencies:
 Signed-off-by: dependabot[bot] <support@github.com>
 """
 
-    assert validate_message(message, label="Dependabot commit") == []
+    assert _dependabot_errors(message, trusted=True) == []
+    assert any(
+        "must contain exactly these second-level headings" in error
+        for error in _dependabot_errors(message)
+    )
+
+    noncanonical_body = message.replace(
+        "Updates `pypa/gh-action-pypi-publish` from 1.14.1 to 1.14.2",
+        "<details>Noncanonical upstream prose that the trusted path intentionally "
+        "ignores despite this deliberately overlong generated line.</details>",
+    )
+    assert _dependabot_errors(noncanonical_body, trusted=True) == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        """\
+Bumps [example-package](https://example.com/package) from 1.0.0 to 1.0.1.
+
+| Package | From | To |
+| --- | --- | --- |
+| example-package | 1.0.0 | 1.0.1 |""",
+        """\
+Bumps [example-package](https://example.com/package) from 1.0.0 to 1.0.1.
+- [Release notes](https://example.com/package/releases)
+- [Upgrade guide](https://example.com/package/upgrade)""",
+        """\
+Bumps [example-package](https://example.com/package) from 1.0.0 to 1.0.1.
+- [Release notes](https://example.com/package/releases)""",
+        """\
+Bumps [example-package](https://example.com/package) from 1.0.0 to 1.0.1 to
+address a security vulnerability in the dependency tree.""",
+    ),
+    ids=("table", "upgrade-guide", "without-commits-link", "security-sentence"),
+)
+def test_authenticated_dependabot_accepts_current_upstream_body_variants(body: str) -> None:
+    message = _single_dependabot_message(body)
+
+    assert _dependabot_errors(message, trusted=True) == []
+    assert any(
+        "must contain exactly these second-level headings" in error
+        for error in _dependabot_errors(message)
+    )
+
+
+def test_authenticated_dependabot_still_requires_canonical_identity_metadata() -> None:
+    valid = _single_dependabot_message()
+
+    candidates = (
+        valid.replace("chore(deps):", "feat(deps):"),
+        valid.replace("chore(deps):", "chore(other):"),
+        valid.replace("Signed-off-by: dependabot[bot]", "Signed-off-by: automation[bot]"),
+        valid.replace("Signed-off-by: dependabot[bot]", " Signed-off-by: dependabot[bot]"),
+        valid.replace("  update-type: version-update:semver-patch\n", ""),
+        valid.replace(
+            "  dependency-version: 1.0.1",
+            "  dependency-version: 1.0.2",
+        ),
+    )
+
+    for candidate in candidates:
+        errors = _dependabot_errors(candidate, trusted=True)
+        assert any("must contain exactly these second-level headings" in error for error in errors)
+
+
+def test_generated_dependency_cli_flag_is_explicit(capsys: pytest.CaptureFixture[str]) -> None:
+    message = _single_dependabot_message()
+
+    assert main(["--commit", message]) == 1
+    capsys.readouterr()
+    assert main(["--commit", message, "--allow-generated-dependency"]) == 0
+
+
+def test_required_sections_must_be_exact_complete_and_ordered() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    candidates = (
+        valid.replace("## Investigation\n\n", ""),
+        valid.replace("## Summary", "## Overview"),
+        valid.replace(
+            "## Investigation",
+            "## Investigation\n\n- Duplicate context.\n\n## Investigation",
+        ),
+        valid.replace(
+            "## Summary\n\n- Keep commit history readable across Git and rendered GitHub views.\n\n"
+            "## Boundaries and compatibility",
+            "## Boundaries and compatibility\n\n"
+            "- Retain durable compatibility context for every logical change.\n\n"
+            "## Summary",
+        ),
+    )
+
+    for candidate in candidates:
+        errors = validate_message(candidate, label="Commit")
+        assert any("must contain exactly these second-level headings" in error for error in errors)
+
+
+def test_rendered_noncanonical_h2s_are_rejected() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    additions = (
+        "##\tExtra\n\n- Tab-delimited heading.",
+        *(f"{' ' * width}## Extra\n\n- Indented heading." for width in range(1, 4)),
+        "##",
+        "Extra\n-----",
+    )
+
+    for addition in additions:
+        errors = validate_message(f"{valid}\n{addition}\n", label="Commit")
+        assert any("must contain exactly these second-level headings" in error for error in errors)
+
+
+def test_h3_and_code_examples_do_not_create_extra_h2s() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    additions = (
+        "### Extra context\n\n- A third-level heading remains ordinary section content.",
+        "```markdown\n## Extra\n\nExtra\n-----\n```",
+        "    ## Extra\n    Extra\n    -----",
+    )
+
+    for addition in additions:
+        assert validate_message(f"{valid}\n{addition}\n", label="Commit") == []
+
+
+def test_body_cannot_have_a_nonblank_preamble_before_summary() -> None:
+    message = _policy_message("uv run pytest: 4 passed.").replace(
+        "## Summary",
+        "Preamble text that would be detached from the required record.\n\n## Summary",
+    )
+
+    assert (
+        "Commit body must begin with '## Summary'; remove the nonblank preamble."
+        in validate_message(message, label="Commit")
+    )
+
+
+def test_required_headings_cannot_hide_in_markdown_structure() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    candidates = (
+        valid.replace("## Summary", "> ## Summary"),
+        valid.replace("## Summary", "  ## Summary"),
+        valid.replace("## Summary", "- Nested record\n  ## Summary"),
+        valid.replace("## Summary", "```text\n```not-a-closing-fence\n## Summary"),
+        valid.replace("## Summary", "````text\n```\n## Summary"),
+        valid.replace("## Summary", "```text\n~~~\n## Summary"),
+        valid.replace("## Summary", "```text\n    ```\n## Summary"),
+    )
+
+    for candidate in candidates:
+        errors = validate_message(candidate, label="Commit")
+        assert any("must contain exactly these second-level headings" in error for error in errors)
+
+
+def test_raw_html_policy_preserves_headers_autolinks_and_code() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    investigation = "- Exercise the commit-message checker independently of pull requests."
+    candidates = (
+        valid.replace(
+            "refactor: preserve validation evidence structure",
+            "docs: explain <details> syntax",
+        ),
+        valid.replace(
+            investigation,
+            "- Inspect <https://example.com> as a normal Markdown autolink.",
+        ),
+        valid.replace(
+            investigation,
+            "```html\n<!--\n<details></details>\n--!>\n```` \t\n\n" + investigation,
+        ),
+        valid.replace(
+            investigation,
+            "    <!-- literal comment -->\n    <details></details>\n\n" + investigation,
+        ),
+    )
+
+    for message in candidates:
+        assert validate_message(message, label="Commit") == []
+
+
+def test_raw_html_outside_code_is_rejected() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    summary = "- Keep commit history readable across Git and rendered GitHub views."
+    investigation = "- Exercise the commit-message checker independently of pull requests."
+    candidates = (
+        valid.replace("## Summary", "<pre>\n## Summary"),
+        valid.replace("## Summary", "<pre\n## Summary\n>"),
+        valid.replace("## Summary", "--!>\n## Summary"),
+        valid.replace(summary, "<details></details>"),
+        valid.replace(summary, "<!--\n## Hidden summary\n--!>"),
+        valid.replace(investigation, "<!-- hidden context -->\n" + investigation),
+        valid.replace(investigation, "<!DOCTYPE html>\n" + investigation),
+    )
+
+    for message in candidates:
+        errors = validate_message(message, label="Commit")
+        assert any(
+            "contains raw HTML outside a fenced or indented code block" in error for error in errors
+        )
+
+    details_errors = validate_message(candidates[3], label="Commit")
+    assert any(
+        "section '## Summary' must contain rendered alphanumeric prose" in error
+        for error in details_errors
+    )
+
+
+def test_required_sections_must_contain_meaningful_content() -> None:
+    valid = _policy_message("uv run pytest: 4 passed.")
+    contents = {
+        "## Summary": "- Keep commit history readable across Git and rendered GitHub views.",
+        "## Boundaries and compatibility": (
+            "- Retain durable compatibility context for every logical change."
+        ),
+        "## Investigation": (
+            "- Exercise the commit-message checker independently of pull requests."
+        ),
+        "## Validation": "uv run pytest: 4 passed.",
+    }
+
+    for heading, content in contents.items():
+        message = valid.replace(f"{heading}\n\n{content}", heading)
+        errors = validate_message(message, label="Commit")
+        assert any(
+            f"Commit section {heading!r} must contain rendered alphanumeric prose" in error
+            for error in errors
+        )
+
+    content_free = (
+        ("## Summary", contents["## Summary"], "---"),
+        ("## Summary", contents["## Summary"], "!!!"),
+        ("## Summary", contents["## Summary"], "[]()"),
+        ("## Investigation", contents["## Investigation"], "[parser]: https://example.com"),
+        ("## Investigation", contents["## Investigation"], "```text\n```"),
+        ("## Validation", contents["## Validation"], "&nbsp;"),
+    )
+    for heading, content, replacement in content_free:
+        message = valid.replace(f"{heading}\n\n{content}", f"{heading}\n\n{replacement}")
+        errors = validate_message(message, label="Commit")
+        assert any(
+            f"Commit section {heading!r} must contain rendered alphanumeric prose" in error
+            for error in errors
+        )

--- a/tests/unit/test_release_workflow_contract.py
+++ b/tests/unit/test_release_workflow_contract.py
@@ -188,3 +188,9 @@ def test_commit_message_checkout_does_not_persist_credentials() -> None:
     assert "persist-credentials: false" in workflow[checkout:validation_step]
     assert "github.event.repository.default_branch" in workflow[checkout:validation_step]
     assert "github.event.pull_request.head.sha" not in workflow[checkout:validation_step]
+    assert "PR_AUTHOR: ${{ github.event.pull_request.user.login }}" in workflow
+    assert "PUSH_ACTOR: ${{ github.actor }}" in workflow
+    assert 'if [ "$PR_AUTHOR" = "dependabot[bot]" ]' in workflow
+    assert 'if [ "$PUSH_ACTOR" = "dependabot[bot]" ]' in workflow
+    assert workflow.count("generated_dependency_flag+=(--allow-generated-dependency)") == 2
+    assert workflow.count('"${generated_dependency_flag[@]}"') == 3


### PR DESCRIPTION
## Problem

The tracked commit template described useful sections but left them optional, so flat and poorly rendered validation records could pass policy. The checker also needed a safe exception for Dependabot's generated messages without parsing every upstream body variation.

## Approach

- Require the exact `Summary`, `Boundaries and compatibility`, `Investigation`, and `Validation` sections for every retained human-authored commit.
- Reject noncanonical rendered H2 forms, hidden or empty sections, raw HTML outside code blocks, and repeated independent validation results that do not use separate list items.
- Permit canonical Dependabot messages only when the protected workflow authenticates the bot event and the commit retains its configured header, complete metadata, and exact sign-off.
- Keep the root and rendered contributor guides synchronized and make the tracked template normative.

## Compatibility

The rule is prospective; existing history is not rewritten. One clean aggregate validation result remains valid, and current Dependabot body formats remain accepted through the authenticated exception.

## Validation

- `uvx --from "uv==0.12.5" uv run --no-sync make ci`: 946 tests passed with 95.93% coverage; Ruff, ty, strict mypy, and Vulture passed.
- `uvx --from "uv==0.12.5" uv run --no-sync make docs-build-strict`: passed.
- `zizmor --pedantic .github/workflows`: no findings; two documented ignores remain.
- Focused commit/workflow contract suite: 35 passed.
- Historical Dependabot commit `6c35562` passes only with the authenticated flag.
- `git diff --check`: passed.

Closes #144