### PR TITLE
fix(runtime): preserve canonical Python transition values

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -59,6 +59,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collectable, subclasses do not inherit defaults, and a rebuilt replacement
   can atomically take over only after the selected family graph contains an
   invalid compiled component.
+- Corrected the pre-1.0 canonical callback seam so migrations receive detached,
+  validated Python scalars, mapping keys, and exact built-in container kinds;
+  secrets no longer become display masks before a transition, strict models
+  can validate their own values, and JSON conversion occurs only at final
+  target serialization. `use_enum_values=True` repair runs only when the
+  stored raw value cannot validate unchanged; enum-bearing unions preserve an
+  exact raw-compatible arm or fail closed rather than changing Python type.
+  Carrier-backed set and mapping-key equality collapses are rejected at the
+  exact canonical before/core collection branch that loses data, even when an
+  application wrap validator catches the underlying validation error; valid
+  alternate union arms and deliberate application before, plain, after, and
+  wrap validator outputs remain Pydantic-owned. Exact-instance revalidation
+  now preserves excluded state, allowed extras, nested instance policy, and
+  `model_fields_set` before the declared transition projection. Schema-only
+  serializer, computed-field, and JSON Schema subtrees cannot activate runtime
+  bridges, private hash carriers cannot escape through `Any`, and adapted
+  validation fails closed for overridden or wrapped authoritative validation
+  entry points. Historical rendering now removes child version metadata
+  reliably from decorator-discovered families nested through unordered
+  containers, regardless of set iteration order.
 - Scoped generated set-element models and cached render validators to their
   owning compiled family, preventing temporary families from accumulating in
   process-global caches while preserving stable identities and thread-safe

--- a/docs/guide/application-exchange.md
+++ b/docs/guide/application-exchange.md
@@ -282,5 +282,5 @@ The same primitives support several deployments:
   version shared during the rollout.
 
 The integration suite exercises the independent producer/consumer file exchange
-as executable documentation. A future capability or negotiation API should be
-based on repeated real application code rather than required for this workflow.
+as executable documentation. Capability advertisement and negotiation remain
+application-owned; this workflow requires no library transport API.

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -216,17 +216,39 @@ do. It contains safe schema paths and conditional templates, never actual list
 indices, mapping keys, values, exception messages, or timing data. Creating or
 serializing a plan does not emit logs.
 
-An execution trace records what actually happened for one payload. Structured
-per-step traces are separate later work. Until then,
-`VersionedValidation.migrations_applied` remains the compatibility view of
-top-level custom upgrades that completed; it intentionally excludes implicit
-identity steps.
+An execution trace would record what happened for one payload, but structured
+per-step traces are not part of this API. `VersionedValidation.migrations_applied`
+is the compatibility view of top-level custom upgrades that completed; it
+intentionally excludes implicit identity steps.
 
-## Return values
+## Transition payload contract
 
-Migration functions receive a fresh dictionary using current field names and
-must return a dictionary. Returning any other type raises
+Upgrade and downgrade functions receive the same private canonical payload: a
+fresh dictionary using current field names, built from declared values that
+have already crossed the source model's Pydantic validation boundary. This is a
+Python-value contract rather than a serialized JSON shape:
+
+- validated scalars and mapping keys retain their Python values;
+- exact built-in `list`, `tuple`, `set`, and `frozenset` values retain their
+  container kinds;
+- source model and field serializers are not invoked, so values such as
+  secrets are not replaced by their display or wire representation;
+- caller-owned built-in mappings and containers are detached recursively before
+  a callback can mutate them; and
+- fields omitted by `Field(exclude=True)` or `exclude_if`, historical removals,
+  allowed extras, and subclass-only fields are not transition input.
+
+The same rules apply while validating old input forward and while rendering
+current data backward. JSON conversion occurs only after the selected target
+model has validated the completed transition payload. Pydantic's selected
+application validators keep their native results, while a conversion that
+cannot preserve set or mapping-key cardinality, a stored enum value's Python
+shape, or a private hash-required mapping representation fails with
 `InvalidMigrationError`.
+
+Migration functions must return a dictionary. Returning any other type raises
+`InvalidMigrationError`; exceptions raised by the callback itself propagate
+unchanged.
 
 Downgrade declarations and historical rendering across value-changing upgrades
 are executed natively by the active conversion contract. A missing downgrade

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -86,12 +86,60 @@ validators, alias priority, defaults, and constraints apply before any
 downgrade. An already-constructed instance of the authoritative model is
 handled according to that model's Pydantic `revalidate_instances` policy, so
 the default avoids duplicate validation while an opt-in revalidation policy is
-still enforced.
+still enforced. Revalidation receives a detached copy of the complete
+top-level instance state, including excluded declared values and allowed
+extras, while nested model and dataclass instances retain their native
+Pydantic instance semantics. Only the later transition projection omits those
+private values. A model whose canonical bridge would bypass an overridden
+`model_validate` or wrapped `__pydantic_validator__` fails closed.
 
-Rendering extracts declared fields into a private JSON-shaped payload without
-flattening allowed extras, accepting subclass-only fields, or invoking model
-and field serializers. Mutations made by a downgrade therefore cannot reach
-caller-owned nested mappings or collections.
+### Transition payload during rendering
+
+Downgrades use the shared [transition payload
+contract](migrations.md#transition-payload-contract). Rendering extracts
+declared fields into a private Python-value canonical
+mapping without flattening allowed extras, accepting subclass-only fields, or
+invoking model and field serializers. Validated scalars and mapping keys retain
+their Python values, and exact built-in `list`, `tuple`, `set`, and `frozenset`
+containers retain their kinds. Caller-owned mappings and containers are copied
+recursively, so mutations made by a downgrade cannot reach them. Pydantic
+converts values to JSON only when the validated target wire model is finally
+serialized. Cycles encountered while extracting caller-owned models cannot
+form this detached tree and fail through the authoritative validation boundary
+instead of recursing; a migration may still deliberately create a cycle for a
+native target arm such as `Any`.
+
+### Enums and application validators
+
+With `use_enum_values=True`, callbacks receive the raw value stored by
+Pydantic. A direct enum or enum-valued Literal retries its declared member only
+after native validation rejects that raw value. Ordinary unions do not repair
+individual arms: Pydantic keeps its native arm and validator selection (so
+`Mode | str` retains the raw string arm), and canonical validation fails closed
+if a successful selection would instead change an erased enum's Python type or
+container shape. A selected application-owned `BeforeValidator`,
+`PlainValidator`, `AfterValidator`, or `WrapValidator` keeps its native result,
+including deliberate nested value or container edits, and executes once.
+Failed and unselected application arms cannot authorize another arm's result.
+Ordinary Literal coercion remains Pydantic-owned.
+
+### Sets and mapping keys
+
+Private identity-based mapping carriers keep projected models distinct inside
+sets and mapping-key positions while callbacks run. Canonical guards reject a
+carrier-backed cardinality collapse in a field before-validator or in the
+declared set, frozenset, or mapping-key parser; another non-lossy union arm may
+still succeed. An application wrap validator cannot swallow that core-loss
+invariant, but its output remains native when no guarded parse loses a carrier.
+Callback-supplied iterables and coercive scalar collection edits without
+private carriers retain Pydantic's native behavior. Dataclass construction and
+collection semantics likewise remain Pydantic-owned rather than gaining a
+separate canonical reconstruction contract. A carrier that reaches a non-hash
+`Any` position becomes an ordinary `dict` before it can enter a public model.
+Opaque hash positions such as `set[Any]` and `dict[Any, ...]` fail closed when
+only the private carrier could keep a projected mapping hashable.
+
+### Target validation boundaries
 
 An unrelated `BaseModel` is accepted only when its declared structure validates
 as current input. Otherwise Pydantic raises a validation error for the
@@ -99,10 +147,12 @@ authoritative current model. Package-generated current wire instances also
 remain renderable, including hashable set projections that the original model
 annotation cannot construct directly.
 
-If that set bridge is required, an enclosing model with a custom `__init__`
-fails closed with `UnsupportedWireModelError`. Pydantic validators and
-`model_post_init` retain their exact model type and once-only lifecycle; a
-custom initializer cannot be replayed without re-entering field validation.
+If that bridge is required, an enclosing model with a custom `__init__`, a
+nonstandard `__new__`, an overridden `model_validate`, or a wrapped
+`__pydantic_validator__` fails closed with `UnsupportedWireModelError`.
+Pydantic validators and `model_post_init` retain their exact model type and
+once-only lifecycle; custom construction and validation entry points cannot be
+replayed without bypassing or re-entering field validation.
 
 Fields removed in the target version are dropped before historical validation.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -582,12 +582,19 @@ class VersionedValidation[T: BaseModel]:
   - `DuplicateSchemaVersionError`
   - `InvalidMigrationError`
 
-`UnsupportedWireModelError` reports that automatic projection cannot safely
-produce the required object-shaped Pydantic v2 wire contract. It is raised
-during compilation and includes safe family, model, and unsupported-reason
-context, plus the version for projection-specific failures. Direct validation
-of a successfully generated wire model still raises Pydantic's native
-`ValidationError`.
+`UnsupportedWireModelError` reports that automatic projection or canonical
+validation cannot preserve the required Pydantic behavior safely. Most
+declaration and projection failures are raised during compilation with safe
+family, model, unsupported-reason, and, when applicable, version context.
+`validate()` or `dump()` can also raise it when a required canonical adapter
+would bypass an overridden `model_validate`, a wrapped
+`__pydantic_validator__`, or a nonstandard construction boundary.
+
+Ordinary Pydantic input failures remain native `ValidationError` instances.
+Loss of canonical set or mapping-key cardinality, a stored enum value's Python
+shape, or a private hash-required mapping representation raises
+`InvalidMigrationError`. Direct validation of a successfully generated wire
+model also retains Pydantic's native `ValidationError` behavior.
 
 See the [stability and compatibility policy](stability-policy.md) for the exact
 public/private boundary and the Semantic Versioning rules applied to this API.

--- a/docs/reference/stability-policy.md
+++ b/docs/reference/stability-policy.md
@@ -43,6 +43,9 @@ documented behavior of:
 - historical defaults, removals, and renames;
 - upgrade and downgrade ordering;
 - nested-family conversion;
+- transition callbacks receiving detached, declared, already-validated Python
+  values, including exact built-in container kinds, without invoking source
+  serializers or admitting excluded, extra, or subclass-only fields;
 - exact, lossy, and unavailable rendering semantics; and
 - validation into the authoritative current Pydantic model.
 

--- a/src/pydantic_versions/_compiler.py
+++ b/src/pydantic_versions/_compiler.py
@@ -126,10 +126,15 @@ class _CompiledDecoratorNestedFamily:
 
 
 class _CompiledFamilyRuntimeCache:
-    __slots__ = ("adapter", "lock")
+    __slots__ = ("adapter", "canonical_adapters", "guarded_adapter", "lock")
 
     def __init__(self) -> None:
         self.adapter: object | None = None
+        self.guarded_adapter: object | None = None
+        self.canonical_adapters: dict[
+            tuple[type[BaseModel], bool, bool],
+            tuple[object, object | None],
+        ] = {}
         self.lock = Lock()
 
 

--- a/src/pydantic_versions/_runtime.py
+++ b/src/pydantic_versions/_runtime.py
@@ -6,34 +6,32 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    get_args,
 )
 
 from pydantic import BaseModel
 
-from pydantic_versions._compiler import _CompiledFamily
+from pydantic_versions._compiler import _CompiledFamily, _CompiledFamilyRuntimeCache
 from pydantic_versions._runtime_decorators import (
     _decorator_collection_kind,
     _decorator_selections_child_first,
     _decorator_selections_parent_first,
-    _decorator_set_cardinalities,
     _DecoratorRouteSelection,
-    _materialize_selected_decorator_models,
     _normalize_decorator_value,
     _normalize_selected_decorator_payloads,
     _payload_at_location,
     _reconcile_decorator_selections,
     _refresh_decorator_selection_identities,
-    _refresh_decorator_selection_identity,
+    _route_has_non_child_mapping_arm,
     _select_decorator_routes,
     _serialized_decorator_selection_location,
-    _transform_payload_at_location,
-    _walk_decorator_payload_candidates,
+    _transform_payload_at_locations,
 )
 from pydantic_versions._runtime_nested import (
     _apply_nested_family_migrations,
     _convert_nested_family_payload,
     _declared_nested_version_metadata,
-    _nested_family_collection_kind,
+    _normalize_validated_explicit_nested_payloads,
     _preflight_nested_version_metadata,
     _preflight_validation_route,
     _project_nested_family_payload,
@@ -45,11 +43,10 @@ from pydantic_versions._runtime_nested import (
     _verify_validated_family_version_metadata,
 )
 from pydantic_versions._runtime_payload import (
-    _declared_payload_occurrences_at_path,
-    _explicit_runtime_body_model,
     _extract_declared_fields,
     _extract_preflight_fields,
-    _runtime_nested_structural_occurrences,
+    _preserve_canonical_mapping_copy,
+    _strip_annotated,
 )
 from pydantic_versions._runtime_render import (
     _copy_render_input,
@@ -57,6 +54,12 @@ from pydantic_versions._runtime_render import (
     _validate_base_model_render_metadata,
     _validate_current_render_metadata,
     _without_family_render_metadata,
+)
+from pydantic_versions._runtime_validation import (
+    _contains_hashable_canonical_mapping,
+    _revalidate_canonical_model_instance,
+    _validate_canonical_adapter_payload,
+    _validate_canonical_model,
 )
 from pydantic_versions._runtime_versioning import (
     _apply_serialized_version_metadata,
@@ -123,7 +126,17 @@ def _validate_family[T: BaseModel](
         parent_label=source_version,
     )
     source = compiled.version(source_version)
-    source_model = source.model.model_validate(data)
+    if isinstance(data, source.model) and _model_instance_requires_revalidation(
+        source.model,
+        data,
+    ):
+        source_model = _revalidate_canonical_model_instance(
+            source.model,
+            data,
+            cache=compiled._runtime_cache,
+        )
+    else:
+        source_model = source.model.model_validate(data)
     _validate_explicit_nested_runtime_shapes(
         source_model,
         compiled=compiled,
@@ -156,8 +169,15 @@ def _validate_family[T: BaseModel](
     payload = _to_current_names(
         compiled,
         source,
-        _extract_declared_fields(source_model),
+        _extract_declared_fields(source_model, declared_model=source.model),
     )
+    nested_payload_is_canonical = source.wire_model_kind != "explicit"
+    if nested_payload_is_canonical:
+        payload = _normalize_validated_explicit_nested_payloads(
+            payload=payload,
+            compiled=compiled,
+            parent_label=source_version,
+        )
     payload = _normalize_selected_decorator_payloads(
         payload=payload,
         selections=decorator_selections,
@@ -166,7 +186,6 @@ def _validate_family[T: BaseModel](
 
     migrations_applied: list[tuple[str, str]] = []
     source_index = compiled.index(source_version)
-    nested_payload_is_canonical = False
     for transition in compiled.transitions[source_index:]:
         payload = _apply_nested_family_migrations(
             payload=payload,
@@ -213,11 +232,13 @@ def _validate_family[T: BaseModel](
         compiled=compiled,
         discover_new=False,
     )
+    nested_container_ids: set[int] = set()
     payload = _project_nested_family_payloads(
         payload=payload,
         compiled=compiled,
         parent_label=compiled.current_version,
         wire_boundary=False,
+        guarded_container_ids=nested_container_ids,
     )
     payload = _project_selected_decorator_payloads(
         payload=payload,
@@ -225,13 +246,25 @@ def _validate_family[T: BaseModel](
         parent_label=compiled.current_version,
         wire_boundary=False,
     )
-    payload = _materialize_selected_decorator_models(
+    payload, materialized_model_ids = _materialize_selected_decorator_wire_models(
         payload=payload,
         selections=decorator_selections,
+        compiled=compiled,
+        parent_label=compiled.current_version,
+        wire_boundary=False,
     )
-    current_model = family.model.model_validate(
-        _current_validation_input(family.model, payload),
-        by_name=True,
+    current_model = _validate_canonical_model(
+        family.model,
+        _current_validation_input(
+            family.model,
+            payload,
+            tracked_container_ids=nested_container_ids,
+            mapping_copy=_preserve_canonical_mapping_copy,
+        ),
+        cache=compiled._runtime_cache,
+        materialized_model_ids=materialized_model_ids,
+        materialized_container_ids=frozenset(nested_container_ids)
+        | _materialized_hash_container_ids(payload, materialized_model_ids),
     )
     return VersionedValidation(
         source_version=source_version,
@@ -334,15 +367,24 @@ def _dump_family[T: BaseModel](
         compiled=compiled,
         discover_new=False,
     )
+    nested_container_ids: set[int] = set()
     payload = _project_nested_family_payloads(
         payload=payload,
         compiled=compiled,
         parent_label=requested,
         wire_boundary=True,
+        guarded_container_ids=nested_container_ids,
     )
     payload = _project_selected_decorator_payloads(
         payload=payload,
         selections=decorator_selections,
+        parent_label=requested,
+        wire_boundary=True,
+    )
+    payload, materialized_model_ids = _materialize_selected_decorator_wire_models(
+        payload=payload,
+        selections=decorator_selections,
+        compiled=compiled,
         parent_label=requested,
         wire_boundary=True,
     )
@@ -356,20 +398,26 @@ def _dump_family[T: BaseModel](
         else:
             payload[_model_metadata_field_name(compiled)] = requested
 
-    target_payload = _to_version_names(target, payload)
-    target_model = target.model.model_validate(target_payload, by_name=True)
+    target_payload = _to_version_names(
+        target,
+        payload,
+        tracked_container_ids=nested_container_ids,
+        mapping_copy=_preserve_canonical_mapping_copy,
+    )
+    target_model = _validate_canonical_model(
+        target.model,
+        target_payload,
+        cache=compiled._runtime_cache,
+        materialized_model_ids=materialized_model_ids,
+        materialized_container_ids=frozenset(nested_container_ids)
+        | _materialized_hash_container_ids(target_payload, materialized_model_ids),
+    )
     _validate_explicit_nested_runtime_shapes(
         target_model,
         compiled=compiled,
         version=target,
         label=requested,
         recurse_nested_targets=True,
-    )
-    _validate_nested_collection_cardinality(
-        input_payload=target_payload,
-        validated_model=target_model,
-        compiled=compiled,
-        parent_label=requested,
     )
     return _serialize_target_model(
         compiled=compiled,
@@ -574,6 +622,7 @@ def _prune_serialized_decorator_metadata(
     if not selections:
         return
     source_payload = _extract_declared_fields(source_model)
+    source_set_index_cache = {}
     for selection in _decorator_selections_child_first(selections):
         location = _serialized_decorator_selection_location(
             compiled=compiled,
@@ -585,10 +634,19 @@ def _prune_serialized_decorator_metadata(
             continue
         found, payload = _payload_at_location(dumped, location)
         if not found:
-            continue
+            msg = (
+                f"Target serialization for family {compiled.name!r} and version "
+                f"{parent_label!r} omitted managed decorator route "
+                f"{selection.route.path!r}"
+            )
+            raise ValueError(msg)
         source_found, source_value = _payload_at_location(
             source_payload,
             selection.location,
+            _set_index_cache=source_set_index_cache,
+            # Detached identity-hashed sets may iterate differently; keep the
+            # target-model ordinals that address the already serialized payload.
+            _update_set_locations=False,
         )
         if not source_found:
             source_value = selection
@@ -611,7 +669,14 @@ def _validated_current_render_payload[T: BaseModel](
     current_wire = current_version.model
     if isinstance(data, family.model):
         _validate_base_model_render_metadata(compiled, data)
-        current_model = family.model.model_validate(data)
+        if _model_instance_requires_revalidation(family.model, data):
+            current_model = _revalidate_canonical_model_instance(
+                family.model,
+                data,
+                cache=compiled._runtime_cache,
+            )
+        else:
+            current_model = family.model.model_validate(data)
         raw_payload = _extract_declared_fields(
             current_model,
             declared_model=family.model,
@@ -627,17 +692,15 @@ def _validated_current_render_payload[T: BaseModel](
             else _without_family_render_metadata(compiled, raw_payload)
         )
         if isinstance(data, current_wire):
-            current_model = _current_wire_validation_adapter(
-                compiled,
-            ).validate_python(
+            current_model = _validate_canonical_adapter_payload(
+                _current_wire_validation_adapter(
+                    compiled,
+                    guard_collections=_contains_hashable_canonical_mapping(validation_payload),
+                ),
                 validation_payload,
-                by_name=True,
             )
         else:
-            current_model = family.model.model_validate(
-                validation_payload,
-                by_name=True,
-            )
+            current_model = family.model.model_validate(validation_payload)
     elif isinstance(data, Mapping):
         raw_payload = _copy_render_input(data)
         _validate_current_render_metadata(compiled, raw_payload)
@@ -676,32 +739,48 @@ def _validated_current_render_payload[T: BaseModel](
     return payload, selections
 
 
+def _model_instance_requires_revalidation(
+    model: type[BaseModel],
+    value: BaseModel,
+) -> bool:
+    policy = model.model_config.get("revalidate_instances", "never")
+    return policy == "always" or (policy == "subclass-instances" and type(value) is not model)
+
+
 def _apply_selected_decorator_migrations(
     *,
     payload: dict[str, Any],
     selections: tuple[_DecoratorRouteSelection, ...],
     target_label: str,
 ) -> dict[str, Any]:
-    converted = payload
+    pending: list[tuple[_DecoratorRouteSelection, str]] = []
+    transforms = []
     for selection in _decorator_selections_child_first(selections):
         nested_source = selection.label
         nested_target = selection.route.child_label(target_label)
         if nested_source == nested_target:
             continue
-
-        converted = _transform_payload_at_location(
-            converted,
-            location=selection.location,
-            transform=partial(
-                _convert_decorator_value,
-                family=selection.route.family,
-                source_label=nested_source,
-                target_label=nested_target,
-                collection_kind=_decorator_collection_kind(selection.route),
+        pending.append((selection, nested_target))
+        transforms.append(
+            (
+                selection.location,
+                partial(
+                    _convert_decorator_value,
+                    family=selection.route.family,
+                    source_label=nested_source,
+                    target_label=nested_target,
+                    collection_kind=_decorator_collection_kind(selection.route),
+                ),
             ),
         )
+    converted = _transform_payload_at_locations(
+        payload,
+        transforms=tuple(transforms),
+        order="child_first",
+    )
+    for selection, nested_target in pending:
         selection.label = nested_target
-        _refresh_decorator_selection_identity(converted, selection)
+    _refresh_decorator_selection_identities(converted, selections)
     return converted
 
 
@@ -730,23 +809,191 @@ def _project_selected_decorator_payloads(
     parent_label: str,
     wire_boundary: bool,
 ) -> dict[str, Any]:
-    projected = payload
+    transforms = []
     for selection in _decorator_selections_child_first(selections):
         target_label = selection.route.child_label(parent_label)
-
-        projected = _transform_payload_at_location(
-            projected,
-            location=selection.location,
-            transform=partial(
-                _project_decorator_value,
-                family=selection.route.family,
-                target_label=target_label,
-                wire_boundary=wire_boundary,
-                collection_kind=_decorator_collection_kind(selection.route),
+        transforms.append(
+            (
+                selection.location,
+                partial(
+                    _project_decorator_value,
+                    family=selection.route.family,
+                    target_label=target_label,
+                    wire_boundary=wire_boundary,
+                    collection_kind=_decorator_collection_kind(selection.route),
+                ),
             ),
         )
-        _refresh_decorator_selection_identity(projected, selection)
+    projected = _transform_payload_at_locations(
+        payload,
+        transforms=tuple(transforms),
+        order="child_first",
+    )
+    _refresh_decorator_selection_identities(projected, selections)
     return projected
+
+
+def _materialize_selected_decorator_wire_models(
+    *,
+    payload: dict[str, Any],
+    selections: tuple[_DecoratorRouteSelection, ...],
+    compiled: _CompiledFamily,
+    parent_label: str,
+    wire_boundary: bool,
+) -> tuple[dict[str, Any], frozenset[int]]:
+    transforms = []
+    materialized_model_ids: set[int] = set()
+    for selection in _decorator_selections_child_first(selections):
+        if not any(step.kind == "union_arm" for step in selection.route.traversal):
+            continue
+        owner_model = (
+            compiled.model if selection.parent is None else selection.parent.route.family.model
+        )
+        if len(selection.site_routes) == 1 and not _route_has_non_child_mapping_arm(
+            owner_model,
+            selection.route,
+        ):
+            continue
+        child_compiled = selection.route.family._compiled_family()
+        transforms.append(
+            (
+                selection.location,
+                partial(
+                    _materialize_selected_decorator_wire_model,
+                    model=_selected_decorator_wire_model(
+                        compiled=compiled,
+                        parent_label=parent_label,
+                        selection=selection,
+                        wire_boundary=wire_boundary,
+                    ),
+                    cache=child_compiled._runtime_cache,
+                    materialized_model_ids=materialized_model_ids,
+                ),
+            )
+        )
+    materialized = _transform_payload_at_locations(
+        payload,
+        transforms=tuple(transforms),
+        order="child_first",
+    )
+    assert isinstance(materialized, dict)
+    _refresh_decorator_selection_identities(materialized, selections)
+    return materialized, frozenset(materialized_model_ids)
+
+
+def _materialize_selected_decorator_wire_model(
+    value: Any,
+    *,
+    model: type[BaseModel],
+    cache: _CompiledFamilyRuntimeCache,
+    materialized_model_ids: set[int],
+) -> Any:
+    if not isinstance(value, Mapping):
+        return value
+    existing_ids = frozenset(materialized_model_ids)
+    validated = _validate_canonical_model(
+        model,
+        dict(value),
+        cache=cache,
+        materialized_model_ids=existing_ids,
+        materialized_container_ids=_materialized_hash_container_ids(value, existing_ids),
+    )
+    materialized_model_ids.add(id(validated))
+    return validated
+
+
+def _materialized_hash_container_ids(
+    value: Any,
+    materialized_model_ids: frozenset[int],
+) -> frozenset[int]:
+    if not materialized_model_ids:
+        return frozenset()
+    found: set[int] = set()
+    seen: set[int] = set()
+
+    def contains_materialized_hash_value(item: Any) -> bool:
+        if id(item) in materialized_model_ids:
+            return True
+        if isinstance(item, tuple | frozenset):
+            return any(contains_materialized_hash_value(child) for child in item)
+        return False
+
+    def visit(current: Any) -> None:
+        if not isinstance(current, Mapping | list | tuple | set | frozenset):
+            return
+        identity = id(current)
+        if identity in seen:
+            return
+        seen.add(identity)
+        if isinstance(current, set | frozenset):
+            if any(contains_materialized_hash_value(item) for item in current):
+                found.add(identity)
+            for item in current:
+                visit(item)
+            return
+        if isinstance(current, Mapping):
+            if any(contains_materialized_hash_value(key) for key in current):
+                found.add(identity)
+            for key, item in current.items():
+                visit(key)
+                visit(item)
+            return
+        for item in current:
+            visit(item)
+
+    visit(value)
+    return frozenset(found)
+
+
+def _selected_decorator_wire_model(
+    *,
+    compiled: _CompiledFamily,
+    parent_label: str,
+    selection: _DecoratorRouteSelection,
+    wire_boundary: bool,
+) -> type[BaseModel]:
+    if selection.parent is None:
+        owner_compiled = compiled
+        owner_label = parent_label
+        owner_model = (
+            owner_compiled.version(owner_label).model if wire_boundary else owner_compiled.model
+        )
+    else:
+        owner_compiled = selection.parent.route.family._compiled_family()
+        owner_label = selection.parent.label
+        owner_model = _selected_decorator_wire_model(
+            compiled=compiled,
+            parent_label=parent_label,
+            selection=selection.parent,
+            wire_boundary=wire_boundary,
+        )
+
+    owner_target = owner_compiled.version(owner_label)
+    annotation: Any = owner_model
+    for step_index, step in enumerate(selection.route.traversal):
+        normalized = _strip_annotated(annotation)
+        if step.kind == "field":
+            field_name = step.value
+            if wire_boundary and step_index == 0:
+                projected_name = owner_target.projection.field(field_name).version_name
+                assert projected_name is not None
+                field_name = projected_name
+            annotation = normalized.model_fields[field_name].annotation
+            continue
+        arguments = get_args(normalized)
+        if step.kind == "union_arm":
+            annotation = arguments[int(step.value)]
+        elif step.kind == "mapping_values":
+            annotation = arguments[1]
+        elif step.kind == "tuple_index":
+            annotation = arguments[int(step.value)]
+        else:
+            assert step.kind == "each"
+            annotation = arguments[0]
+
+    target_model = _strip_annotated(annotation)
+    assert isinstance(target_model, type) and issubclass(target_model, BaseModel)
+    return target_model
 
 
 def _project_decorator_value(
@@ -781,239 +1028,65 @@ def _preflight_selected_decorator_version_metadata(
     if not isinstance(payload, Mapping):
         return
     canonical = _to_current_names(compiled, parent_version, dict(payload))
+    transforms = []
     for selection in _decorator_selections_parent_first(selections):
         route = selection.route
-        found_raw, raw = _payload_at_location(canonical, selection.location)
-        if not found_raw:
-            continue
-        if isinstance(raw, BaseModel):
-            raw = _extract_preflight_fields(raw)
-        if not isinstance(raw, Mapping):
-            continue
         expected = route.child_label(parent_label)
         child_compiled = route.family._compiled_family()
-        found, declared = _declared_nested_version_metadata(
-            payload=raw,
-            compiled=child_compiled,
-            source_label=expected,
-        )
-        if found and not _matches_version_label(declared, expected):
-            declared_display = _safe_nested_version_display(
-                declared,
-                compiled=child_compiled,
-            )
-            msg = (
-                f"Decorator nested family {route.family.name!r} at path {route.path!r} "
-                f"expects version {expected!r} for parent label {parent_label!r}, "
-                f"but the payload declares {declared_display}"
-            )
-            raise SchemaVersionError(msg)
-        _preflight_nested_version_metadata(
-            payload=raw,
-            compiled=child_compiled,
-            parent_label=expected,
-        )
-        canonical = _transform_payload_at_location(
-            canonical,
-            location=selection.location,
-            transform=partial(
-                _normalize_decorator_value,
-                compiled=child_compiled,
-                child_label=expected,
+        transforms.append(
+            (
+                selection.location,
+                partial(
+                    _preflight_decorator_value,
+                    route=route,
+                    child_compiled=child_compiled,
+                    expected=expected,
+                    parent_label=parent_label,
+                ),
             ),
         )
+    _transform_payload_at_locations(
+        canonical,
+        transforms=tuple(transforms),
+        order="parent_first",
+    )
 
 
-def _validate_nested_collection_cardinality(
+def _preflight_decorator_value(
+    raw: Any,
     *,
-    input_payload: dict[str, Any],
-    validated_model: BaseModel,
-    compiled: _CompiledFamily,
+    route: Any,
+    child_compiled: _CompiledFamily,
+    expected: str,
     parent_label: str,
-) -> None:
-    if not compiled.nested and not compiled.decorator_nested:
-        return
-    target = compiled.version(parent_label)
-    validated_payload = _extract_declared_fields(validated_model)
-    _validate_nested_collection_cardinality_payloads(
-        input_payloads=(input_payload,),
-        validated_payloads=(validated_payload,),
-        input_annotations=(target.model,),
-        validated_annotations=(target.model,),
-        compiled=compiled,
-        parent_label=parent_label,
+) -> Any:
+    if isinstance(raw, BaseModel):
+        raw = _extract_preflight_fields(raw)
+    if not isinstance(raw, Mapping):
+        return raw
+    found, declared = _declared_nested_version_metadata(
+        payload=raw,
+        compiled=child_compiled,
+        source_label=expected,
     )
-
-
-def _validate_nested_collection_cardinality_payloads(
-    *,
-    input_payloads: tuple[Any, ...],
-    validated_payloads: tuple[Any, ...],
-    input_annotations: tuple[Any, ...] | None = None,
-    validated_annotations: tuple[Any, ...] | None = None,
-    compiled: _CompiledFamily,
-    parent_label: str,
-) -> None:
-    target = compiled.version(parent_label)
-    resolved_input_annotations = (
-        (target.model,) * len(input_payloads) if input_annotations is None else input_annotations
-    )
-    resolved_validated_annotations = (
-        (target.model,) * len(validated_payloads)
-        if validated_annotations is None
-        else validated_annotations
-    )
-    for nested in compiled.nested:
-        target_path = _target_nested_path(target, nested.path)
-        input_occurrences = tuple(
-            occurrence
-            for payload, annotation in zip(
-                input_payloads,
-                resolved_input_annotations,
-                strict=True,
-            )
-            for occurrence in _declared_payload_occurrences_at_path(
-                payload,
-                annotation=annotation,
-                path=target_path,
-            )
-        )
-        validated_occurrences = tuple(
-            occurrence
-            for payload, annotation in zip(
-                validated_payloads,
-                resolved_validated_annotations,
-                strict=True,
-            )
-            for occurrence in _declared_payload_occurrences_at_path(
-                payload,
-                annotation=annotation,
-                path=target_path,
-            )
-        )
-        input_values = tuple(value for value, _annotation in input_occurrences)
-        validated_values = tuple(value for value, _annotation in validated_occurrences)
-        collection_kind = _nested_family_collection_kind(
-            model=compiled.model,
-            path=nested.path,
-        )
-        if collection_kind in ("set", "frozenset"):
-            before = sorted(
-                len(value)
-                for value in input_values
-                if isinstance(value, list | tuple | set | frozenset)
-            )
-            after = sorted(
-                len(value)
-                for value in validated_values
-                if isinstance(value, list | tuple | set | frozenset)
-            )
-            collapsed = len(after) < len(before) or any(
-                actual < expected for expected, actual in zip(before, after, strict=False)
-            )
-            if collapsed:
-                msg = (
-                    f"Nested migration for family {nested.family.name!r} cannot "
-                    "preserve set cardinality after target wire validation at path "
-                    f"{nested.path!r}"
-                )
-                raise InvalidMigrationError(msg)
-
-        child_compiled = nested.family._compiled_family()
-        if child_compiled.nested or child_compiled.decorator_nested:
-            child_label = nested.child_label(parent_label)
-            child_model = _explicit_runtime_body_model(
-                child_compiled.version(child_label).model,
-            )
-            child_input_occurrences = tuple(
-                child_occurrence
-                for value, annotation in input_occurrences
-                for child_occurrence in _runtime_nested_structural_occurrences(
-                    value,
-                    annotation=annotation,
-                    model=child_model,
-                )
-            )
-            child_validated_occurrences = tuple(
-                child_occurrence
-                for value, annotation in validated_occurrences
-                for child_occurrence in _runtime_nested_structural_occurrences(
-                    value,
-                    annotation=annotation,
-                    model=child_model,
-                )
-            )
-            _validate_nested_collection_cardinality_payloads(
-                input_payloads=tuple(value for value, _annotation in child_input_occurrences),
-                validated_payloads=tuple(
-                    value for value, _annotation in child_validated_occurrences
-                ),
-                input_annotations=tuple(
-                    annotation for _value, annotation in child_input_occurrences
-                ),
-                validated_annotations=tuple(
-                    annotation for _value, annotation in child_validated_occurrences
-                ),
-                compiled=child_compiled,
-                parent_label=child_label,
-            )
-
-    canonical_input = tuple(
-        _to_current_names(compiled, target, payload) if isinstance(payload, Mapping) else payload
-        for payload in input_payloads
-    )
-    canonical_validated = tuple(
-        _to_current_names(compiled, target, payload) if isinstance(payload, Mapping) else payload
-        for payload in validated_payloads
-    )
-    for route in compiled.decorator_nested:
-        set_steps = tuple(
-            index
-            for index, step in enumerate(route.traversal)
-            if step.kind == "each" and step.value in ("set", "frozenset")
-        )
-        before_maps = tuple(
-            _decorator_set_cardinalities(payload, route) for payload in canonical_input
-        )
-        after_maps = tuple(
-            _decorator_set_cardinalities(payload, route) for payload in canonical_validated
-        )
-        for step_index in set_steps:
-            expected = sorted(
-                value
-                for cardinalities in before_maps
-                for value in cardinalities.get(step_index, ())
-            )
-            actual = sorted(
-                value for cardinalities in after_maps for value in cardinalities.get(step_index, ())
-            )
-            collapsed = len(actual) < len(expected) or any(
-                observed < original for original, observed in zip(expected, actual, strict=False)
-            )
-            if collapsed:
-                msg = (
-                    f"Nested migration for family {route.family.name!r} cannot preserve "
-                    "set cardinality after target wire validation at path "
-                    f"{route.path!r}"
-                )
-                raise InvalidMigrationError(msg)
-
-        child_compiled = route.family._compiled_family()
-        if not child_compiled.nested and not child_compiled.decorator_nested:
-            continue
-        child_input = tuple(
-            value
-            for payload in canonical_input
-            for value, _ in _walk_decorator_payload_candidates(payload, route)
-        )
-        child_validated = tuple(
-            value
-            for payload in canonical_validated
-            for value, _ in _walk_decorator_payload_candidates(payload, route)
-        )
-        _validate_nested_collection_cardinality_payloads(
-            input_payloads=child_input,
-            validated_payloads=child_validated,
+    if found and not _matches_version_label(declared, expected):
+        declared_display = _safe_nested_version_display(
+            declared,
             compiled=child_compiled,
-            parent_label=route.child_label(parent_label),
         )
+        msg = (
+            f"Decorator nested family {route.family.name!r} at path {route.path!r} "
+            f"expects version {expected!r} for parent label {parent_label!r}, "
+            f"but the payload declares {declared_display}"
+        )
+        raise SchemaVersionError(msg)
+    _preflight_nested_version_metadata(
+        payload=raw,
+        compiled=child_compiled,
+        parent_label=expected,
+    )
+    return _normalize_decorator_value(
+        raw,
+        compiled=child_compiled,
+        child_label=expected,
+    )

--- a/src/pydantic_versions/_runtime_decorators.py
+++ b/src/pydantic_versions/_runtime_decorators.py
@@ -18,20 +18,48 @@ from pydantic_versions._compiler import (
 )
 from pydantic_versions._runtime_nested import _normalize_validated_explicit_nested_payloads
 from pydantic_versions._runtime_payload import (
+    _bind_canonical_source_identity,
+    _canonical_source_identities,
     _extract_declared_fields,
+    _hashable_canonical_value,
     _matching_declared_annotation,
+    _rebuild_canonical_set,
     _strip_annotated,
 )
 from pydantic_versions._runtime_versioning import (
-    _current_validation_input,
     _serialized_field_name,
     _to_current_names,
 )
 from pydantic_versions.exceptions import InvalidMigrationError
 
 type _DecoratorDispatchSite = tuple[tuple[str, str], ...]
-type _DecoratorLocation = tuple[str | int, ...]
+
+
+@dataclass(eq=False)
+class _DecoratorSetLocation:
+    """Stable occurrence token for an unordered canonical set member."""
+
+    value: Any
+    ordinal: int
+    logical_identity: int
+
+    def __hash__(self) -> int:
+        return hash(self.logical_identity)
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, _DecoratorSetLocation)
+            and self.logical_identity == other.logical_identity
+        )
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+
+type _DecoratorLocationPart = str | int | _DecoratorSetLocation
+type _DecoratorLocation = tuple[_DecoratorLocationPart, ...]
 type _DecoratorCandidate = tuple[Any, _DecoratorLocation, _DecoratorLocation]
+type _DecoratorTransform = tuple[_DecoratorLocation, Callable[[Any], Any]]
 type _DecoratorUnionArmCache = dict[tuple[int, int], Any]
 type _DecoratorRouteGroups = dict[
     _DecoratorDispatchSite,
@@ -51,13 +79,27 @@ class _DecoratorRouteSelection:
     value_identity: int | None = None
 
 
+def _decorator_collection_location(
+    collection: Any,
+    item: Any,
+    ordinal: int,
+) -> int | _DecoratorSetLocation:
+    if not isinstance(collection, set | frozenset):
+        return ordinal
+    return _DecoratorSetLocation(
+        value=item,
+        ordinal=ordinal,
+        logical_identity=id(item),
+    )
+
+
 def _select_decorator_routes(
     value: BaseModel,
     *,
     compiled: _CompiledFamily,
     parent_label: str,
     source_version: _CompiledVersion | None,
-    location_prefix: tuple[str | int, ...] = (),
+    location_prefix: _DecoratorLocation = (),
     parent_selection: _DecoratorRouteSelection | None = None,
     _union_arm_cache: _DecoratorUnionArmCache | None = None,
     _route_group_cache: _DecoratorRouteGroupCache | None = None,
@@ -130,10 +172,10 @@ def _walk_authoritative_decorator_route(
     route: _CompiledDecoratorNestedFamily,
     root_names: Mapping[str, str | None],
     union_arm_cache: _DecoratorUnionArmCache,
-) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
-    states: list[tuple[Any, Any, tuple[str | int, ...]]] = [(value, annotation, ())]
+) -> tuple[tuple[Any, _DecoratorLocation], ...]:
+    states: list[tuple[Any, Any, _DecoratorLocation]] = [(value, annotation, ())]
     for step_index, step in enumerate(route.traversal):
-        next_states: list[tuple[Any, Any, tuple[str | int, ...]]] = []
+        next_states: list[tuple[Any, Any, _DecoratorLocation]] = []
         for current, current_annotation, location in states:
             normalized_annotation = _strip_annotated(current_annotation)
             if step.kind == "field":
@@ -181,7 +223,18 @@ def _walk_authoritative_decorator_route(
                     continue
                 item_annotation = arguments[0]
                 next_states.extend(
-                    (item, item_annotation, (*location, ordinal))
+                    (
+                        item,
+                        item_annotation,
+                        (
+                            *location,
+                            _decorator_collection_location(
+                                current,
+                                item,
+                                ordinal,
+                            ),
+                        ),
+                    )
                     for ordinal, item in enumerate(current)
                 )
                 continue
@@ -261,11 +314,14 @@ def _serialized_decorator_selection_location(
         if step.kind == "each":
             occurrence = next(relative)
             arguments = get_args(normalized)
-            serialized.append(occurrence)
+            serialized.append(
+                occurrence.ordinal if isinstance(occurrence, _DecoratorSetLocation) else occurrence
+            )
             annotation = arguments[0]
             continue
         if step.kind == "tuple_index":
             occurrence = next(relative)
+            assert isinstance(occurrence, int)
             ordinal = int(step.value)
             arguments = get_args(normalized)
             serialized.append(occurrence)
@@ -273,6 +329,7 @@ def _serialized_decorator_selection_location(
             continue
         if step.kind == "mapping_values":
             occurrence = next(relative)
+            assert isinstance(occurrence, str | int)
             arguments = get_args(normalized)
             serialized.append(occurrence)
             annotation = arguments[1]
@@ -286,24 +343,28 @@ def _normalize_selected_decorator_payloads(
     selections: tuple[_DecoratorRouteSelection, ...],
     parent_label: str,
 ) -> dict[str, Any]:
-    normalized = payload
     # Historical ancestor field names must become canonical before a
     # descendant's canonical location is reachable.  Conversion and final
     # projection remain child-first, but input-name normalization is the
     # inverse traversal.
-    for selection in _decorator_selections_parent_first(selections):
-        child_compiled = selection.route.family._compiled_family()
-        child_label = selection.route.child_label(parent_label)
-        normalized = _transform_payload_at_location(
-            normalized,
-            location=selection.location,
-            transform=partial(
+    transforms = tuple(
+        (
+            selection.location,
+            partial(
                 _normalize_decorator_value,
-                compiled=child_compiled,
-                child_label=child_label,
+                compiled=selection.route.family._compiled_family(),
+                child_label=selection.route.child_label(parent_label),
             ),
         )
-        _refresh_decorator_selection_identity(normalized, selection)
+        for selection in _decorator_selections_parent_first(selections)
+    )
+    normalized = _transform_payload_at_locations(
+        payload,
+        transforms=transforms,
+        order="parent_first",
+    )
+    assert isinstance(normalized, dict)
+    _refresh_decorator_selection_identities(normalized, selections)
     return normalized
 
 
@@ -329,42 +390,6 @@ def _normalize_decorator_value(
     )
 
 
-def _materialize_selected_decorator_models(
-    *,
-    payload: dict[str, Any],
-    selections: tuple[_DecoratorRouteSelection, ...],
-) -> dict[str, Any]:
-    materialized = payload
-    for selection in _decorator_selections_child_first(selections):
-        materialized = _transform_payload_at_location(
-            materialized,
-            location=selection.location,
-            transform=partial(
-                _materialize_decorator_model,
-                model=selection.route.family.model,
-            ),
-        )
-        _refresh_decorator_selection_identity(materialized, selection)
-    return materialized
-
-
-def _materialize_decorator_model(value: Any, *, model: type[BaseModel]) -> Any:
-    if type(value) is model:
-        return value
-    if not isinstance(value, Mapping):
-        return value
-    validation_input = _current_validation_input(model, dict(value))
-    if model.model_config.get("revalidate_instances") == "always":
-        # Preserve the authoritative branch as an exact instance, but let the
-        # final parent validation perform the one real validation required by
-        # the model's explicit revalidation policy.
-        return model.model_construct(**validation_input)
-    return model.model_validate(
-        validation_input,
-        by_name=True,
-    )
-
-
 def _decorator_collection_kind(
     route: _CompiledDecoratorNestedFamily,
 ) -> Literal["list", "tuple", "set", "frozenset"] | None:
@@ -373,56 +398,204 @@ def _decorator_collection_kind(
     return route.collection_kind
 
 
-def _transform_payload_at_location(
+type _DecoratorSetIndex = tuple[
+    set[Any] | frozenset[Any],
+    tuple[Any, ...],
+    dict[int, int],
+    dict[int, int | None],
+]
+type _DecoratorSetIndexCache = dict[int, _DecoratorSetIndex]
+
+
+def _decorator_set_index(
+    payload: set[Any] | frozenset[Any],
+    cache: _DecoratorSetIndexCache | None = None,
+) -> _DecoratorSetIndex:
+    if cache is not None:
+        cached = cache.get(id(payload))
+        if cached is not None and cached[0] is payload:
+            return cached
+    items = tuple(payload)
+    object_indexes = {id(item): index for index, item in enumerate(items)}
+    source_indexes: dict[int, int | None] = {}
+    for index, item in enumerate(items):
+        for identity in _canonical_source_identities(item):
+            if identity not in source_indexes:
+                source_indexes[identity] = index
+            elif source_indexes[identity] != index:
+                source_indexes[identity] = None
+    built = payload, items, object_indexes, source_indexes
+    if cache is not None:
+        cache[id(payload)] = built
+    return built
+
+
+def _resolve_decorator_set_location(
+    index: _DecoratorSetIndex,
+    location: _DecoratorSetLocation,
+    *,
+    update_location: bool = True,
+) -> int | None:
+    _payload, items, object_indexes, source_indexes = index
+    object_index = object_indexes.get(id(location.value))
+    if object_index is not None and items[object_index] is location.value:
+        if update_location:
+            location.ordinal = object_index
+            location.value = items[object_index]
+        return object_index
+    if location.logical_identity not in source_indexes:
+        return None
+    source_index = source_indexes[location.logical_identity]
+    if source_index is None:
+        msg = "Decorator nested migration has ambiguous unordered occurrence identity"
+        raise InvalidMigrationError(msg)
+    if update_location:
+        location.ordinal = source_index
+        location.value = items[source_index]
+    return source_index
+
+
+def _transform_payload_at_locations(
     payload: Any,
     *,
-    location: tuple[str | int, ...],
-    transform: Callable[[Any], Any],
+    transforms: tuple[_DecoratorTransform, ...],
+    order: Literal["parent_first", "child_first"],
 ) -> Any:
-    if not location:
-        return transform(payload)
-    head, *remaining = location
-    tail = tuple(remaining)
+    """Apply a location forest while copying each affected container at most once."""
+    terminal = tuple(transform for location, transform in transforms if not location)
+    descendants = tuple((location, transform) for location, transform in transforms if location)
+    transformed = payload
+    if order == "parent_first":
+        for transform in terminal:
+            transformed = transform(transformed)
+    if descendants:
+        transformed = _transform_payload_children(
+            transformed,
+            transforms=descendants,
+            order=order,
+        )
+    if order == "child_first":
+        for transform in terminal:
+            transformed = transform(transformed)
+    return transformed
+
+
+def _transform_payload_children(
+    payload: Any,
+    *,
+    transforms: tuple[_DecoratorTransform, ...],
+    order: Literal["parent_first", "child_first"],
+) -> Any:
     if isinstance(payload, BaseModel):
-        return _transform_payload_at_location(
+        return _transform_payload_children(
             _extract_declared_fields(payload),
-            location=location,
-            transform=transform,
+            transforms=transforms,
+            order=order,
         )
     if isinstance(payload, Mapping):
-        if head not in payload:
+        grouped: dict[Any, list[_DecoratorTransform]] = {}
+        for location, transform in transforms:
+            head, *remaining = location
+            grouped.setdefault(head, []).append((tuple(remaining), transform))
+        copied: dict[Any, Any] | None = None
+        for head, mapping_transforms in grouped.items():
+            if head not in payload:
+                continue
+            current = payload[head]
+            transformed = _transform_payload_at_locations(
+                current,
+                transforms=tuple(mapping_transforms),
+                order=order,
+            )
+            if transformed is current:
+                continue
+            if copied is None:
+                copied = dict(payload)
+            copied[head] = transformed
+        return payload if copied is None else copied
+    if isinstance(payload, list | tuple):
+        grouped_sequence: dict[int, list[_DecoratorTransform]] = {}
+        for location, transform in transforms:
+            head, *remaining = location
+            if isinstance(head, int):
+                grouped_sequence.setdefault(head, []).append((tuple(remaining), transform))
+        copied_items: list[Any] | None = None
+        for index, sequence_transforms in grouped_sequence.items():
+            if index < 0 or index >= len(payload):
+                continue
+            current = payload[index]
+            transformed = _transform_payload_at_locations(
+                current,
+                transforms=tuple(sequence_transforms),
+                order=order,
+            )
+            if transformed is current:
+                continue
+            if copied_items is None:
+                copied_items = list(payload)
+            copied_items[index] = transformed
+        if copied_items is None:
             return payload
-        current = payload[head]
-        transformed = _transform_payload_at_location(
-            current,
-            location=tail,
-            transform=transform,
-        )
-        if transformed is current:
-            return payload
-        copied = dict(payload)
-        copied[head] = transformed
-        return copied
-    if isinstance(payload, list | tuple) and isinstance(head, int):
-        if head < 0 or head >= len(payload):
-            return payload
-        current = payload[head]
-        transformed = _transform_payload_at_location(
-            current,
-            location=tail,
-            transform=transform,
-        )
-        if transformed is current:
-            return payload
-        copied_items = list(payload)
-        copied_items[head] = transformed
         return copied_items if isinstance(payload, list) else tuple(copied_items)
+    if isinstance(payload, set | frozenset):
+        set_index = _decorator_set_index(payload)
+        grouped_set: dict[
+            int,
+            list[tuple[_DecoratorSetLocation, _DecoratorLocation, Callable[[Any], Any]]],
+        ] = {}
+        for location, transform in transforms:
+            head, *remaining = location
+            if not isinstance(head, _DecoratorSetLocation):
+                continue
+            item_index = _resolve_decorator_set_location(set_index, head)
+            if item_index is not None:
+                grouped_set.setdefault(item_index, []).append((head, tuple(remaining), transform))
+        copied_items = list(set_index[1])
+        changed = False
+        for item_index, set_transforms in grouped_set.items():
+            current = copied_items[item_index]
+            transformed = _transform_payload_at_locations(
+                current,
+                transforms=tuple(
+                    (location, transform) for _head, location, transform in set_transforms
+                ),
+                order=order,
+            )
+            replacement = (
+                current if transformed is current else _hashable_canonical_value(transformed)
+            )
+            for identity in {
+                head.logical_identity for head, _location, _transform in set_transforms
+            }:
+                _bind_canonical_source_identity(replacement, identity)
+            for head, _location, _transform in set_transforms:
+                head.value = replacement
+            if replacement is not current:
+                copied_items[item_index] = replacement
+                changed = True
+        if not changed:
+            return payload
+        rebuilt = _rebuild_canonical_set(
+            payload,
+            copied_items,
+            error_message="Decorator nested migration cannot preserve set cardinality",
+        )
+        rebuilt_index = _decorator_set_index(rebuilt)
+        for set_transforms in grouped_set.values():
+            for head, _location, _transform in set_transforms:
+                if _resolve_decorator_set_location(rebuilt_index, head) is None:
+                    msg = "Decorator nested migration lost an unordered occurrence identity"
+                    raise InvalidMigrationError(msg)
+        return rebuilt
     return payload
 
 
 def _payload_at_location(
     payload: Any,
-    location: tuple[str | int, ...],
+    location: _DecoratorLocation,
+    *,
+    _set_index_cache: _DecoratorSetIndexCache | None = None,
+    _update_set_locations: bool = True,
 ) -> tuple[bool, Any]:
     current = payload
     for part in location:
@@ -436,6 +609,20 @@ def _payload_at_location(
                 return False, None
             current = current[part]
             continue
+        if isinstance(current, set | frozenset) and isinstance(
+            part,
+            _DecoratorSetLocation,
+        ):
+            set_index = _decorator_set_index(current, _set_index_cache)
+            item_index = _resolve_decorator_set_location(
+                set_index,
+                part,
+                update_location=_update_set_locations,
+            )
+            if item_index is None:
+                return False, None
+            current = set_index[1][item_index]
+            continue
         return False, None
     return True, current
 
@@ -444,18 +631,16 @@ def _refresh_decorator_selection_identities(
     payload: Any,
     selections: tuple[_DecoratorRouteSelection, ...],
 ) -> None:
+    set_index_cache: _DecoratorSetIndexCache = {}
     for selection in selections:
-        _refresh_decorator_selection_identity(payload, selection)
-
-
-def _refresh_decorator_selection_identity(
-    payload: Any,
-    selection: _DecoratorRouteSelection,
-) -> None:
-    found, value = _payload_at_location(payload, selection.location)
-    selection.value_identity = (
-        id(value) if found and isinstance(value, Mapping | BaseModel) else None
-    )
+        found, value = _payload_at_location(
+            payload,
+            selection.location,
+            _set_index_cache=set_index_cache,
+        )
+        selection.value_identity = (
+            id(value) if found and isinstance(value, Mapping | BaseModel) else None
+        )
 
 
 def _decorator_selection_depth(selection: _DecoratorRouteSelection) -> int:
@@ -520,10 +705,10 @@ def _decorator_route_groups(
 def _walk_decorator_payload_candidates(
     payload: Any,
     route: _CompiledDecoratorNestedFamily,
-) -> tuple[tuple[Any, tuple[str | int, ...]], ...]:
-    states: list[tuple[Any, tuple[str | int, ...]]] = [(payload, ())]
+) -> tuple[tuple[Any, _DecoratorLocation], ...]:
+    states: list[tuple[Any, _DecoratorLocation]] = [(payload, ())]
     for step in route.traversal:
-        next_states: list[tuple[Any, tuple[str | int, ...]]] = []
+        next_states: list[tuple[Any, _DecoratorLocation]] = []
         for current, location in states:
             if step.kind == "field":
                 if isinstance(current, BaseModel):
@@ -540,7 +725,14 @@ def _walk_decorator_payload_candidates(
                 if not isinstance(current, list | tuple | set | frozenset):
                     continue
                 next_states.extend(
-                    (item, (*location, ordinal)) for ordinal, item in enumerate(current)
+                    (
+                        item,
+                        (
+                            *location,
+                            _decorator_collection_location(current, item, ordinal),
+                        ),
+                    )
+                    for ordinal, item in enumerate(current)
                 )
                 continue
             if step.kind == "tuple_index":
@@ -613,6 +805,7 @@ def _reconcile_decorator_selections(
         if selection.value_identity is not None
     }
     replaced_owner_ids: set[int] = set()
+    set_index_cache: _DecoratorSetIndexCache = {}
     groups = tuple(
         sorted(
             selected_by_site.items(),
@@ -629,9 +822,13 @@ def _reconcile_decorator_selections(
         parent = previous[0].parent
         if parent is None:
             base_payload = payload
-            location_prefix: tuple[str | int, ...] = ()
+            location_prefix: _DecoratorLocation = ()
         else:
-            found, base_payload = _payload_at_location(payload, parent.location)
+            found, base_payload = _payload_at_location(
+                payload,
+                parent.location,
+                _set_index_cache=set_index_cache,
+            )
             if not found:
                 msg = (
                     "Parent migration removed a decorator nested owner occurrence at "
@@ -672,10 +869,10 @@ def _reconcile_decorator_selections(
         # Object identity is the authoritative occurrence token. It permits a
         # heterogeneous list to reorder without rediscovering its union branch.
         for previous_index, selection in enumerate(previous):
-            identity = selection.value_identity
-            if identity is None:
+            selection_identity = selection.value_identity
+            if selection_identity is None:
                 continue
-            candidate_indexes = candidate_indexes_by_identity.get(identity, ())
+            candidate_indexes = candidate_indexes_by_identity.get(selection_identity, ())
             if len(candidate_indexes) > 1:
                 msg = (
                     "Parent migration reused one decorator nested occurrence at "
@@ -853,7 +1050,7 @@ def _selection_has_replaced_ancestor(
 def _validate_unique_decorator_selection_identities(
     selections: tuple[_DecoratorRouteSelection, ...],
 ) -> None:
-    locations_by_identity: dict[int, tuple[str | int, ...]] = {}
+    locations_by_identity: dict[int, _DecoratorLocation] = {}
     for selection in selections:
         identity = selection.value_identity
         if identity is None:
@@ -876,7 +1073,7 @@ def _discover_typed_decorator_selections(
 ) -> tuple[_DecoratorRouteSelection, ...]:
     discovered = list(selections)
     occupied_locations = {(id(selection.parent), selection.location) for selection in selections}
-    locations_by_identity: dict[int, set[tuple[str | int, ...]]] = {}
+    locations_by_identity: dict[int, set[_DecoratorLocation]] = {}
     children_by_parent: dict[int, list[_DecoratorRouteSelection]] = {}
     for selection in selections:
         children_by_parent.setdefault(id(selection.parent), []).append(selection)
@@ -885,12 +1082,13 @@ def _discover_typed_decorator_selections(
                 selection.location
             )
     route_group_cache: _DecoratorRouteGroupCache = {}
+    set_index_cache: _DecoratorSetIndexCache = {}
 
     def visit_owner(
         owner_payload: Any,
         owner_compiled: _CompiledFamily,
         *,
-        location_prefix: tuple[str | int, ...],
+        location_prefix: _DecoratorLocation,
         parent: _DecoratorRouteSelection | None,
     ) -> None:
         parent_identity = id(parent)
@@ -955,12 +1153,19 @@ def _discover_typed_decorator_selections(
 
         children = tuple(children_by_parent.get(parent_identity, ()))
         for child in children:
-            found, child_payload = _payload_at_location(payload, child.location)
+            child_compiled = child.route.family._compiled_family()
+            if not child_compiled.decorator_nested:
+                continue
+            found, child_payload = _payload_at_location(
+                payload,
+                child.location,
+                _set_index_cache=set_index_cache,
+            )
             if not found:
                 continue
             visit_owner(
                 child_payload,
-                child.route.family._compiled_family(),
+                child_compiled,
                 location_prefix=child.location,
                 parent=child,
             )
@@ -1014,43 +1219,3 @@ def _annotation_accepts_raw_mapping(annotation: Any) -> bool:
         return issubclass(dict, runtime_type)
     except TypeError:
         return False
-
-
-def _decorator_set_cardinalities(
-    payload: Any,
-    route: _CompiledDecoratorNestedFamily,
-) -> dict[int, tuple[int, ...]]:
-    states: list[Any] = [payload]
-    cardinalities: dict[int, list[int]] = {}
-    for step_index, step in enumerate(route.traversal):
-        next_states: list[Any] = []
-        for current in states:
-            if step.kind == "field":
-                if isinstance(current, BaseModel) and step.value in current.__dict__:
-                    next_states.append(current.__dict__[step.value])
-                elif isinstance(current, Mapping) and step.value in current:
-                    next_states.append(current[step.value])
-                continue
-            if step.kind == "union_arm":
-                next_states.append(current)
-                continue
-            if step.kind == "each":
-                if not isinstance(current, list | tuple | set | frozenset):
-                    continue
-                if step.value in ("set", "frozenset"):
-                    cardinalities.setdefault(step_index, []).append(len(current))
-                next_states.extend(current)
-                continue
-            if step.kind == "tuple_index":
-                if not isinstance(current, list | tuple):
-                    continue
-                ordinal = int(step.value)
-                if ordinal < len(current):
-                    next_states.append(current[ordinal])
-                continue
-            if step.kind == "mapping_values" and isinstance(current, Mapping):
-                next_states.extend(current.values())
-        states = next_states
-        if not states:
-            break
-    return {index: tuple(values) for index, values in cardinalities.items()}

--- a/src/pydantic_versions/_runtime_nested.py
+++ b/src/pydantic_versions/_runtime_nested.py
@@ -35,9 +35,12 @@ from pydantic_versions._runtime_payload import (
     _explicit_runtime_body_model,
     _extract_declared_fields,
     _extract_preflight_fields,
+    _HashableCanonicalMapping,
     _is_concrete_runtime_scalar_annotation,
     _is_runtime_base_model_type,
     _matching_declared_annotation,
+    _preserve_canonical_mapping_copy,
+    _rebuild_canonical_set,
     _runtime_annotation_value,
     _runtime_nested_structural_occurrences,
     _runtime_structural_field_value,
@@ -271,10 +274,9 @@ def _normalize_validated_nested_family_value(
     if isinstance(value, BaseModel):
         value = _extract_declared_fields(value)
     if isinstance(value, list | tuple | set | frozenset):
-        # Transition payloads intentionally use JSON-shaped lists for every
-        # supported collection.  The source wire model already validated each
-        # item, so normalizing here must not invoke child validators again.
-        return [
+        # The source wire model already validated each item, so normalizing
+        # here must not invoke child validators again.
+        normalized_items = [
             _normalize_validated_nested_family_value(
                 item,
                 family=family,
@@ -282,19 +284,33 @@ def _normalize_validated_nested_family_value(
             )
             for item in value
         ]
+        if isinstance(value, list):
+            return normalized_items
+        if isinstance(value, tuple):
+            return tuple(normalized_items)
+        return _rebuild_canonical_set(
+            value,
+            normalized_items,
+            error_message=(
+                f"Nested migration for family {family.name!r} cannot preserve "
+                "set cardinality while normalizing validated values"
+            ),
+        )
     if not isinstance(value, Mapping):
         return value
+    source_mapping = value
     child_compiled = family._compiled_family()
     normalized = _to_current_names(
         child_compiled,
         child_compiled.version(child_label),
         dict(value),
     )
-    return _normalize_validated_explicit_nested_payloads(
+    normalized = _normalize_validated_explicit_nested_payloads(
         payload=normalized,
         compiled=child_compiled,
         parent_label=child_label,
     )
+    return _preserve_canonical_mapping_copy(source_mapping, normalized)
 
 
 def _apply_nested_family_migrations(
@@ -1358,18 +1374,29 @@ def _convert_nested_family_payload(
             )
             for item in payload
         ]
-        if _has_duplicate_payload(converted_items):
-            msg = (
+        return _rebuild_canonical_set(
+            payload,
+            converted_items,
+            error_message=(
                 f"Nested migration for family {family.name!r} "
                 "cannot preserve set cardinality while converting mixed payload values"
-            )
-            raise InvalidMigrationError(msg)
-        try:
-            return type(payload)(converted_items)
-        except TypeError:
-            return converted_items
+            ),
+        )
     if not isinstance(payload, Mapping):
         return payload
+    source_identities = (
+        payload.source_identities if isinstance(payload, _HashableCanonicalMapping) else frozenset()
+    )
+
+    def preserve_source_identity(
+        value: dict[str, Any],
+    ) -> dict[str, Any] | _HashableCanonicalMapping:
+        return (
+            _HashableCanonicalMapping(value, source_identities=source_identities)
+            if source_identities
+            else value
+        )
+
     if source_payload_is_canonical:
         current_payload = dict(payload)
     else:
@@ -1413,7 +1440,7 @@ def _convert_nested_family_payload(
             compiled=compiled,
             target_label=target_label,
         )
-        return current_payload
+        return preserve_source_identity(current_payload)
     if source_index < target_index:
         for edge_index in range(source_index, target_index):
             transition = compiled.transitions[edge_index]
@@ -1461,7 +1488,7 @@ def _convert_nested_family_payload(
         compiled=compiled,
         target_label=target_label,
     )
-    return current_payload
+    return preserve_source_identity(current_payload)
 
 
 def _rebase_canonical_version_metadata(
@@ -1485,6 +1512,7 @@ def _project_nested_family_payloads(
     compiled: _CompiledFamily,
     parent_label: str,
     wire_boundary: bool,
+    guarded_container_ids: set[int] | None = None,
 ) -> dict[str, Any]:
     if not compiled.nested:
         return payload
@@ -1501,6 +1529,7 @@ def _project_nested_family_payloads(
                 model=compiled.model,
                 path=nested.path,
             ),
+            guarded_container_ids=guarded_container_ids,
         )
     return projected
 
@@ -1514,15 +1543,24 @@ def _project_nested_child_family(
     target_label: str,
     wire_boundary: bool,
     collection_kind: Literal["list", "tuple", "set", "frozenset"] | None,
+    guarded_container_ids: set[int] | None,
 ) -> Any:
     def project(nested_payload: Any) -> Any:
-        return _project_nested_family_payload(
+        projected = _project_nested_family_payload(
             family=family,
             payload=nested_payload,
             target_label=target_label,
             wire_boundary=wire_boundary,
             collection_kind=collection_kind,
+            guarded_container_ids=guarded_container_ids,
         )
+        if (
+            guarded_container_ids is not None
+            and collection_kind in {"set", "frozenset"}
+            and isinstance(projected, list | tuple | set | frozenset)
+        ):
+            guarded_container_ids.add(id(projected))
+        return projected
 
     return _transform_declared_payload_at_path(
         payload,
@@ -1539,6 +1577,7 @@ def _project_nested_family_payload(
     target_label: str,
     wire_boundary: bool,
     collection_kind: Literal["list", "tuple", "set", "frozenset"] | None,
+    guarded_container_ids: set[int] | None = None,
 ) -> Any:
     if payload is None:
         return payload
@@ -1550,6 +1589,7 @@ def _project_nested_family_payload(
                 target_label=target_label,
                 wire_boundary=wire_boundary,
                 collection_kind=collection_kind,
+                guarded_container_ids=guarded_container_ids,
             )
             for item in payload
         ]
@@ -1561,24 +1601,37 @@ def _project_nested_family_payload(
                 target_label=target_label,
                 wire_boundary=wire_boundary,
                 collection_kind=collection_kind,
+                guarded_container_ids=guarded_container_ids,
             )
             for item in payload
         )
     if isinstance(payload, set | frozenset):
-        return [
+        projected_items = [
             _project_nested_family_payload(
                 family=family,
                 payload=item,
                 target_label=target_label,
                 wire_boundary=wire_boundary,
                 collection_kind=collection_kind,
+                guarded_container_ids=guarded_container_ids,
             )
             for item in payload
         ]
+        return _rebuild_canonical_set(
+            payload,
+            projected_items,
+            error_message=(
+                f"Nested rendering for family {family.name!r} cannot preserve "
+                "set cardinality while projecting canonical values"
+            ),
+        )
     if isinstance(payload, BaseModel):
         payload = _extract_declared_fields(payload)
     if not isinstance(payload, Mapping):
         return payload
+    source_identities = (
+        payload.source_identities if isinstance(payload, _HashableCanonicalMapping) else frozenset()
+    )
 
     compiled = family._compiled_family()
     metadata = compiled.version_metadata
@@ -1594,6 +1647,7 @@ def _project_nested_family_payload(
         compiled=compiled,
         parent_label=target_label,
         wire_boundary=wire_boundary,
+        guarded_container_ids=guarded_container_ids,
     )
     _rebase_canonical_version_metadata(
         payload=projected,
@@ -1601,15 +1655,28 @@ def _project_nested_family_payload(
         target_label=target_label,
     )
     if not wire_boundary:
-        return projected
+        return (
+            _HashableCanonicalMapping(projected, source_identities=source_identities)
+            if source_identities
+            else projected
+        )
 
-    target_payload = _to_version_names(compiled.version(target_label), projected)
+    target_payload = _to_version_names(
+        compiled.version(target_label),
+        projected,
+        tracked_container_ids=guarded_container_ids,
+        mapping_copy=_preserve_canonical_mapping_copy,
+    )
     if metadata is not None and metadata.owner == "family":
         if collection_kind in ("set", "tuple", "frozenset"):
             _set_version_field(target_payload, metadata.path, target_label)
         else:
             _remove_version_field(target_payload, metadata.path)
-    return target_payload
+    return (
+        _HashableCanonicalMapping(target_payload, source_identities=source_identities)
+        if source_identities
+        else target_payload
+    )
 
 
 def _target_nested_path(

--- a/src/pydantic_versions/_runtime_payload.py
+++ b/src/pydantic_versions/_runtime_payload.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import datetime as dt
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from dataclasses import fields as dataclass_fields
 from dataclasses import is_dataclass
 from types import NoneType, UnionType
@@ -11,19 +10,18 @@ from typing import (
     Annotated,
     Any,
     Literal,
-    NoReturn,
     TypeVar,
     Union,
     cast,
     get_args,
     get_origin,
     get_type_hints,
+    overload,
 )
 from typing import TypeAliasType as StdlibTypeAliasType
 from typing import is_typeddict as stdlib_is_typeddict
 
 from pydantic import BaseModel
-from pydantic_core import to_jsonable_python
 from typing_extensions import TypeAliasType as ExtensionsTypeAliasType  # noqa: UP035
 from typing_extensions import is_typeddict as extensions_is_typeddict
 
@@ -37,30 +35,300 @@ from pydantic_versions.exceptions import InvalidMigrationError
 _TYPE_ALIAS_TYPES = (StdlibTypeAliasType, ExtensionsTypeAliasType)
 
 
+class _HashableCanonicalMapping(MutableMapping[Any, Any]):
+    """Identity-hashable private mapping for canonical set and mapping-key positions."""
+
+    __slots__ = ("_data", "source_identities")
+    __hash__ = object.__hash__
+    __eq__ = object.__eq__
+    __ne__ = object.__ne__
+
+    def __init__(
+        self,
+        value: Mapping[Any, Any],
+        *,
+        source_identities: Iterable[int] = (),
+    ) -> None:
+        self._data = dict(value)
+        self.source_identities = frozenset(source_identities)
+
+    def __getitem__(self, key: Any) -> Any:
+        return self._data[key]
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        self._data[key] = value
+
+    def __delitem__(self, key: Any) -> None:
+        del self._data[key]
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return repr(self._data)
+
+    def copy(self) -> _HashableCanonicalMapping:
+        """Copy callback-visible data without discarding private occurrence lineage."""
+        return _HashableCanonicalMapping(
+            self._data,
+            source_identities=self.source_identities,
+        )
+
+    def __or__(self, other: Any) -> Any:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        merged = dict(self._data)
+        merged.update(other)
+        return _HashableCanonicalMapping(
+            merged,
+            source_identities=self.source_identities | _direct_canonical_source_identities(other),
+        )
+
+    def __ror__(self, other: Any) -> Any:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        merged = dict(other)
+        merged.update(self._data)
+        return _HashableCanonicalMapping(
+            merged,
+            source_identities=self.source_identities | _direct_canonical_source_identities(other),
+        )
+
+    def __ior__(self, other: Any) -> Any:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        self._data.update(other)
+        self.source_identities |= _direct_canonical_source_identities(other)
+        return self
+
+
+def _direct_canonical_source_identities(value: Any) -> frozenset[int]:
+    if isinstance(value, _HashableCanonicalMapping):
+        return value.source_identities
+    return frozenset()
+
+
+def _preserve_canonical_mapping_copy(
+    source: Mapping[Any, Any],
+    copied: dict[Any, Any],
+) -> Mapping[Any, Any]:
+    """Keep private occurrence lineage while copying canonical mapping contents."""
+    if isinstance(source, _HashableCanonicalMapping):
+        return _HashableCanonicalMapping(
+            copied,
+            source_identities=source.source_identities,
+        )
+    return copied
+
+
+def _hashable_canonical_value(value: Any) -> Any:
+    """Keep recursively projected mappings usable in exact set containers."""
+    if isinstance(value, _HashableCanonicalMapping):
+        return value
+    if isinstance(value, Mapping):
+        return _HashableCanonicalMapping(value)
+    if isinstance(value, tuple):
+        source_items = value
+        items = tuple(_hashable_canonical_value(item) for item in source_items)
+        unchanged = all(item is source for item, source in zip(items, source_items, strict=True))
+        return value if unchanged else items
+    if isinstance(value, frozenset):
+        source_items = tuple(value)
+        items = tuple(_hashable_canonical_value(item) for item in source_items)
+        if all(item is source for item, source in zip(items, source_items, strict=True)):
+            return value
+        return frozenset(items)
+    return value
+
+
+def _canonical_source_identities(value: Any) -> frozenset[int]:
+    if isinstance(value, _HashableCanonicalMapping):
+        return value.source_identities
+    if isinstance(value, tuple | frozenset):
+        return frozenset(
+            identity for item in value for identity in _canonical_source_identities(item)
+        )
+    return frozenset()
+
+
+def _bind_canonical_source_identity(value: Any, source_identity: int) -> Any:
+    """Bind one unordered occurrence through exact hashable container layers."""
+    if isinstance(value, _HashableCanonicalMapping):
+        value.source_identities |= frozenset((source_identity,))
+    elif isinstance(value, tuple | frozenset):
+        for item in value:
+            _bind_canonical_source_identity(item, source_identity)
+    return value
+
+
+def _rebuild_canonical_set(
+    source: set[Any] | frozenset[Any],
+    items: Iterable[Any],
+    *,
+    error_message: str,
+) -> set[Any] | frozenset[Any]:
+    """Rebuild one exact set kind without hiding an equality collapse."""
+    canonical_items = [_hashable_canonical_value(item) for item in items]
+    if len(canonical_items) != len(source):
+        raise InvalidMigrationError(error_message)
+    try:
+        rebuilt = type(source)(canonical_items)
+    except (TypeError, ValueError) as exc:
+        raise InvalidMigrationError(error_message) from exc
+    if len(rebuilt) != len(source):
+        raise InvalidMigrationError(error_message)
+    return rebuilt
+
+
+def _model_revalidation_input(value: BaseModel) -> dict[str, Any]:
+    """Detach one model's full native revalidation state without projecting children."""
+    memo: dict[int, Any] = {}
+    payload = {
+        name: _detach_revalidation_value(item, memo=memo) for name, item in value.__dict__.items()
+    }
+    extras = value.__pydantic_extra__
+    if isinstance(extras, Mapping):
+        payload.update(
+            {name: _detach_revalidation_value(item, memo=memo) for name, item in extras.items()},
+        )
+    return payload
+
+
+def _detach_revalidation_value(value: Any, *, memo: dict[int, Any]) -> Any:
+    if isinstance(value, BaseModel) or is_dataclass(value):
+        return value
+    identity = id(value)
+    if identity in memo:
+        return memo[identity]
+    if type(value) is dict:
+        copied: dict[Any, Any] = {}
+        memo[identity] = copied
+        copied.update(
+            {
+                _detach_revalidation_value(key, memo=memo): _detach_revalidation_value(
+                    item,
+                    memo=memo,
+                )
+                for key, item in value.items()
+            },
+        )
+        return copied
+    if type(value) is list:
+        copied_list: list[Any] = []
+        memo[identity] = copied_list
+        copied_list.extend(_detach_revalidation_value(item, memo=memo) for item in value)
+        return copied_list
+    if type(value) is tuple:
+        memo[identity] = value
+        copied_tuple = tuple(_detach_revalidation_value(item, memo=memo) for item in value)
+        memo[identity] = copied_tuple
+        return copied_tuple
+    if type(value) in {set, frozenset}:
+        copied_items = [_detach_revalidation_value(item, memo=memo) for item in value]
+        copied_collection = type(value)(copied_items)
+        memo[identity] = copied_collection
+        return copied_collection
+    return value
+
+
+@overload
 def _extract_declared_fields(
     value: BaseModel,
     *,
     declared_model: type[BaseModel] | None = None,
-) -> dict[str, Any]:
+    hash_required: Literal[False] = False,
+    _active_ids: set[int] | None = None,
+) -> dict[str, Any]: ...
+
+
+@overload
+def _extract_declared_fields(
+    value: BaseModel,
+    *,
+    declared_model: type[BaseModel] | None = None,
+    hash_required: Literal[True],
+    _active_ids: set[int] | None = None,
+) -> _HashableCanonicalMapping: ...
+
+
+def _extract_declared_fields(
+    value: BaseModel,
+    *,
+    declared_model: type[BaseModel] | None = None,
+    hash_required: bool = False,
+    _active_ids: set[int] | None = None,
+) -> dict[str, Any] | _HashableCanonicalMapping:
     """Build a private canonical payload from validated, declared fields only."""
-    selected_model = type(value) if declared_model is None else declared_model
-    fields = selected_model.model_fields
-    return {
-        name: _extract_declared_value(
-            value.__dict__[name],
-            config=selected_model.model_config,
-            annotation=field_info.annotation,
+    active_ids = set() if _active_ids is None else _active_ids
+    identity = id(value)
+    if identity in active_ids:
+        msg = "Canonical extraction cannot preserve cyclic model or container references"
+        raise InvalidMigrationError(msg)
+    active_ids.add(identity)
+    try:
+        selected_model = type(value) if declared_model is None else declared_model
+        fields = selected_model.model_fields
+        extracted = {
+            name: _extract_declared_value(
+                value.__dict__[name],
+                annotation=field_info.annotation,
+                _active_ids=active_ids,
+            )
+            for name, field_info in fields.items()
+            if name in value.__dict__ and _field_crosses_wire_boundary(field_info)
+        }
+        return (
+            _HashableCanonicalMapping(extracted, source_identities=(identity,))
+            if hash_required
+            else extracted
         )
-        for name, field_info in fields.items()
-        if name in value.__dict__ and _field_crosses_wire_boundary(field_info)
-    }
+    finally:
+        active_ids.remove(identity)
 
 
 def _extract_declared_value(
     value: Any,
     *,
-    config: Mapping[str, Any],
     annotation: Any = None,
+    hash_required: bool = False,
+    _active_ids: set[int] | None = None,
+) -> Any:
+    guarded = not isinstance(value, BaseModel) and (
+        isinstance(value, Mapping | list | tuple | set | frozenset) or is_dataclass(value)
+    )
+    if not guarded:
+        return _extract_declared_value_unchecked(
+            value,
+            annotation=annotation,
+            hash_required=hash_required,
+            _active_ids=_active_ids,
+        )
+    active_ids = set() if _active_ids is None else _active_ids
+    identity = id(value)
+    if identity in active_ids:
+        msg = "Canonical extraction cannot preserve cyclic model or container references"
+        raise InvalidMigrationError(msg)
+    active_ids.add(identity)
+    try:
+        return _extract_declared_value_unchecked(
+            value,
+            annotation=annotation,
+            hash_required=hash_required,
+            _active_ids=active_ids,
+        )
+    finally:
+        active_ids.remove(identity)
+
+
+def _extract_declared_value_unchecked(
+    value: Any,
+    *,
+    annotation: Any,
+    hash_required: bool,
+    _active_ids: set[int] | None,
 ) -> Any:
     declared_annotation = _matching_declared_annotation(annotation, value)
     if isinstance(value, BaseModel):
@@ -71,37 +339,128 @@ def _extract_declared_value(
             and isinstance(value, declared_annotation)
             else None
         )
-        return _extract_declared_fields(value, declared_model=declared_model)
+        if hash_required:
+            return _extract_declared_fields(
+                value,
+                declared_model=declared_model,
+                hash_required=True,
+                _active_ids=_active_ids,
+            )
+        return _extract_declared_fields(
+            value,
+            declared_model=declared_model,
+            _active_ids=_active_ids,
+        )
+    structure = _runtime_structural_fields(declared_annotation)
+    if structure is None and is_dataclass(value):
+        structure = _single_declared_dataclass_structure(declared_annotation)
+    if structure is not None and structure[0] != "model":
+        kind, owner, field_annotations, _required = structure
+        assert kind in ("dataclass", "typed_dict")
+        extracted: dict[str, Any] = {}
+        for field_name, field_annotation in field_annotations.items():
+            present, field_value = _runtime_structural_field_value(
+                value,
+                kind=kind,
+                field_name=field_name,
+            )
+            if not present or not _runtime_structural_field_crosses_wire_boundary(
+                kind=kind,
+                owner=owner,
+                field_name=field_name,
+                field_annotation=field_annotation,
+            ):
+                continue
+            extracted[field_name] = _extract_declared_value(
+                field_value,
+                annotation=field_annotation,
+                _active_ids=_active_ids,
+            )
+        return (
+            _HashableCanonicalMapping(extracted, source_identities=(id(value),))
+            if hash_required
+            else extracted
+        )
     if isinstance(value, Mapping):
         arguments = get_args(declared_annotation)
+        key_annotation = arguments[0] if len(arguments) == 2 else None
         item_annotation = arguments[1] if len(arguments) == 2 else None
-        return {
-            _jsonable_declared_mapping_key(key, config=config): _extract_declared_value(
-                item,
-                config=config,
-                annotation=item_annotation,
+        extracted_items = [
+            (
+                _extract_declared_value(
+                    key,
+                    annotation=key_annotation,
+                    hash_required=True,
+                    _active_ids=_active_ids,
+                ),
+                _extract_declared_value(
+                    item,
+                    annotation=item_annotation,
+                    _active_ids=_active_ids,
+                ),
             )
             for key, item in value.items()
-        }
-    if isinstance(value, list | tuple | set | frozenset):
-        # Pydantic's JSON-shaped transition payload has historically represented
-        # every supported sequence and set container as a list.  Keep that shape
-        # while reading nested model values without invoking serializers.
+        ]
+        try:
+            extracted = dict(extracted_items)
+        except (TypeError, ValueError) as exc:
+            msg = "Canonical extraction cannot preserve hashable mapping keys"
+            raise InvalidMigrationError(msg) from exc
+        if len(extracted) != len(value):
+            msg = "Canonical extraction cannot preserve mapping key cardinality"
+            raise InvalidMigrationError(msg)
+        return _HashableCanonicalMapping(extracted) if hash_required else extracted
+    if isinstance(value, list):
         arguments = get_args(declared_annotation)
-        if isinstance(value, tuple) and len(arguments) > 1 and arguments[-1] is not Ellipsis:
-            item_annotations = arguments
-        else:
-            item_annotation = arguments[0] if arguments else None
-            item_annotations = (item_annotation,) * len(value)
+        item_annotation = arguments[0] if arguments else None
         return [
             _extract_declared_value(
                 item,
-                config=config,
                 annotation=item_annotation,
+                _active_ids=_active_ids,
+            )
+            for item in value
+        ]
+    if isinstance(value, tuple):
+        arguments = get_args(declared_annotation)
+        if len(arguments) > 1 and arguments[-1] is not Ellipsis:
+            item_annotations = arguments[: len(value)] + (None,) * max(
+                0,
+                len(value) - len(arguments),
+            )
+        else:
+            item_annotation = arguments[0] if arguments else None
+            item_annotations = (item_annotation,) * len(value)
+        return tuple(
+            _extract_declared_value(
+                item,
+                annotation=item_annotation,
+                hash_required=hash_required,
+                _active_ids=_active_ids,
             )
             for item, item_annotation in zip(value, item_annotations, strict=True)
+        )
+    if isinstance(value, set | frozenset):
+        arguments = get_args(declared_annotation)
+        item_annotation = arguments[0] if arguments else None
+        extracted_items = [
+            _bind_canonical_source_identity(
+                _extract_declared_value(
+                    item,
+                    annotation=item_annotation,
+                    hash_required=True,
+                    _active_ids=_active_ids,
+                ),
+                id(item),
+            )
+            for item in value
         ]
-    return _jsonable_declared_scalar(value, config=config)
+        return _rebuild_canonical_set(
+            value,
+            extracted_items,
+            error_message="Canonical extraction cannot preserve set cardinality",
+        )
+    return value
 
 
 def _matching_declared_annotation(annotation: Any, value: Any) -> Any:
@@ -343,7 +702,7 @@ def _runtime_value_matches_typed_dict(value: Any, annotation: Any) -> bool:
 def _runtime_typed_dict_origin(annotation: Any) -> type[Any] | None:
     normalized = _runtime_annotation_value(annotation)
     if stdlib_is_typeddict(normalized) or extensions_is_typeddict(normalized):
-        return normalized
+        return cast(type[Any], normalized)
     origin = get_origin(normalized)
     if stdlib_is_typeddict(origin) or extensions_is_typeddict(origin):
         return cast(type[Any], origin)
@@ -582,6 +941,33 @@ def _runtime_structural_fields(
     return "dataclass", dataclass_type, fields, frozenset(fields)
 
 
+def _single_declared_dataclass_structure(
+    annotation: Any,
+) -> (
+    tuple[
+        Literal["model", "dataclass", "typed_dict"],
+        type[Any],
+        dict[str, Any],
+        frozenset[str],
+    ]
+    | None
+):
+    normalized = _runtime_annotation_value(annotation)
+    if isinstance(normalized, TypeVar):
+        candidates = _runtime_type_parameter_values(normalized)
+    elif get_origin(normalized) in (Union, UnionType):
+        candidates = get_args(normalized)
+    else:
+        return None
+    matches = [
+        structure
+        for candidate in candidates
+        if (structure := _runtime_structural_fields(candidate)) is not None
+        and structure[0] == "dataclass"
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
 def _runtime_structural_field_value(
     value: Any,
     *,
@@ -626,84 +1012,48 @@ def _runtime_undeclared_field_is_present(
 
 
 def _field_crosses_wire_boundary(field_info: Any) -> bool:
-    for value in (field_info.exclude, field_info.exclude_if):
-        if value is None or value is False:
-            continue
-        if isinstance(value, Mapping | tuple | list | set | frozenset) and not value:
-            continue
+    return not any(
+        _wire_boundary_omits_value(value) for value in (field_info.exclude, field_info.exclude_if)
+    )
+
+
+def _wire_boundary_omits_value(value: Any) -> bool:
+    if value is _MISSING or value is None or value is False:
         return False
-    return True
+    return not (isinstance(value, Mapping | tuple | list | set | frozenset) and not value)
 
 
-def _jsonable_declared_scalar(value: Any, *, config: Mapping[str, Any]) -> Any:
-    value_type = type(value)
-    if (
-        value_type is NoneType
-        or value_type is bool
-        or value_type is int
-        or value_type is float
-        or value_type is str
-    ):
-        return value
-    try:
-        if isinstance(value, bytes):
-            return to_jsonable_python(
-                value,
-                bytes_mode=config.get("ser_json_bytes", "utf8"),
-                fallback=_signal_unknown_scalar,
-            )
-        if isinstance(value, dt.timedelta):
-            temporal_mode = config.get("ser_json_temporal")
-            if temporal_mode is not None:
-                return to_jsonable_python(
-                    value,
-                    temporal_mode=temporal_mode,
-                    fallback=_signal_unknown_scalar,
-                )
-            return to_jsonable_python(
-                value,
-                timedelta_mode=config.get("ser_json_timedelta", "iso8601"),
-                fallback=_signal_unknown_scalar,
-            )
-        if isinstance(value, dt.datetime | dt.date | dt.time):
-            return to_jsonable_python(
-                value,
-                temporal_mode=config.get("ser_json_temporal", "iso8601"),
-                fallback=_signal_unknown_scalar,
-            )
-        return to_jsonable_python(value, fallback=_signal_unknown_scalar)
-    except _UnknownScalarError:
-        return value
-
-
-def _jsonable_declared_mapping_key(value: Any, *, config: Mapping[str, Any]) -> Any:
-    temporal_mode = config.get("ser_json_temporal")
-    try:
-        if temporal_mode is not None:
-            dumped = to_jsonable_python(
-                {value: None},
-                bytes_mode=config.get("ser_json_bytes", "utf8"),
-                temporal_mode=temporal_mode,
-                fallback=_signal_unknown_scalar,
-            )
-        else:
-            dumped = to_jsonable_python(
-                {value: None},
-                bytes_mode=config.get("ser_json_bytes", "utf8"),
-                timedelta_mode=config.get("ser_json_timedelta", "iso8601"),
-                fallback=_signal_unknown_scalar,
-            )
-    except _UnknownScalarError:
-        return value
-    return next(iter(dumped))
-
-
-class _UnknownScalarError(Exception):
-    pass
-
-
-def _signal_unknown_scalar(_value: Any) -> NoReturn:
-    raise _UnknownScalarError
+def _runtime_structural_field_crosses_wire_boundary(
+    *,
+    kind: Literal["dataclass", "typed_dict"],
+    owner: type[Any],
+    field_name: str,
+    field_annotation: Any,
+) -> bool:
+    (
+        _config,
+        resolved_field_info,
+        assigned_field_info,
+        field_metadata,
+        annotated_field_infos,
+    ) = _runtime_structural_field_sources(
+        kind=kind,
+        owner=owner,
+        field_name=field_name,
+        field_annotation=field_annotation,
+    )
+    return not any(
+        _wire_boundary_omits_value(
+            _runtime_effective_structural_field_attribute(
+                attribute=attribute,
+                resolved_field_info=resolved_field_info,
+                assigned_field_info=assigned_field_info,
+                field_metadata=field_metadata,
+                annotated_field_infos=annotated_field_infos,
+            ),
+        )
+        for attribute in ("exclude", "exclude_if")
+    )
 
 
 def _extract_preflight_fields(
@@ -1267,17 +1617,11 @@ def _transform_declared_payload_through_annotation(
         return transformed_items
     if isinstance(payload, tuple):
         return tuple(transformed_items)
-    try:
-        transformed_set = type(payload)(transformed_items)
-    except TypeError:
-        # Canonical transition payloads use JSON-shaped lists for set-like
-        # fields, so an intermediate model-to-mapping conversion may cease to
-        # be hashable without losing any declared member.
-        return transformed_items
-    if len(transformed_set) != len(payload):
-        msg = "Nested migration cannot preserve set cardinality along its declared path"
-        raise InvalidMigrationError(msg)
-    return transformed_set
+    return _rebuild_canonical_set(
+        payload,
+        transformed_items,
+        error_message="Nested migration cannot preserve set cardinality along its declared path",
+    )
 
 
 def _declared_traversal_annotation(

--- a/src/pydantic_versions/_runtime_render.py
+++ b/src/pydantic_versions/_runtime_render.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from functools import partial
 from typing import Any, cast
 
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, create_model
 from pydantic_core import SchemaValidator, core_schema
 
 from pydantic_versions._compiler import _CompiledFamily
+from pydantic_versions._runtime_payload import _HashableCanonicalMapping
 from pydantic_versions._runtime_versioning import (
     _alias_paths,
     _model_metadata_field_name,
@@ -56,16 +57,33 @@ def _without_family_render_metadata(
 
 def _current_wire_validation_adapter(
     compiled: _CompiledFamily,
+    *,
+    guard_collections: bool = False,
 ) -> SchemaValidator:
+    from pydantic_versions._runtime_validation import (  # noqa: PLC0415
+        _ensure_canonical_validation_supported,
+    )
+
+    _ensure_canonical_validation_supported(compiled.model)
     cache = compiled._runtime_cache
     with cache.lock:
-        adapter = cache.adapter
+        adapter = cache.guarded_adapter if guard_collections else cache.adapter
         if adapter is None:
-            adapter = _build_current_wire_validation_adapter(
-                compiled.model,
-                family_name=compiled.name,
-            )
-            cache.adapter = adapter
+            if guard_collections:
+                adapter = _build_current_wire_validation_adapter(
+                    compiled.model,
+                    family_name=compiled.name,
+                    guard_collections=True,
+                )
+            else:
+                adapter = _build_current_wire_validation_adapter(
+                    compiled.model,
+                    family_name=compiled.name,
+                )
+            if guard_collections:
+                cache.guarded_adapter = adapter
+            else:
+                cache.adapter = adapter
         return cast(SchemaValidator, adapter)
 
 
@@ -73,25 +91,77 @@ def _build_current_wire_validation_adapter(
     model: type[BaseModel],
     *,
     family_name: str,
+    guard_collections: bool = False,
 ) -> SchemaValidator:
+    # Imported lazily so the validation module can reuse the schema-cloning
+    # machinery below without introducing an import cycle.
+    from pydantic_versions._runtime_validation import (  # noqa: PLC0415
+        _build_canonical_validation_schema,
+    )
+
+    schema, _changes = _build_canonical_validation_schema(
+        model,
+        family_name=family_name,
+        bypass_materialized_models=False,
+        guard_collections=guard_collections,
+    )
+    return SchemaValidator(
+        schema,
+        config=_authoritative_core_config(model),
+    )
+
+
+_ENUM_BRIDGE_CHANGE = 1
+_STRUCTURAL_CHANGE = 2
+_ENUM_UNION_CHANGE = 4
+_APPLICATION_VALIDATOR_CHANGE = 8
+_CARRIER_UNWRAP_CHANGE = 16
+_OPAQUE_HASH_CHANGE = 32
+type _SchemaChanges = int
+type _ValidationSchemaTransform = Callable[
+    [dict[str, Any], _SchemaChanges, bool, bool],
+    tuple[dict[str, Any], _SchemaChanges],
+]
+
+
+def _build_adapted_validation_schema(
+    model: type[BaseModel],
+    *,
+    family_name: str,
+    bypass_materialized_models: bool,
+    schema_transform: _ValidationSchemaTransform | None,
+) -> tuple[core_schema.CoreSchema, _SchemaChanges]:
+    """Clone a model schema while preserving its reference and model shells."""
     source_schema = model.__pydantic_core_schema__
-    model_references = _render_validation_model_references(source_schema)
-    changed_references: set[str] = set()
+    reachable_references = _validation_reachable_references(source_schema)
+    model_references = _render_validation_model_references(
+        source_schema,
+        reachable_references=reachable_references,
+    )
+    reference_changes: dict[str, _SchemaChanges] = {}
     carrier_cache: dict[type[BaseModel], type[BaseModel]] = {}
     while True:
-        discovered_references: set[str] = set()
-        schema, _changed = _clone_render_validation_schema(
+        discovered_reference_changes: dict[str, _SchemaChanges] = {}
+        schema, changes = _clone_render_validation_schema(
             source_schema,
             family_name=family_name,
             model_references=model_references,
-            changed_references=changed_references,
-            discovered_references=discovered_references,
+            reachable_references=reachable_references,
+            reference_changes=reference_changes,
+            discovered_reference_changes=discovered_reference_changes,
             carrier_cache=carrier_cache,
             hash_required=False,
+            allow_enum_bridges=True,
+            bypass_materialized_models=bypass_materialized_models,
+            schema_transform=schema_transform,
         )
-        if discovered_references <= changed_references:
-            return SchemaValidator(cast(core_schema.CoreSchema, schema))
-        changed_references.update(discovered_references)
+        if all(
+            reference_changes.get(ref, 0) | discovered == reference_changes.get(ref, 0)
+            for ref, discovered in discovered_reference_changes.items()
+        ):
+            return cast(core_schema.CoreSchema, schema), changes
+        for ref, discovered in discovered_reference_changes.items():
+            reference_changes[ref] = reference_changes.get(ref, 0) | discovered
 
 
 class _RenderValidationShell:
@@ -129,11 +199,156 @@ def _construct_hashable_render_carrier(
     return instance
 
 
-def _render_validation_model_references(value: Any) -> dict[str, type[BaseModel]]:
+def _validation_schema_child_keys(schema: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return only runtime-validation child-schema keys for one core node."""
+    schema_type = schema.get("type")
+    if schema_type is None:
+        return tuple(schema)
+    if schema_type in {"list", "set", "frozenset", "generator"}:
+        return ("items_schema",)
+    if schema_type == "tuple":
+        return ("items_schema",)
+    if schema_type == "dict":
+        return ("keys_schema", "values_schema")
+    if schema_type in {
+        "custom-error",
+        "dataclass",
+        "dataclass-field",
+        "default",
+        "function-after",
+        "function-before",
+        "function-wrap",
+        "json",
+        "model",
+        "model-field",
+        "nullable",
+        "typed-dict-field",
+    }:
+        return ("schema",)
+    if schema_type in {"union", "tagged-union"}:
+        return ("choices",)
+    if schema_type == "chain":
+        return ("steps",)
+    if schema_type == "lax-or-strict":
+        return ("lax_schema", "strict_schema")
+    if schema_type == "json-or-python":
+        return ("json_schema", "python_schema")
+    if schema_type in {"typed-dict", "model-fields"}:
+        return ("fields", "extras_schema", "extras_keys_schema")
+    if schema_type == "dataclass-args":
+        return ("fields",)
+    if schema_type == "arguments":
+        return ("arguments_schema", "var_args_schema", "var_kwargs_schema")
+    if schema_type == "arguments-v3":
+        return ("arguments_schema",)
+    if schema_type == "call":
+        return ("arguments_schema", "return_schema")
+    if schema_type == "definitions":
+        return ("schema",)
+    return ()
+
+
+def _validation_reachable_references(value: Any) -> frozenset[str]:
+    definitions: dict[str, Mapping[str, Any]] = {}
+
+    def collect_definitions(current: Any) -> None:
+        if isinstance(current, list | tuple):
+            for item in current:
+                collect_definitions(item)
+            return
+        if not isinstance(current, Mapping):
+            return
+        schema_ref = current.get("ref")
+        if isinstance(schema_ref, str):
+            definitions[schema_ref] = current
+        if current.get("type") == "definitions":
+            stored = current.get("definitions")
+            if isinstance(stored, list):
+                for definition in stored:
+                    collect_definitions(definition)
+        for key in _validation_schema_child_keys(current):
+            if key in current:
+                collect_definitions(current[key])
+
+    collect_definitions(value)
+    reachable: set[str] = set()
+    active_values: set[int] = set()
+
+    def visit(current: Any) -> None:
+        if isinstance(current, list | tuple):
+            for item in current:
+                visit(item)
+            return
+        if not isinstance(current, Mapping):
+            return
+        identity = id(current)
+        if identity in active_values:
+            return
+        active_values.add(identity)
+        try:
+            if current.get("type") == "definition-ref":
+                schema_ref = current.get("schema_ref")
+                if isinstance(schema_ref, str) and schema_ref not in reachable:
+                    reachable.add(schema_ref)
+                    target = definitions.get(schema_ref)
+                    if target is not None:
+                        visit(target)
+                return
+            for key in _validation_schema_child_keys(current):
+                if key in current:
+                    visit(current[key])
+        finally:
+            active_values.remove(identity)
+
+    visit(value)
+    return frozenset(reachable)
+
+
+def _authoritative_core_config(model: type[BaseModel]) -> core_schema.CoreConfig:
+    source_schema = model.__pydantic_core_schema__
+    reachable_references = _validation_reachable_references(source_schema)
+    pending: list[Any] = [source_schema]
+    while pending:
+        current = pending.pop()
+        if not isinstance(current, Mapping):
+            if isinstance(current, list | tuple):
+                pending.extend(current)
+            continue
+        if current.get("type") == "model" and current.get("cls") is model:
+            config = current.get("config")
+            values = dict(config) if isinstance(config, Mapping) else {}
+            values["title"] = values.get("title") or model.__name__
+            return core_schema.CoreConfig(**values)
+        if current.get("type") == "definitions":
+            pending.append(current.get("schema"))
+            definitions = current.get("definitions")
+            if isinstance(definitions, list):
+                pending.extend(
+                    definition
+                    for definition in definitions
+                    if isinstance(definition, Mapping)
+                    and definition.get("ref") in reachable_references
+                )
+            continue
+        pending.extend(
+            current[key] for key in _validation_schema_child_keys(current) if key in current
+        )
+    return core_schema.CoreConfig(title=model.model_config.get("title") or model.__name__)
+
+
+def _render_validation_model_references(
+    value: Any,
+    *,
+    reachable_references: frozenset[str],
+) -> dict[str, type[BaseModel]]:
     references: dict[str, type[BaseModel]] = {}
     while True:
         previous = dict(references)
-        _collect_render_validation_model_references(value, references)
+        _collect_render_validation_model_references(
+            value,
+            references,
+            reachable_references=reachable_references,
+        )
         if references == previous:
             return references
 
@@ -141,6 +356,8 @@ def _render_validation_model_references(value: Any) -> dict[str, type[BaseModel]
 def _collect_render_validation_model_references(
     value: Any,
     references: dict[str, type[BaseModel]],
+    *,
+    reachable_references: frozenset[str],
 ) -> None:
     if isinstance(value, dict):
         schema_ref = value.get("ref")
@@ -148,12 +365,41 @@ def _collect_render_validation_model_references(
             model = _render_validation_schema_model(value, model_references=references)
             if model is not None:
                 references[schema_ref] = model
-        for item in value.values():
-            _collect_render_validation_model_references(item, references)
+        if value.get("type") == "definitions":
+            _collect_render_validation_model_references(
+                value.get("schema"),
+                references,
+                reachable_references=reachable_references,
+            )
+            definitions = value.get("definitions")
+            if isinstance(definitions, list):
+                for definition in definitions:
+                    if (
+                        isinstance(definition, dict)
+                        and definition.get("ref") in reachable_references
+                    ):
+                        _collect_render_validation_model_references(
+                            definition,
+                            references,
+                            reachable_references=reachable_references,
+                        )
+            return
+        for key in _validation_schema_child_keys(value):
+            if key not in value:
+                continue
+            _collect_render_validation_model_references(
+                value[key],
+                references,
+                reachable_references=reachable_references,
+            )
         return
     if isinstance(value, list | tuple):
         for item in value:
-            _collect_render_validation_model_references(item, references)
+            _collect_render_validation_model_references(
+                item,
+                references,
+                reachable_references=reachable_references,
+            )
 
 
 def _render_validation_schema_model(
@@ -214,164 +460,253 @@ def _clone_render_validation_schema(
     *,
     family_name: str,
     model_references: Mapping[str, type[BaseModel]],
-    changed_references: set[str],
-    discovered_references: set[str],
+    reachable_references: frozenset[str],
+    reference_changes: Mapping[str, _SchemaChanges],
+    discovered_reference_changes: dict[str, _SchemaChanges],
     carrier_cache: dict[type[BaseModel], type[BaseModel]],
     hash_required: bool,
-) -> tuple[Any, bool]:
-    """Clone an authoritative schema and bridge only hash-required model outputs."""
-    if isinstance(value, list):
+    allow_enum_bridges: bool,
+    bypass_materialized_models: bool,
+    schema_transform: _ValidationSchemaTransform | None,
+) -> tuple[Any, _SchemaChanges]:
+    """Clone an authoritative schema and bridge changed model definitions."""
+    if isinstance(value, list | tuple):
         cloned_items = [
             _clone_render_validation_schema(
                 item,
                 family_name=family_name,
                 model_references=model_references,
-                changed_references=changed_references,
-                discovered_references=discovered_references,
+                reachable_references=reachable_references,
+                reference_changes=reference_changes,
+                discovered_reference_changes=discovered_reference_changes,
                 carrier_cache=carrier_cache,
                 hash_required=hash_required,
+                allow_enum_bridges=allow_enum_bridges,
+                bypass_materialized_models=bypass_materialized_models,
+                schema_transform=schema_transform,
             )
             for item in value
         ]
-        return [item for item, _changed in cloned_items], any(
-            changed for _item, changed in cloned_items
+        cloned_values = [item for item, _changes in cloned_items]
+        if isinstance(value, tuple):
+            return tuple(cloned_values), _combined_schema_changes(cloned_items)
+        return cloned_values, _combined_schema_changes(cloned_items)
+    if not isinstance(value, dict):
+        return value, 0
+
+    schema_type = value.get("type")
+    child_enum_bridges_allowed = allow_enum_bridges and not (
+        schema_type == "model" and value.get("custom_init") is True
+    )
+    if hash_required:
+        output_model = _render_validation_schema_model(
+            value,
+            model_references=model_references,
         )
-    if isinstance(value, tuple):
-        cloned_items = tuple(
-            _clone_render_validation_schema(
-                item,
-                family_name=family_name,
-                model_references=model_references,
-                changed_references=changed_references,
-                discovered_references=discovered_references,
-                carrier_cache=carrier_cache,
-                hash_required=hash_required,
-            )
-            for item in value
-        )
-        return tuple(item for item, _changed in cloned_items), any(
-            changed for _item, changed in cloned_items
-        )
-    if isinstance(value, dict):
-        schema_type = value.get("type")
-        if hash_required:
-            output_model = _render_validation_schema_model(
+        if output_model is not None:
+            cloned, changes = _clone_render_validation_schema(
                 value,
-                model_references=model_references,
-            )
-            if output_model is not None:
-                cloned, changed = _clone_render_validation_schema(
-                    value,
-                    family_name=family_name,
-                    model_references=model_references,
-                    changed_references=changed_references,
-                    discovered_references=discovered_references,
-                    carrier_cache=carrier_cache,
-                    hash_required=False,
-                )
-                if output_model.__hash__ is not None:
-                    return cloned, changed
-                carrier = _build_hashable_render_carrier(
-                    model=output_model,
-                    cache=carrier_cache,
-                )
-                return (
-                    core_schema.no_info_after_validator_function(
-                        partial(_construct_hashable_render_carrier, carrier),
-                        cast(core_schema.CoreSchema, cloned),
-                    ),
-                    True,
-                )
-        if schema_type == "definitions":
-            definitions, _definitions_changed = _clone_render_validation_schema(
-                value.get("definitions", []),
                 family_name=family_name,
                 model_references=model_references,
-                changed_references=changed_references,
-                discovered_references=discovered_references,
+                reachable_references=reachable_references,
+                reference_changes=reference_changes,
+                discovered_reference_changes=discovered_reference_changes,
                 carrier_cache=carrier_cache,
                 hash_required=False,
+                allow_enum_bridges=child_enum_bridges_allowed,
+                bypass_materialized_models=bypass_materialized_models,
+                schema_transform=schema_transform,
             )
-            schema, schema_changed = _clone_render_validation_schema(
-                value.get("schema"),
-                family_name=family_name,
-                model_references=model_references,
-                changed_references=changed_references,
-                discovered_references=discovered_references,
-                carrier_cache=carrier_cache,
-                hash_required=hash_required,
-            )
-            cloned = dict(value)
-            cloned["definitions"] = definitions
-            cloned["schema"] = schema
-            return cloned, schema_changed
-        if schema_type == "definition-ref":
-            schema_ref = value.get("schema_ref")
-            return dict(value), isinstance(schema_ref, str) and schema_ref in changed_references
-
-        propagate_hash_keys: set[str] = set()
-        if schema_type is None and hash_required:
-            propagate_hash_keys.update(value)
-        elif schema_type in {"set", "frozenset"}:
-            propagate_hash_keys.add("items_schema")
-        elif hash_required and schema_type == "tuple":
-            propagate_hash_keys.add("items_schema")
-        elif hash_required and schema_type in {"union", "tagged-union"}:
-            propagate_hash_keys.add("choices")
-        elif hash_required and schema_type == "chain":
-            propagate_hash_keys.add("steps")
-        elif hash_required and schema_type == "json-or-python":
-            propagate_hash_keys.update(("json_schema", "python_schema"))
-        elif hash_required and schema_type == "lax-or-strict":
-            propagate_hash_keys.update(("lax_schema", "strict_schema"))
-        elif hash_required and schema_type in {
-            "custom-error",
-            "default",
-            "function-after",
-            "function-before",
-            "function-wrap",
-            "nullable",
-        }:
-            propagate_hash_keys.add("schema")
-
-        cloned_items = {
-            key: _clone_render_validation_schema(
-                item,
-                family_name=family_name,
-                model_references=model_references,
-                changed_references=changed_references,
-                discovered_references=discovered_references,
-                carrier_cache=carrier_cache,
-                hash_required=key in propagate_hash_keys,
-            )
-            for key, item in value.items()
-        }
-        cloned = {key: item for key, (item, _changed) in cloned_items.items()}
-        changed = any(changed for _item, changed in cloned_items.values())
-        if schema_type == "model" and changed:
-            model = value.get("cls")
-            if not isinstance(model, type) or not issubclass(model, BaseModel):
-                return cloned, changed
-            if value.get("custom_init"):
-                msg = (
-                    f"Automatic current-wire render validation for family {family_name!r} "
-                    f"cannot safely execute custom __init__ on model {model.__qualname__!r}"
-                )
-                raise UnsupportedWireModelError(msg)
-            cloned["cls"] = _RenderValidationShell
-            cloned["custom_init"] = False
-            cloned.pop("post_init", None)
-            schema_ref = cloned.pop("ref", None)
-            cloned = core_schema.no_info_after_validator_function(
-                partial(_construct_authoritative_render_model, model),
+            unwrapped = core_schema.no_info_before_validator_function(
+                _unwrap_hashable_canonical_mapping,
                 cast(core_schema.CoreSchema, cloned),
-                ref=schema_ref,
             )
-        schema_ref = value.get("ref")
-        if changed and isinstance(schema_ref, str):
-            discovered_references.add(schema_ref)
-        return cloned, changed
-    return value, False
+            if output_model.__hash__ is not None:
+                return unwrapped, changes | _STRUCTURAL_CHANGE
+            carrier = _build_hashable_render_carrier(
+                model=output_model,
+                cache=carrier_cache,
+            )
+            return (
+                core_schema.no_info_after_validator_function(
+                    partial(_construct_hashable_render_carrier, carrier),
+                    unwrapped,
+                ),
+                changes | _STRUCTURAL_CHANGE,
+            )
+    if schema_type == "definitions":
+        definitions = []
+        for definition in value.get("definitions", []):
+            if isinstance(definition, dict) and definition.get("ref") in reachable_references:
+                cloned_definition, _changes = _clone_render_validation_schema(
+                    definition,
+                    family_name=family_name,
+                    model_references=model_references,
+                    reachable_references=reachable_references,
+                    reference_changes=reference_changes,
+                    discovered_reference_changes=discovered_reference_changes,
+                    carrier_cache=carrier_cache,
+                    hash_required=False,
+                    allow_enum_bridges=child_enum_bridges_allowed,
+                    bypass_materialized_models=bypass_materialized_models,
+                    schema_transform=schema_transform,
+                )
+                definitions.append(cloned_definition)
+            else:
+                definitions.append(definition)
+        schema, changes = _clone_render_validation_schema(
+            value.get("schema"),
+            family_name=family_name,
+            model_references=model_references,
+            reachable_references=reachable_references,
+            reference_changes=reference_changes,
+            discovered_reference_changes=discovered_reference_changes,
+            carrier_cache=carrier_cache,
+            hash_required=hash_required,
+            allow_enum_bridges=child_enum_bridges_allowed,
+            bypass_materialized_models=bypass_materialized_models,
+            schema_transform=schema_transform,
+        )
+        cloned = dict(value)
+        cloned["definitions"] = definitions
+        cloned["schema"] = schema
+        return cloned, changes
+    if schema_type == "definition-ref":
+        schema_ref = value.get("schema_ref")
+        changes = reference_changes.get(schema_ref, 0) if isinstance(schema_ref, str) else 0
+        if not allow_enum_bridges:
+            changes &= ~(_ENUM_BRIDGE_CHANGE | _ENUM_UNION_CHANGE | _APPLICATION_VALIDATOR_CHANGE)
+        return dict(value), changes
+
+    propagate_hash_keys: set[str] = set()
+    if schema_type is None and hash_required:
+        propagate_hash_keys.update(value)
+    elif schema_type in {"set", "frozenset"}:
+        propagate_hash_keys.add("items_schema")
+    elif schema_type == "dict":
+        propagate_hash_keys.add("keys_schema")
+    elif hash_required and schema_type == "tuple":
+        propagate_hash_keys.add("items_schema")
+    elif hash_required and schema_type in {"union", "tagged-union"}:
+        propagate_hash_keys.add("choices")
+    elif hash_required and schema_type == "chain":
+        propagate_hash_keys.add("steps")
+    elif hash_required and schema_type == "json-or-python":
+        propagate_hash_keys.update(("json_schema", "python_schema"))
+    elif hash_required and schema_type == "lax-or-strict":
+        propagate_hash_keys.update(("lax_schema", "strict_schema"))
+    elif hash_required and schema_type in {
+        "custom-error",
+        "default",
+        "function-after",
+        "function-before",
+        "function-wrap",
+        "nullable",
+    }:
+        propagate_hash_keys.add("schema")
+
+    child_keys = frozenset(_validation_schema_child_keys(value))
+    cloned_items: dict[str, tuple[Any, _SchemaChanges]] = {}
+    for key, item in value.items():
+        if key not in child_keys:
+            cloned_items[key] = (item, 0)
+            continue
+        cloned_items[key] = _clone_render_validation_schema(
+            item,
+            family_name=family_name,
+            model_references=model_references,
+            reachable_references=reachable_references,
+            reference_changes=reference_changes,
+            discovered_reference_changes=discovered_reference_changes,
+            carrier_cache=carrier_cache,
+            hash_required=key in propagate_hash_keys,
+            allow_enum_bridges=child_enum_bridges_allowed,
+            bypass_materialized_models=bypass_materialized_models,
+            schema_transform=schema_transform,
+        )
+    cloned = {key: item for key, (item, _changes) in cloned_items.items()}
+    changes = _combined_schema_changes(cloned_items.values())
+    if schema_transform is not None:
+        cloned, transformed = schema_transform(
+            cloned,
+            changes,
+            allow_enum_bridges,
+            hash_required,
+        )
+        changes |= transformed
+    if schema_type == "model" and changes:
+        model = value.get("cls")
+        if not isinstance(model, type) or not issubclass(model, BaseModel):
+            return cloned, changes
+        if value.get("custom_init"):
+            msg = (
+                f"Automatic canonical validation for family {family_name!r} "
+                f"cannot safely execute custom __init__ on model {model.__qualname__!r}"
+            )
+            raise UnsupportedWireModelError(msg)
+        if model.__new__ is not object.__new__:
+            msg = (
+                f"Automatic canonical validation for family {family_name!r} "
+                f"cannot safely execute custom __new__ on model {model.__qualname__!r}"
+            )
+            raise UnsupportedWireModelError(msg)
+        cloned["cls"] = _RenderValidationShell
+        cloned["custom_init"] = False
+        cloned.pop("post_init", None)
+        schema_ref = cloned.pop("ref", None)
+        cloned = core_schema.no_info_after_validator_function(
+            partial(_construct_authoritative_render_model, model),
+            cast(core_schema.CoreSchema, cloned),
+            ref=schema_ref,
+        )
+    schema_ref = value.get("ref")
+    output_model = _render_validation_schema_model(
+        value,
+        model_references=model_references,
+    )
+    if bypass_materialized_models and isinstance(schema_ref, str) and output_model is not None:
+        nested = dict(cloned)
+        nested.pop("ref", None)
+        cloned = core_schema.no_info_wrap_validator_function(
+            partial(_validate_or_bypass_materialized_model, output_model),
+            cast(core_schema.CoreSchema, nested),
+            ref=schema_ref,
+        )
+        changes |= _STRUCTURAL_CHANGE
+    if changes and isinstance(schema_ref, str):
+        discovered_reference_changes[schema_ref] = (
+            discovered_reference_changes.get(schema_ref, 0) | changes
+        )
+    return cloned, changes
+
+
+def _combined_schema_changes(items: Any) -> _SchemaChanges:
+    changes = 0
+    for _item, item_changes in items:
+        changes |= item_changes
+    return changes
+
+
+def _unwrap_hashable_canonical_mapping(value: Any) -> Any:
+    if isinstance(value, _HashableCanonicalMapping):
+        return dict(value)
+    return value
+
+
+def _validate_or_bypass_materialized_model(
+    model: type[BaseModel],
+    value: Any,
+    handler: Any,
+) -> Any:
+    # Imported lazily to keep the shared schema clone usable by canonical
+    # validation without introducing a module-import cycle.
+    from pydantic_versions._runtime_validation import (  # noqa: PLC0415
+        _is_call_local_materialized_model,
+    )
+
+    if type(value) is model and _is_call_local_materialized_model(value):
+        return value
+    return handler(value)
 
 
 def _construct_authoritative_render_model(

--- a/src/pydantic_versions/_runtime_validation.py
+++ b/src/pydantic_versions/_runtime_validation.py
@@ -1,0 +1,882 @@
+"""Canonical-payload validation against authoritative Pydantic core schemas."""
+
+from __future__ import annotations
+
+import operator
+from collections.abc import Mapping, Sized
+from contextvars import ContextVar
+from enum import Enum
+from functools import partial
+from typing import TYPE_CHECKING, Any, NoReturn, cast
+
+from pydantic import BaseModel
+from pydantic_core import (
+    PydanticCustomError,
+    SchemaError,
+    SchemaValidator,
+    ValidationError,
+    core_schema,
+)
+
+from pydantic_versions._runtime_payload import (
+    _canonical_source_identities,
+    _extract_declared_fields,
+    _HashableCanonicalMapping,
+    _model_revalidation_input,
+)
+from pydantic_versions._runtime_render import (
+    _APPLICATION_VALIDATOR_CHANGE,
+    _CARRIER_UNWRAP_CHANGE,
+    _ENUM_BRIDGE_CHANGE,
+    _ENUM_UNION_CHANGE,
+    _OPAQUE_HASH_CHANGE,
+    _STRUCTURAL_CHANGE,
+    _authoritative_core_config,
+    _build_adapted_validation_schema,
+)
+from pydantic_versions.exceptions import InvalidMigrationError, UnsupportedWireModelError
+
+if TYPE_CHECKING:
+    from pydantic_versions._compiler import _CompiledFamilyRuntimeCache
+
+
+_COLLECTION_CARDINALITY_ERROR = "pydantic_versions_collection_cardinality"
+_ENUM_UNION_TYPE_ERROR = "pydantic_versions_enum_union_type"
+_PRIVATE_CARRIER_ERROR = "pydantic_versions_private_carrier"
+_CANONICAL_ERROR_TYPES = {
+    _COLLECTION_CARDINALITY_ERROR,
+    _ENUM_UNION_TYPE_ERROR,
+    _PRIVATE_CARRIER_ERROR,
+}
+_ATTRGETTER_TYPE = type(operator.attrgetter("value"))
+_NOT_FOUND = object()
+_UNION_CHOICE_LABEL_METADATA = "pydantic_versions_union_choice_label"
+
+
+class _CanonicalUnionFrame:
+    __slots__ = ("choice_results", "suppressed_enum")
+
+    def __init__(self) -> None:
+        self.suppressed_enum = False
+        self.choice_results: list[tuple[Any, bool]] = []
+
+
+class _CanonicalChoiceFrame:
+    __slots__ = ("application_validator_ran", "collection_violation")
+
+    def __init__(self) -> None:
+        self.application_validator_ran = False
+        self.collection_violation: tuple[str, int, int] | None = None
+
+
+class _CanonicalApplicationFrame:
+    __slots__ = ("collection_violation",)
+
+    def __init__(self) -> None:
+        self.collection_violation: tuple[str, int, int] | None = None
+
+
+_CANONICAL_UNION_FRAMES: ContextVar[tuple[_CanonicalUnionFrame, ...]] = ContextVar(
+    "pydantic_versions_canonical_union_frames",
+    default=(),
+)
+_CANONICAL_CHOICE_FRAMES: ContextVar[tuple[_CanonicalChoiceFrame, ...]] = ContextVar(
+    "pydantic_versions_canonical_choice_frames",
+    default=(),
+)
+_CANONICAL_APPLICATION_FRAMES: ContextVar[tuple[_CanonicalApplicationFrame, ...]] = ContextVar(
+    "pydantic_versions_canonical_application_frames",
+    default=(),
+)
+_MATERIALIZED_MODEL_IDS: ContextVar[frozenset[int]] = ContextVar(
+    "pydantic_versions_materialized_model_ids",
+    default=frozenset(),
+)
+_MATERIALIZED_CONTAINER_IDS: ContextVar[frozenset[int]] = ContextVar(
+    "pydantic_versions_materialized_container_ids",
+    default=frozenset(),
+)
+
+
+def _is_call_local_materialized_model(value: BaseModel) -> bool:
+    return id(value) in _MATERIALIZED_MODEL_IDS.get()
+
+
+def _validate_canonical_model[T: BaseModel](
+    model: type[T],
+    payload: Mapping[str, Any],
+    *,
+    cache: _CompiledFamilyRuntimeCache | None = None,
+    by_name: bool | None = True,
+    materialized_model_ids: frozenset[int] = frozenset(),
+    materialized_container_ids: frozenset[int] = frozenset(),
+) -> T:
+    """Validate an already-canonical payload exactly once at a model boundary."""
+    validation_payload: Mapping[str, Any] = (
+        dict(payload) if isinstance(payload, _HashableCanonicalMapping) else payload
+    )
+    guard_collections = bool(materialized_container_ids) or _contains_hashable_canonical_mapping(
+        validation_payload
+    )
+    adapter = _canonical_validation_adapter(
+        model,
+        cache=cache,
+        guard_collections=guard_collections,
+        materialized_models=bool(materialized_model_ids),
+    )
+    if adapter is not None:
+        _ensure_canonical_validation_supported(model)
+    union_token = _CANONICAL_UNION_FRAMES.set(())
+    choice_token = _CANONICAL_CHOICE_FRAMES.set(())
+    application_token = _CANONICAL_APPLICATION_FRAMES.set(())
+    model_token = _MATERIALIZED_MODEL_IDS.set(materialized_model_ids)
+    container_token = _MATERIALIZED_CONTAINER_IDS.set(materialized_container_ids)
+    try:
+        if adapter is None:
+            return model.model_validate(validation_payload, by_name=by_name)
+        return cast(
+            T,
+            adapter.validate_python(validation_payload, by_name=by_name),
+        )
+    except ValidationError as exc:
+        _raise_canonical_migration_error(exc)
+        raise
+    finally:
+        _MATERIALIZED_CONTAINER_IDS.reset(container_token)
+        _MATERIALIZED_MODEL_IDS.reset(model_token)
+        _CANONICAL_APPLICATION_FRAMES.reset(application_token)
+        _CANONICAL_CHOICE_FRAMES.reset(choice_token)
+        _CANONICAL_UNION_FRAMES.reset(union_token)
+
+
+def _revalidate_canonical_model_instance[T: BaseModel](
+    model: type[T],
+    value: BaseModel,
+    *,
+    cache: _CompiledFamilyRuntimeCache | None = None,
+) -> T:
+    """Revalidate one exact/subclass instance with its complete native state."""
+    adapter = _canonical_validation_adapter(
+        model,
+        cache=cache,
+        guard_collections=False,
+        materialized_models=False,
+    )
+    if adapter is None:
+        return model.model_validate(value)
+    validated = _validate_canonical_model(
+        model,
+        _model_revalidation_input(value),
+        cache=cache,
+        by_name=None,
+    )
+    object.__setattr__(
+        validated,
+        "__pydantic_fields_set__",
+        set(value.__pydantic_fields_set__),
+    )
+    return validated
+
+
+def _validate_canonical_adapter_payload(
+    adapter: SchemaValidator,
+    payload: Mapping[str, Any],
+    *,
+    by_name: bool = True,
+) -> BaseModel:
+    """Validate through a caller-owned canonical adapter and translate invariants."""
+    union_token = _CANONICAL_UNION_FRAMES.set(())
+    choice_token = _CANONICAL_CHOICE_FRAMES.set(())
+    application_token = _CANONICAL_APPLICATION_FRAMES.set(())
+    model_token = _MATERIALIZED_MODEL_IDS.set(frozenset())
+    container_token = _MATERIALIZED_CONTAINER_IDS.set(frozenset())
+    try:
+        return cast(BaseModel, adapter.validate_python(payload, by_name=by_name))
+    except ValidationError as exc:
+        _raise_canonical_migration_error(exc)
+        raise
+    finally:
+        _MATERIALIZED_CONTAINER_IDS.reset(container_token)
+        _MATERIALIZED_MODEL_IDS.reset(model_token)
+        _CANONICAL_APPLICATION_FRAMES.reset(application_token)
+        _CANONICAL_CHOICE_FRAMES.reset(choice_token)
+        _CANONICAL_UNION_FRAMES.reset(union_token)
+
+
+def _canonical_validation_adapter(
+    model: type[BaseModel],
+    *,
+    cache: _CompiledFamilyRuntimeCache | None,
+    guard_collections: bool,
+    materialized_models: bool,
+) -> SchemaValidator | None:
+    core_schema_identity = model.__pydantic_core_schema__
+    cache_key = (model, guard_collections, materialized_models)
+    if cache is not None:
+        with cache.lock:
+            cached = cache.canonical_adapters.get(cache_key)
+            if cached is not None and cached[0] is core_schema_identity:
+                return cast(SchemaValidator | None, cached[1])
+            adapter = _build_canonical_validation_adapter(
+                model,
+                guard_collections=guard_collections,
+                materialized_models=materialized_models,
+            )
+            cache.canonical_adapters[cache_key] = (core_schema_identity, adapter)
+            return adapter
+    return _build_canonical_validation_adapter(
+        model,
+        guard_collections=guard_collections,
+        materialized_models=materialized_models,
+    )
+
+
+def _build_canonical_validation_adapter(
+    model: type[BaseModel],
+    *,
+    guard_collections: bool,
+    materialized_models: bool,
+) -> SchemaValidator | None:
+    schema, changes = _build_canonical_validation_schema(
+        model,
+        family_name=model.__qualname__,
+        bypass_materialized_models=materialized_models,
+        guard_collections=guard_collections,
+    )
+    if not changes:
+        return None
+    return SchemaValidator(
+        schema,
+        config=_authoritative_core_config(model),
+    )
+
+
+def _build_canonical_validation_schema(
+    model: type[BaseModel],
+    *,
+    family_name: str,
+    bypass_materialized_models: bool,
+    guard_collections: bool,
+) -> tuple[core_schema.CoreSchema, int]:
+    """Build one canonical schema, enabling app tracing only when required."""
+    instrument_applications = guard_collections
+    schema, changes = _build_adapted_validation_schema(
+        model,
+        family_name=family_name,
+        bypass_materialized_models=bypass_materialized_models,
+        schema_transform=partial(
+            _canonical_validation_schema_transform,
+            guard_collections=guard_collections,
+            instrument_applications=instrument_applications,
+        ),
+    )
+    if not instrument_applications and changes & _ENUM_UNION_CHANGE:
+        schema, changes = _build_adapted_validation_schema(
+            model,
+            family_name=family_name,
+            bypass_materialized_models=bypass_materialized_models,
+            schema_transform=partial(
+                _canonical_validation_schema_transform,
+                guard_collections=guard_collections,
+                instrument_applications=True,
+            ),
+        )
+    if changes:
+        _ensure_canonical_validation_supported(model)
+    return schema, changes
+
+
+def _ensure_canonical_validation_supported(model: type[BaseModel]) -> None:
+    callback = getattr(model.model_validate, "__func__", model.model_validate)
+    standard = getattr(BaseModel.model_validate, "__func__", BaseModel.model_validate)
+    if callback is not standard:
+        msg = (
+            f"Automatic canonical validation for model {model.__qualname__!r} "
+            "cannot safely bypass an overridden model_validate"
+        )
+        raise UnsupportedWireModelError(msg)
+    if type(model.__pydantic_validator__) is not SchemaValidator:
+        msg = (
+            f"Automatic canonical validation for model {model.__qualname__!r} "
+            "cannot safely bypass a wrapped __pydantic_validator__"
+        )
+        raise UnsupportedWireModelError(msg)
+
+
+def _canonical_validation_schema_transform(
+    schema: dict[str, Any],
+    descendant_changes: int,
+    allow_enum_bridges: bool,
+    hash_required: bool,
+    *,
+    guard_collections: bool,
+    instrument_applications: bool,
+) -> tuple[dict[str, Any], int]:
+    """Add only canonical-input bridges local to authoritative schema nodes."""
+    schema_type = schema.get("type")
+    if allow_enum_bridges and schema_type == "function-after":
+        enum_values = _enum_values(schema)
+        if enum_values is not None:
+            choice_label = SchemaValidator(cast(core_schema.CoreSchema, schema)).title
+            wrapped = _wrap_validation_schema(
+                partial(_retry_enum_value, enum_values=enum_values),
+                schema,
+            )
+            metadata = wrapped.get("metadata")
+            wrapped["metadata"] = {
+                **(dict(metadata) if isinstance(metadata, Mapping) else {}),
+                _UNION_CHOICE_LABEL_METADATA: choice_label,
+            }
+            return (
+                wrapped,
+                _ENUM_BRIDGE_CHANGE,
+            )
+    if guard_collections and schema_type == "any":
+        if hash_required:
+            return (
+                _before_validation_schema(_reject_hash_required_canonical_carrier, schema),
+                _STRUCTURAL_CHANGE | _OPAQUE_HASH_CHANGE,
+            )
+        return (
+            _before_validation_schema(_unwrap_non_hash_canonical_value, schema),
+            _CARRIER_UNWRAP_CHANGE,
+        )
+    if guard_collections and schema_type in {"dict", "set", "frozenset"}:
+        wrapped = _wrap_validation_schema(
+            partial(_guard_collection_cardinality, collection_type=schema_type),
+            schema,
+        )
+        return wrapped, _STRUCTURAL_CHANGE
+    if (
+        instrument_applications
+        and allow_enum_bridges
+        and _is_application_validation_function(schema)
+    ):
+        wrapped = _wrap_validation_schema(_record_union_application_result, schema)
+        changes = _APPLICATION_VALIDATOR_CHANGE
+        if hash_required or descendant_changes & _OPAQUE_HASH_CHANGE:
+            wrapped = _before_validation_schema(
+                _reject_hash_required_canonical_carrier,
+                wrapped,
+            )
+            changes |= _STRUCTURAL_CHANGE
+        elif (
+            not hash_required
+            and not descendant_changes & _STRUCTURAL_CHANGE
+            and schema_type
+            in {
+                "function-before",
+                "function-plain",
+                "function-wrap",
+            }
+        ):
+            wrapped = _before_validation_schema(_unwrap_non_hash_canonical_value, wrapped)
+            changes |= _CARRIER_UNWRAP_CHANGE
+        if (
+            guard_collections
+            and descendant_changes & _STRUCTURAL_CHANGE
+            and schema_type == "function-before"
+        ):
+            wrapped = _wrap_validation_schema(
+                partial(_guard_collection_cardinality, collection_type="before-validator"),
+                wrapped,
+            )
+            changes |= _STRUCTURAL_CHANGE
+        return wrapped, changes
+    if (
+        guard_collections
+        and descendant_changes & _STRUCTURAL_CHANGE
+        and schema_type == "function-before"
+    ):
+        wrapped = _wrap_validation_schema(
+            partial(_guard_collection_cardinality, collection_type="before-validator"),
+            schema,
+        )
+        return wrapped, _STRUCTURAL_CHANGE
+    if schema_type == "union" and descendant_changes & (_ENUM_BRIDGE_CHANGE | _STRUCTURAL_CHANGE):
+        labeled = _label_canonical_union_choices(schema)
+        instrumented = (
+            _instrument_union_application_choices(labeled)
+            if instrument_applications
+            and descendant_changes & (_APPLICATION_VALIDATOR_CHANGE | _STRUCTURAL_CHANGE)
+            else labeled
+        )
+        if descendant_changes & _ENUM_BRIDGE_CHANGE:
+            return (
+                _wrap_validation_schema(_validate_canonical_union, instrumented),
+                _ENUM_BRIDGE_CHANGE | _ENUM_UNION_CHANGE,
+            )
+        return instrumented, 0
+    return schema, 0
+
+
+def _wrap_validation_schema(callback: Any, schema: dict[str, Any]) -> dict[str, Any]:
+    nested = dict(schema)
+    schema_ref = nested.pop("ref", None)
+    wrapped = core_schema.no_info_wrap_validator_function(
+        callback,
+        cast(core_schema.CoreSchema, nested),
+        ref=schema_ref,
+    )
+    return cast(dict[str, Any], wrapped)
+
+
+def _before_validation_schema(callback: Any, schema: dict[str, Any]) -> dict[str, Any]:
+    nested = dict(schema)
+    schema_ref = nested.pop("ref", None)
+    wrapped = core_schema.no_info_before_validator_function(
+        callback,
+        cast(core_schema.CoreSchema, nested),
+        ref=schema_ref,
+    )
+    return cast(dict[str, Any], wrapped)
+
+
+def _enum_values(schema: Mapping[str, Any]) -> tuple[Enum, ...] | None:
+    function = schema.get("function")
+    nested = schema.get("schema")
+    if not isinstance(function, Mapping) or not isinstance(nested, Mapping):
+        return None
+    callback = function.get("function")
+    if (
+        nested.get("type") == "enum"
+        and isinstance(nested.get("cls"), type)
+        and type(callback) is _ATTRGETTER_TYPE
+        and repr(callback) == "operator.attrgetter('value')"
+    ):
+        return tuple(nested["cls"])
+    expected = tuple(nested.get("expected", ()))
+    if (
+        nested.get("type") == "literal"
+        and any(isinstance(item, Enum) for item in expected)
+        and getattr(callback, "__module__", "") == "pydantic._internal._generate_schema"
+        and getattr(callback, "__qualname__", "")
+        == "GenerateSchema._literal_schema.<locals>.<lambda>"
+    ):
+        return tuple(item for item in expected if isinstance(item, Enum))
+    return None
+
+
+def _retry_enum_value(
+    value: Any,
+    handler: Any,
+    *,
+    enum_values: tuple[Enum, ...],
+) -> Any:
+    validation_error: ValidationError | None = None
+    try:
+        validated = handler(value)
+    except ValidationError as exc:
+        validation_error = exc
+        validated = _NOT_FOUND
+    if validated is not _NOT_FOUND and _same_python_value(value, validated):
+        return validated
+    matches = tuple(member for member in enum_values if _same_python_value(value, member.value))
+    if len(matches) != 1:
+        if validated is not _NOT_FOUND:
+            return validated
+        assert validation_error is not None
+        raise validation_error
+    if _suppress_enum_repair_inside_union():
+        if validation_error is not None:
+            raise validation_error
+        return validated
+    return handler(matches[0])
+
+
+def _suppress_enum_repair_inside_union() -> bool:
+    frames = _CANONICAL_UNION_FRAMES.get()
+    if not frames:
+        return False
+    for frame in frames:
+        frame.suppressed_enum = True
+    return True
+
+
+def _instrument_union_application_choices(schema: dict[str, Any]) -> dict[str, Any]:
+    choices = schema.get("choices")
+    if not isinstance(choices, list):
+        return schema
+
+    def instrument(choice: Any) -> Any:
+        if isinstance(choice, tuple) and choice and isinstance(choice[0], dict):
+            return (
+                _wrap_validation_schema(_validate_canonical_union_choice, choice[0]),
+                *choice[1:],
+            )
+        if isinstance(choice, dict):
+            wrapped = _wrap_validation_schema(_validate_canonical_union_choice, choice)
+            try:
+                choice_label = SchemaValidator(cast(core_schema.CoreSchema, choice)).title
+            except SchemaError:
+                return wrapped
+            return (wrapped, choice_label)
+        return choice
+
+    instrumented = dict(schema)
+    instrumented["choices"] = [instrument(choice) for choice in choices]
+    return instrumented
+
+
+def _label_canonical_union_choices(schema: dict[str, Any]) -> dict[str, Any]:
+    choices = schema.get("choices")
+    if not isinstance(choices, list):
+        return schema
+
+    def label(choice: Any) -> Any:
+        if not isinstance(choice, dict):
+            return choice
+        metadata = choice.get("metadata")
+        choice_label = (
+            metadata.get(_UNION_CHOICE_LABEL_METADATA) if isinstance(metadata, Mapping) else None
+        )
+        return (choice, choice_label) if isinstance(choice_label, str) else choice
+
+    labeled = dict(schema)
+    labeled["choices"] = [label(choice) for choice in choices]
+    return labeled
+
+
+def _is_application_validation_function(schema: dict[str, Any]) -> bool:
+    if schema.get("type") not in {
+        "function-after",
+        "function-before",
+        "function-plain",
+        "function-wrap",
+    }:
+        return False
+    if _enum_values(schema) is not None:
+        return False
+    function = schema.get("function")
+    callback = function.get("function") if isinstance(function, Mapping) else None
+    while isinstance(callback, partial):
+        callback = callback.func
+    callback = getattr(callback, "__func__", callback)
+    if any(
+        callback is internal
+        for internal in (
+            _guard_collection_cardinality,
+            _record_union_application_result,
+            _retry_enum_value,
+            _validate_canonical_union,
+            _validate_canonical_union_choice,
+        )
+    ):
+        return False
+    module = getattr(callback, "__module__", None)
+    if module is None:
+        module = getattr(type(callback), "__module__", "")
+    if module == "pydantic" or module == "pydantic_core":
+        return False
+    if module.startswith(("pydantic.", "pydantic_core.")):
+        return False
+    return True
+
+
+def _record_union_application_result(value: Any, handler: Any) -> Any:
+    frame = _CanonicalApplicationFrame()
+    frames = _CANONICAL_APPLICATION_FRAMES.get()
+    token = _CANONICAL_APPLICATION_FRAMES.set((*frames, frame))
+    try:
+        validated = handler(value)
+    finally:
+        _CANONICAL_APPLICATION_FRAMES.reset(token)
+    if frame.collection_violation is not None:
+        _raise_collection_cardinality_error(*frame.collection_violation)
+    choice_frames = _CANONICAL_CHOICE_FRAMES.get()
+    if choice_frames:
+        choice_frames[-1].application_validator_ran = True
+    return validated
+
+
+def _validate_canonical_union_choice(value: Any, handler: Any) -> Any:
+    frame = _CanonicalChoiceFrame()
+    frames = _CANONICAL_CHOICE_FRAMES.get()
+    token = _CANONICAL_CHOICE_FRAMES.set((*frames, frame))
+    try:
+        validated = handler(value)
+    finally:
+        _CANONICAL_CHOICE_FRAMES.reset(token)
+    if frame.collection_violation is not None:
+        _raise_collection_cardinality_error(*frame.collection_violation)
+    union_frames = _CANONICAL_UNION_FRAMES.get()
+    if union_frames:
+        union_frames[-1].choice_results.append(
+            (validated, frame.application_validator_ran),
+        )
+    return validated
+
+
+def _validate_canonical_union(value: Any, handler: Any) -> Any:
+    frame = _CanonicalUnionFrame()
+    frames = _CANONICAL_UNION_FRAMES.get()
+    token = _CANONICAL_UNION_FRAMES.set((*frames, frame))
+    try:
+        validated = handler(value)
+    finally:
+        _CANONICAL_UNION_FRAMES.reset(token)
+    matching_choice_results = tuple(
+        application_ran for result, application_ran in frame.choice_results if validated is result
+    )
+    application_result_selected = bool(matching_choice_results) and all(matching_choice_results)
+    if application_result_selected:
+        choice_frames = _CANONICAL_CHOICE_FRAMES.get()
+        if choice_frames:
+            choice_frames[-1].application_validator_ran = True
+    if (
+        frame.suppressed_enum
+        and not application_result_selected
+        and not _same_canonical_python_shape(value, validated)
+    ):
+        raise PydanticCustomError(
+            _ENUM_UNION_TYPE_ERROR,
+            "Canonical union validation would change a stored enum value",
+        )
+    return validated
+
+
+def _contains_hashable_canonical_mapping(value: Any) -> bool:
+    pending = [value]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if isinstance(current, _HashableCanonicalMapping):
+            return True
+        if not isinstance(current, Mapping | list | tuple | set | frozenset):
+            continue
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if isinstance(current, Mapping):
+            pending.extend(current.keys())
+            pending.extend(current.values())
+        else:
+            pending.extend(current)
+    return False
+
+
+def _unwrap_non_hash_canonical_value(value: Any) -> Any:
+    if not _contains_hashable_canonical_mapping(value):
+        return value
+    return _unwrap_non_hash_canonical_value_with_memo(value, memo={})
+
+
+def _unwrap_non_hash_canonical_value_with_memo(
+    value: Any,
+    *,
+    memo: dict[int, Any],
+) -> Any:
+    identity = id(value)
+    if identity in memo:
+        return memo[identity]
+    if isinstance(value, _HashableCanonicalMapping) or type(value) is dict:
+        copied: dict[Any, Any] = {}
+        memo[identity] = copied
+        try:
+            for key, item in value.items():
+                copied[_unwrap_non_hash_canonical_value_with_memo(key, memo=memo)] = (
+                    _unwrap_non_hash_canonical_value_with_memo(item, memo=memo)
+                )
+        except TypeError:
+            _raise_private_carrier_error()
+        return copied
+    if type(value) is list:
+        copied_list: list[Any] = []
+        memo[identity] = copied_list
+        copied_list.extend(
+            _unwrap_non_hash_canonical_value_with_memo(item, memo=memo) for item in value
+        )
+        return copied_list
+    if type(value) is tuple:
+        memo[identity] = value
+        copied_tuple = tuple(
+            _unwrap_non_hash_canonical_value_with_memo(item, memo=memo) for item in value
+        )
+        memo[identity] = copied_tuple
+        return copied_tuple
+    if type(value) in {set, frozenset}:
+        try:
+            copied_collection = type(value)(
+                _unwrap_non_hash_canonical_value_with_memo(item, memo=memo) for item in value
+            )
+        except TypeError:
+            _raise_private_carrier_error()
+        memo[identity] = copied_collection
+        return copied_collection
+    return value
+
+
+def _reject_hash_required_canonical_carrier(value: Any) -> Any:
+    if _contains_hashable_canonical_mapping(value):
+        _raise_private_carrier_error()
+    return value
+
+
+def _raise_private_carrier_error() -> NoReturn:
+    raise PydanticCustomError(
+        _PRIVATE_CARRIER_ERROR,
+        "Canonical validation cannot expose a private hash carrier",
+    )
+
+
+def _same_canonical_python_shape(
+    left: Any,
+    right: Any,
+    active_pairs: set[tuple[int, int]] | None = None,
+) -> bool:
+    if left is right:
+        return True
+    if isinstance(left, _HashableCanonicalMapping):
+        left = dict(left)
+    if isinstance(right, BaseModel) and isinstance(left, Mapping):
+        right = _extract_declared_fields(right, declared_model=type(right))
+    if isinstance(right, _HashableCanonicalMapping):
+        right = dict(right)
+    if type(left) is not type(right):
+        return False
+    if not isinstance(left, Mapping | list | tuple | set | frozenset):
+        return True
+    if active_pairs is None:
+        active_pairs = set()
+    pair = (id(left), id(right))
+    if pair in active_pairs:
+        return True
+    active_pairs.add(pair)
+    try:
+        return _same_canonical_container_shape(left, right, active_pairs)
+    finally:
+        active_pairs.remove(pair)
+
+
+def _same_canonical_container_shape(
+    left: Mapping[Any, Any] | list[Any] | tuple[Any, ...] | set[Any] | frozenset[Any],
+    right: Any,
+    active_pairs: set[tuple[int, int]],
+) -> bool:
+    if isinstance(left, Mapping):
+        if len(left) != len(right):
+            return False
+        unmatched = list(right.items())
+        for left_key, left_value in left.items():
+            match = next(
+                (
+                    index
+                    for index, (right_key, right_value) in enumerate(unmatched)
+                    if _same_canonical_python_shape(left_key, right_key, active_pairs)
+                    and _same_canonical_python_shape(left_value, right_value, active_pairs)
+                ),
+                None,
+            )
+            if match is None:
+                return False
+            unmatched.pop(match)
+        return True
+    if isinstance(left, list | tuple):
+        return len(left) == len(right) and all(
+            _same_canonical_python_shape(left_item, right_item, active_pairs)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    if isinstance(left, set | frozenset):
+        if len(left) != len(right):
+            return False
+        unmatched = list(right)
+        for left_item in left:
+            match = next(
+                (
+                    index
+                    for index, right_item in enumerate(unmatched)
+                    if _same_canonical_python_shape(left_item, right_item, active_pairs)
+                ),
+                None,
+            )
+            if match is None:
+                return False
+            unmatched.pop(match)
+        return True
+    return False
+
+
+def _guard_collection_cardinality(
+    value: Any,
+    handler: Any,
+    *,
+    collection_type: str,
+) -> Any:
+    if id(value) in _MATERIALIZED_CONTAINER_IDS.get():
+        guarded = True
+    elif collection_type in {"set", "frozenset", "before-validator"} and isinstance(
+        value,
+        list | tuple | set | frozenset,
+    ):
+        guarded = any(_canonical_source_identities(item) for item in value)
+    elif isinstance(value, Mapping):
+        guarded = isinstance(value, Mapping) and any(
+            _canonical_source_identities(key) for key in value
+        )
+    else:
+        guarded = False
+    if not guarded:
+        return handler(value)
+    before = len(value) if isinstance(value, Sized) else None
+    validated = handler(value)
+    after = len(validated) if isinstance(validated, Sized) else None
+    if before is not None and after is not None and before != after:
+        violation = (collection_type, before, after)
+        choice_frames = _CANONICAL_CHOICE_FRAMES.get()
+        if choice_frames:
+            choice_frames[-1].collection_violation = violation
+        else:
+            for frame in _CANONICAL_APPLICATION_FRAMES.get():
+                frame.collection_violation = violation
+        _raise_collection_cardinality_error(collection_type, before, after)
+    return validated
+
+
+def _raise_collection_cardinality_error(
+    collection_type: str,
+    before: int,
+    after: int,
+) -> NoReturn:
+    raise PydanticCustomError(
+        _COLLECTION_CARDINALITY_ERROR,
+        "Canonical {collection_type} validation changed cardinality from {before} to {after}",
+        {
+            "collection_type": collection_type,
+            "before": before,
+            "after": after,
+        },
+    )
+
+
+def _same_python_value(left: Any, right: Any) -> bool:
+    if left is right:
+        return True
+    if type(left) is not type(right):
+        return False
+    try:
+        return bool(left == right)
+    except (TypeError, ValueError):
+        return left is right
+
+
+def _raise_canonical_migration_error(exc: ValidationError) -> None:
+    errors = exc.errors(include_url=False)
+    invariants = [error for error in errors if error.get("type") in _CANONICAL_ERROR_TYPES]
+    if not invariants:
+        return
+    invariant = invariants[0]
+    location = tuple(invariant.get("loc", ()))
+    error_type = invariant.get("type")
+    if error_type == _COLLECTION_CARDINALITY_ERROR:
+        msg = (
+            "Canonical validation cannot preserve set cardinality or mapping-key "
+            f"cardinality at {location!r}"
+        )
+    elif error_type == _ENUM_UNION_TYPE_ERROR:
+        msg = f"Canonical validation cannot preserve a stored enum value at {location!r}"
+    elif error_type == _PRIVATE_CARRIER_ERROR:
+        msg = f"Canonical validation cannot expose a private hash carrier at {location!r}"
+    else:
+        return
+    raise InvalidMigrationError(msg) from exc

--- a/src/pydantic_versions/_runtime_versioning.py
+++ b/src/pydantic_versions/_runtime_versioning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any, Literal
 
 from pydantic import AliasChoices, AliasPath, BaseModel
@@ -17,6 +17,10 @@ from pydantic_versions.exceptions import (
 )
 
 _MISSING = object()
+type _CanonicalMappingCopy = Callable[
+    [Mapping[Any, Any], dict[Any, Any]],
+    Mapping[Any, Any],
+]
 
 
 def _runtime_label(value: object, *, family_name: str) -> str:
@@ -324,12 +328,22 @@ def _to_current_names(
 
 
 def _current_validation_input(
-    model_cls: type[BaseModel], payload: dict[str, Any]
+    model_cls: type[BaseModel],
+    payload: dict[str, Any],
+    *,
+    tracked_container_ids: set[int] | None = None,
+    mapping_copy: _CanonicalMappingCopy | None = None,
 ) -> dict[str, Any]:
     current_payload = dict(payload)
     if model_cls.model_config.get("validate_by_alias", True) is False:
         return current_payload
-    return _normalize_payload_field_aliases(model_cls, current_payload, prefer_aliases=True)
+    return _normalize_payload_field_aliases(
+        model_cls,
+        current_payload,
+        prefer_aliases=True,
+        tracked_container_ids=tracked_container_ids,
+        mapping_copy=mapping_copy,
+    )
 
 
 def _normalize_payload_field_aliases(
@@ -337,8 +351,19 @@ def _normalize_payload_field_aliases(
     payload: Mapping[str, Any],
     *,
     prefer_aliases: bool = False,
+    tracked_container_ids: set[int] | None = None,
+    mapping_copy: _CanonicalMappingCopy | None = None,
 ) -> dict[str, Any]:
-    normalized = {key: _copy_alias_payload_value(value) for key, value in payload.items()}
+    memo: dict[int, Any] = {}
+    normalized = {
+        key: _copy_alias_payload_value(
+            value,
+            tracked_container_ids=tracked_container_ids,
+            mapping_copy=mapping_copy,
+            memo=memo,
+        )
+        for key, value in payload.items()
+    }
     for name, field_info in model_cls.model_fields.items():
         alias_paths = _alias_paths(
             field_info.validation_alias,
@@ -371,14 +396,65 @@ def _normalize_payload_field_aliases(
     return normalized
 
 
-def _copy_alias_payload_value(value: Any) -> Any:
+def _copy_alias_payload_value(
+    value: Any,
+    *,
+    tracked_container_ids: set[int] | None = None,
+    mapping_copy: _CanonicalMappingCopy | None = None,
+    memo: dict[int, Any] | None = None,
+) -> Any:
+    if memo is None:
+        memo = {}
+    identity = id(value)
+    if identity in memo:
+        return memo[identity]
     if isinstance(value, Mapping):
-        return {key: _copy_alias_payload_value(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [_copy_alias_payload_value(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_copy_alias_payload_value(item) for item in value)
-    return value
+        copied_items: dict[Any, Any] = {}
+        memo[identity] = copied_items
+        copied_items.update(
+            {
+                key: _copy_alias_payload_value(
+                    item,
+                    tracked_container_ids=tracked_container_ids,
+                    mapping_copy=mapping_copy,
+                    memo=memo,
+                )
+                for key, item in value.items()
+            },
+        )
+        copied = copied_items if mapping_copy is None else mapping_copy(value, copied_items)
+        memo[identity] = copied
+    elif isinstance(value, list):
+        copied = []
+        memo[identity] = copied
+        copied.extend(
+            _copy_alias_payload_value(
+                item,
+                tracked_container_ids=tracked_container_ids,
+                mapping_copy=mapping_copy,
+                memo=memo,
+            )
+            for item in value
+        )
+    elif isinstance(value, tuple):
+        # A tuple can participate in a cycle only through a mutable child. Keep
+        # that back-edge authoritative while detaching the ordinary contents.
+        memo[identity] = value
+        copied = tuple(
+            _copy_alias_payload_value(
+                item,
+                tracked_container_ids=tracked_container_ids,
+                mapping_copy=mapping_copy,
+                memo=memo,
+            )
+            for item in value
+        )
+        memo[identity] = copied
+    else:
+        return value
+    if tracked_container_ids is not None and id(value) in tracked_container_ids:
+        tracked_container_ids.add(id(copied))
+    return copied
 
 
 def _alias_paths(
@@ -477,8 +553,16 @@ def _model_metadata_field_name(compiled: _CompiledFamily) -> str:
 def _to_version_names(
     version: _CompiledVersion,
     payload: dict[str, Any],
+    *,
+    tracked_container_ids: set[int] | None = None,
+    mapping_copy: _CanonicalMappingCopy | None = None,
 ) -> dict[str, Any]:
-    normalized = _normalize_payload_field_aliases(version.model, payload)
+    normalized = _normalize_payload_field_aliases(
+        version.model,
+        payload,
+        tracked_container_ids=tracked_container_ids,
+        mapping_copy=mapping_copy,
+    )
     original = dict(normalized)
     versioned = dict(normalized)
     renamed = tuple(

--- a/tests/unit/test_canonical_payload_security.py
+++ b/tests/unit/test_canonical_payload_security.py
@@ -1,32 +1,69 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from enum import Enum
-from typing import Any, Literal, cast
+from enum import Enum, IntEnum
+from typing import Annotated, Any, Literal, Self, cast
+from uuid import UUID
 
 import pytest
 from pydantic import (
+    AfterValidator,
     AliasChoices,
     AliasPath,
     AnyUrl,
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
+    PlainValidator,
+    SecretBytes,
     SecretStr,
     ValidationError,
+    WrapValidator,
+    computed_field,
+    create_model,
     field_serializer,
     model_serializer,
+    model_validator,
 )
 
 from pydantic_versions import (
+    InvalidMigrationError,
     NestedFamily,
     SchemaFamily,
     SchemaVersion,
+    UnsupportedWireModelError,
     VersionTransition,
     field_removed,
     matching_labels,
 )
+
+
+def _transition_family(
+    model: type[BaseModel],
+    name: str,
+    callback: Callable[[dict[str, Any]], dict[str, Any]],
+    *,
+    semantics: Literal["exact", "lossy"] = "exact",
+    wire_model: type[BaseModel] | None = None,
+) -> SchemaFamily[Any]:
+    return SchemaFamily(
+        model=model,
+        name=name,
+        versions=(SchemaVersion("1", wire_model=wire_model), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=callback,
+                downgrade=callback,
+                downgrade_semantics=semantics,
+            ),
+        ),
+        version_metadata=None,
+    )
 
 
 class ExcludedPayload(BaseModel):
@@ -347,7 +384,283 @@ def test_source_serializers_do_not_define_the_canonical_transition_payload() -> 
     assert result.source_model.__pydantic_extra__ == {"extension": "source-only"}
 
 
-def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
+def test_adapted_source_revalidation_preserves_native_state_before_projection() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    mutate_revalidated_state = False
+    revalidation_events: list[str] = []
+
+    class Child(BaseModel):
+        value: int
+
+    class ExtendedChild(Child):
+        extension: str
+
+    class HistoricalPayload(BaseModel):
+        model_config = ConfigDict(
+            extra="allow",
+            revalidate_instances="always",
+            strict=True,
+            use_enum_values=True,
+        )
+
+        public: int
+        defaulted: int = 2
+        mode: Mode
+        child: Child
+        state: dict[str, list[int]]
+        internal: int = Field(0, exclude=True)
+        conditional: int = Field(0, exclude_if=lambda value: value == 3)
+
+        @model_validator(mode="before")
+        @classmethod
+        def mutate_nested_state(cls, value: Any) -> Any:
+            if mutate_revalidated_state:
+                revalidation_events.append("before")
+                assert isinstance(value, dict)
+                value["state"]["items"].append(2)
+            return value
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        public: int
+        defaulted: int
+        mode: Mode
+        child: Child
+        state: dict[str, list[int]]
+
+    seen: list[dict[str, Any]] = []
+
+    def inspect(data: dict[str, Any]) -> dict[str, Any]:
+        seen.append(dict(data))
+        return data
+
+    family = _transition_family(
+        CurrentPayload,
+        "adapted_source_full_state",
+        inspect,
+        wire_model=HistoricalPayload,
+    )
+    child = ExtendedChild(value=1, extension="child-only")
+    source = HistoricalPayload.model_validate(
+        {
+            "public": 1,
+            "mode": Mode.active,
+            "child": child,
+            "state": {"items": [1]},
+            "internal": 2,
+            "conditional": 3,
+            "extension": "source-only",
+        },
+    )
+    original_fields_set = set(source.model_fields_set)
+    mutate_revalidated_state = True
+
+    result = family.validate(source, version="1")
+    source_model = cast(HistoricalPayload, result.source_model)
+
+    assert source_model.internal == 2
+    assert source_model.conditional == 3
+    assert source_model.__pydantic_extra__ == {"extension": "source-only"}
+    assert source_model.child is child
+    assert source_model.state == {"items": [1, 2]}
+    assert source_model.model_fields_set == original_fields_set
+    assert seen == [
+        {
+            "public": 1,
+            "defaulted": 2,
+            "mode": "active",
+            "child": {"value": 1},
+            "state": {"items": [1, 2]},
+        },
+    ]
+    assert revalidation_events == ["before"]
+    assert source.internal == 2
+    assert source.conditional == 3
+    assert source.child is child
+    assert source.state == {"items": [1]}
+
+
+@pytest.mark.filterwarnings("ignore:Default value .* is not JSON serializable")
+def test_schema_only_serializer_computed_and_json_input_types_do_not_adapt_validation() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class Rendered(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        children: tuple[Self, ...] = ()
+
+    events: list[str] = []
+
+    class Payload(BaseModel):
+        value: Annotated[
+            int,
+            PlainValidator(int, json_schema_input_type=set[Rendered]),
+        ]
+        payload: Any = {
+            "type": "set",
+            "items_schema": Rendered.__pydantic_core_schema__,
+        }
+
+        def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+            events.append("new")
+            return super().__new__(cls)
+
+        @field_serializer("value", return_type=Mode)
+        def serialize_value(self, _value: int) -> Mode:
+            events.append("serializer")
+            return Mode.active
+
+        @computed_field(return_type=set[Rendered])
+        @property
+        def rendered(self) -> set[Rendered]:
+            return set()
+
+    family = SchemaFamily(
+        model=Payload,
+        name="validation_ignores_schema_only_children",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+
+    result = family.validate({"value": 1}, version="1")
+
+    assert result.current_model.value == 1
+    assert result.current_model.payload["type"] == "set"
+    assert events == ["new"]
+
+
+@pytest.mark.parametrize("operation", ["validate", "render"])
+@pytest.mark.parametrize("override_kind", ["model_validate", "validator_proxy"])
+def test_adapted_validation_rejects_runtime_validator_overrides_after_cache_warm(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    override_kind: str,
+) -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class HistoricalPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        item: Mode
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(
+            revalidate_instances="always",
+            strict=True,
+            use_enum_values=True,
+        )
+
+        item: Mode
+
+    family = _transition_family(
+        CurrentPayload,
+        f"runtime_validator_override_{operation}_{override_kind}",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    historical = HistoricalPayload(item=Mode.active)
+    current = CurrentPayload(item=Mode.active)
+    family.validate(historical, version="1")
+    family.dump(version="2", data=current)
+    events: list[str] = []
+
+    if override_kind == "model_validate":
+        original = CurrentPayload.model_validate
+
+        def overridden(_cls: type[CurrentPayload], value: Any, **kwargs: Any) -> Any:
+            events.append("model_validate")
+            return original(value, **kwargs)
+
+        monkeypatch.setattr(CurrentPayload, "model_validate", classmethod(overridden))
+        CurrentPayload.model_validate({"item": Mode.active})
+        match = "overridden model_validate"
+    else:
+        delegate = CurrentPayload.__pydantic_validator__
+
+        class ValidatorProxy:
+            def validate_python(self, *args: Any, **kwargs: Any) -> Any:
+                events.append("validator_proxy")
+                return delegate.validate_python(*args, **kwargs)
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(delegate, name)
+
+        monkeypatch.setattr(CurrentPayload, "__pydantic_validator__", ValidatorProxy())
+        CurrentPayload.model_validate({"item": Mode.active})
+        match = "wrapped __pydantic_validator__"
+    assert len(events) == 1
+    events.clear()
+
+    with pytest.raises(UnsupportedWireModelError, match=match):
+        if operation == "validate":
+            family.validate(historical, version="1")
+        else:
+            family.dump(version="2", data=current)
+    assert events == []
+
+    if override_kind == "model_validate":
+        monkeypatch.setattr(
+            CurrentPayload,
+            "model_validate",
+            BaseModel.__dict__["model_validate"],
+        )
+    else:
+        monkeypatch.setattr(CurrentPayload, "__pydantic_validator__", delegate)
+    if operation == "validate":
+        assert family.validate(historical, version="1").current_model.item == "active"
+    else:
+        assert family.dump(version="2", data=current) == {"item": "active"}
+
+
+@pytest.mark.parametrize("wire_kind", ["explicit", "generated"])
+def test_historical_subclass_fields_stay_outside_canonical_payload(wire_kind: str) -> None:
+    class HistoricalPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        value: int
+
+    seen: list[dict[str, Any]] = []
+
+    def inspect(data: dict[str, Any]) -> dict[str, Any]:
+        seen.append(dict(data))
+        return data
+
+    family = _transition_family(
+        CurrentPayload,
+        f"historical_subclass_boundary_{wire_kind}",
+        inspect,
+        wire_model=HistoricalPayload if wire_kind == "explicit" else None,
+    )
+    declared_source = HistoricalPayload if wire_kind == "explicit" else family.model_for("1")
+    extended_source = create_model(
+        f"ExtendedHistoricalPayload_{wire_kind}",
+        __base__=declared_source,
+        secret=(str, ...),
+    )
+    source: Any = extended_source.model_validate(
+        {"value": 1, "secret": "caller", "extension": "source-only"}
+    )
+
+    result = family.validate(source, version="1")
+
+    assert seen == [{"value": 1}]
+    assert source.secret == "caller"
+    assert source.__pydantic_extra__ == {"extension": "source-only"}
+    assert result.source_model is source
+    assert result.current_model.__pydantic_extra__ == {}
+
+
+def test_declared_extraction_preserves_validated_python_values() -> None:
     class Mode(Enum):
         active = "active"
 
@@ -367,20 +680,26 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
         raw: bytes
         amount: Decimal
         secret: SecretStr
+        secret_bytes: SecretBytes
         labels: tuple[Mode, ...]
         indexes: set[int]
         schedule: dict[datetime, Mode]
+        lookup: dict[UUID, UUID]
 
     class CurrentScalarPayload(BaseModel):
+        model_config = ConfigDict(strict=True)
+
         occurred_at: Any
         endpoint: Any
-        mode: Any
-        raw: Any
+        mode: Mode
+        raw: bytes
         amount: Any
-        secret: Any
-        labels: Any
-        indexes: Any
+        secret: SecretStr
+        secret_bytes: SecretBytes
+        labels: tuple[Mode, ...]
+        indexes: set[int]
         schedule: Any
+        lookup: dict[UUID, UUID]
 
     def inspect_payload(payload: dict[str, Any]) -> dict[str, Any]:
         seen_payloads.append(dict(payload))
@@ -393,7 +712,15 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
             SchemaVersion("1", wire_model=HistoricalScalarWire),
             SchemaVersion("2"),
         ),
-        transitions=(VersionTransition("1", "2", upgrade=inspect_payload),),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=inspect_payload,
+                downgrade=inspect_payload,
+                downgrade_semantics="exact",
+            ),
+        ),
         version_metadata=None,
     )
     source_data = {
@@ -403,35 +730,36 @@ def test_declared_extraction_preserves_the_previous_json_scalar_shape() -> None:
         "raw": "_wA=",
         "amount": "1.20",
         "secret": "private",
+        "secret_bytes": b"private-bytes",
         "labels": ["active"],
         "indexes": [2, 1],
         "schedule": {"2020-01-02T03:04:05Z": "active"},
+        "lookup": {"12345678-1234-5678-1234-567812345678": "12345678-1234-5678-1234-567812345678"},
     }
-    expected = (
-        family.model_for("1")
-        .model_validate(source_data)
-        .model_dump(
-            by_alias=False,
-            mode="json",
-        )
-    )
+    validated = family.validate(source_data, version="1")
+    rendered = family.dump(version="1", data=validated.current_model)
 
-    family.validate(source_data, version="1")
-
-    assert seen_payloads == [expected]
-    assert seen_payloads == [
-        {
-            "occurred_at": 1_577_934_245_000.0,
-            "endpoint": "https://example.com/config",
-            "mode": "active",
-            "raw": "_wA=",
-            "amount": "1.20",
-            "secret": "**********",
-            "labels": ["active"],
-            "indexes": [1, 2],
-            "schedule": {"1577934245000": "active"},
-        },
-    ]
+    assert len(seen_payloads) == 2
+    for payload in seen_payloads:
+        assert payload["occurred_at"] == datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC)
+        assert str(payload["endpoint"]) == "https://example.com/config"
+        assert payload["mode"] is Mode.active
+        assert payload["raw"] == b"\xff\x00"
+        assert payload["amount"] == Decimal("1.20")
+        assert payload["secret"].get_secret_value() == "private"
+        assert payload["secret_bytes"].get_secret_value() == b"private-bytes"
+        assert payload["labels"] == (Mode.active,)
+        assert payload["indexes"] == {1, 2}
+        assert payload["schedule"] == {
+            datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC): Mode.active,
+        }
+        assert payload["lookup"] == {
+            UUID("12345678-1234-5678-1234-567812345678"): UUID(
+                "12345678-1234-5678-1234-567812345678"
+            ),
+        }
+    assert rendered["secret"] == "**********"
+    assert rendered["secret_bytes"] == "**********"
 
 
 def test_legacy_timedelta_mode_does_not_change_other_temporal_scalars() -> None:
@@ -465,21 +793,1064 @@ def test_legacy_timedelta_mode_does_not_change_other_temporal_scalars() -> None:
         "occurred_at": datetime(2020, 1, 2, 3, 4, 5, tzinfo=UTC),
         "duration": timedelta(seconds=1.5),
     }
-    expected = (
-        family.model_for("1")
-        .model_validate(source_data)
-        .model_dump(
-            by_alias=False,
-            mode="json",
-        )
-    )
-
     family.validate(source_data, version="1")
 
-    assert seen_payloads == [expected]
-    assert seen_payloads == [
-        {
-            "occurred_at": "2020-01-02T03:04:05Z",
-            "duration": 1.5,
-        },
+    assert seen_payloads == [source_data]
+
+
+def test_use_enum_values_keeps_raw_values_when_a_strict_declared_arm_accepts_them() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class Number(IntEnum):
+        one = 1
+
+    validator_events: list[str] = []
+    reject_strings = False
+
+    def enum_after(value: Mode) -> Mode:
+        validator_events.append("enum")
+        return value
+
+    def string_after(value: str) -> str:
+        validator_events.append("string")
+        if reject_strings:
+            raise ValueError("string arm rejected")
+        return value
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        direct: (
+            Annotated[Mode, AfterValidator(enum_after)]
+            | Annotated[str, AfterValidator(string_after)]
+        )
+        listed: list[Mode] | list[str]
+        literal: Literal[Mode.active, "active"]
+        literal_list: list[Literal[Mode.active, "active"]]
+        literal_key: dict[Literal[Mode.active, "active"], int]
+        number: Number | int
+        boolean: Number | bool
+
+    seen: list[dict[str, Any]] = []
+
+    def inspect(data: dict[str, Any]) -> dict[str, Any]:
+        seen.append(dict(data))
+        return data
+
+    family = _transition_family(
+        Payload,
+        "raw_enum_union_arms",
+        inspect,
+    )
+    source = {
+        "direct": Mode.active,
+        "listed": [Mode.active],
+        "literal": Mode.active,
+        "literal_list": [Mode.active],
+        "literal_key": {Mode.active: 1},
+        "number": Number.one,
+        "boolean": True,
+    }
+
+    validated = family.validate(source, version="1").current_model
+    family.dump(version="1", data=Payload.model_validate(source))
+
+    assert validated.model_dump() == {
+        "direct": "active",
+        "listed": ["active"],
+        "literal": "active",
+        "literal_list": ["active"],
+        "literal_key": {"active": 1},
+        "number": 1,
+        "boolean": True,
+    }
+    assert seen == [validated.model_dump(), validated.model_dump()]
+    assert validator_events == ["string", "enum"]
+
+    reject_strings = True
+    validator_events.clear()
+    with pytest.raises(ValidationError, match="string arm rejected"):
+        family.validate(source, version="1")
+    assert validator_events == ["string"]
+
+
+def test_strict_enum_unions_keep_application_validator_outputs_once() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class HistoricalPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        scalar: Mode
+        wrapped: Mode
+        listed: list[Mode]
+        mapped: dict[str, Mode]
+
+    events: list[str] = []
+
+    def transform_string(value: str) -> str:
+        events.append("scalar")
+        return f"{value}!"
+
+    def transform_list(value: list[str]) -> list[str]:
+        events.append("list")
+        return [*value, "extra"]
+
+    def transform_mapping(value: dict[str, str]) -> dict[str, str]:
+        events.append("mapping")
+        return {**value, "extra": "added"}
+
+    def transform_wrap(value: Any, handler: Any) -> str:
+        events.append("wrap")
+        return f"{handler(value)}?"
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        scalar: Mode | Annotated[str, AfterValidator(transform_string)]
+        wrapped: Mode | Annotated[str, WrapValidator(transform_wrap)]
+        listed: list[Mode] | Annotated[list[str], AfterValidator(transform_list)]
+        mapped: (
+            dict[str, Mode]
+            | Annotated[
+                dict[str, str],
+                AfterValidator(transform_mapping),
+            ]
+        )
+
+    family = _transition_family(
+        CurrentPayload,
+        "strict_enum_union_application_output",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(
+        scalar=Mode.active,
+        wrapped=Mode.active,
+        listed=[Mode.active],
+        mapped={"value": Mode.active},
+    )
+    events.clear()
+
+    validated = family.validate(source, version="1").current_model
+
+    assert validated.scalar == "active!"
+    assert validated.wrapped == "active?"
+    assert validated.listed == ["active", "extra"]
+    assert validated.mapped == {"value": "active", "extra": "added"}
+    assert events == ["scalar", "wrap", "list", "mapping"]
+
+
+def test_strict_enum_union_keeps_cyclic_application_output_once() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class EnumArm(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        value: Mode
+
+    class HistoricalPayload(BaseModel):
+        item: EnumArm
+
+    events: list[str] = []
+
+    def make_cycle(value: Any) -> Any:
+        events.append("cycle")
+        assert isinstance(value, dict)
+        value["self"] = value
+        return value
+
+    class CurrentPayload(BaseModel):
+        item: EnumArm | Annotated[Any, AfterValidator(make_cycle)]
+
+    family = _transition_family(
+        CurrentPayload,
+        "strict_enum_union_cyclic_application_output",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(item=EnumArm(value=Mode.active))
+    events.clear()
+
+    validated = family.validate(source, version="1").current_model
+
+    assert isinstance(validated.item, dict)
+    assert validated.item["self"] is validated.item
+    assert events == ["cycle"]
+    assert source.item.value == "active"
+
+
+def test_strict_enum_union_keeps_nested_model_application_output_once() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class HistoricalArm(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        value: Mode
+
+    class HistoricalPayload(BaseModel):
+        item: HistoricalArm
+
+    events: list[str] = []
+
+    def to_bytes(value: str) -> bytes:
+        events.append("after")
+        return value.encode()
+
+    class EnumArm(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        value: Mode
+
+    class StringArm(BaseModel):
+        model_config = ConfigDict(strict=True)
+
+        value: Annotated[str, AfterValidator(to_bytes)]
+
+    class CurrentPayload(BaseModel):
+        item: EnumArm | StringArm
+
+    raw = {"item": {"value": "active"}}
+    native = CurrentPayload.model_validate(raw)
+    assert isinstance(native.item, StringArm)
+    assert native.item.value == b"active"
+    events.clear()
+
+    family = _transition_family(
+        CurrentPayload,
+        "strict_enum_union_nested_model_application_output",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(item=HistoricalArm(value=Mode.active))
+
+    validated = family.validate(source, version="1").current_model
+
+    assert isinstance(validated.item, StringArm)
+    assert validated.item.value == b"active"
+    assert events == ["after"]
+    assert source.item.value == "active"
+
+
+def test_callback_created_cycle_uses_native_any_union_arm() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class EnumArm(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        value: Mode
+
+    class HistoricalPayload(BaseModel):
+        item: EnumArm
+
+    class CurrentPayload(BaseModel):
+        item: EnumArm | Any
+
+    def add_cycle(data: dict[str, Any]) -> dict[str, Any]:
+        item = data["item"]
+        item["self"] = item
+        return data
+
+    family = _transition_family(
+        CurrentPayload,
+        "strict_enum_union_callback_cycle",
+        add_cycle,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(item=EnumArm(value=Mode.active))
+
+    validated = family.validate(source, version="1").current_model
+
+    assert isinstance(validated.item, dict)
+    assert validated.item["self"] is validated.item
+    assert source.item.value == "active"
+
+
+def test_strict_enum_unions_keep_before_and_plain_validator_results_once() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class HistoricalPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        before: Mode
+        plain: Mode
+        nested_after: list[Mode]
+        nested_before: list[Mode]
+        nested_plain: list[Mode]
+        unselected: Mode
+        nested_unselected: list[Mode]
+
+    events: list[str] = []
+
+    def select_before(_value: Any) -> int:
+        events.append("before")
+        return 7
+
+    def select_plain(_value: Any) -> int:
+        events.append("plain")
+        return 8
+
+    def select_nested_after(value: str) -> bytes:
+        events.append("nested_after")
+        return value.encode()
+
+    def select_nested_before(_value: Any) -> int:
+        events.append("nested_before")
+        return 10
+
+    def select_nested_plain(_value: Any) -> int:
+        events.append("nested_plain")
+        return 11
+
+    def lose_to_exact_string(_value: Any) -> str:
+        events.append("unselected")
+        return "not-an-integer"
+
+    def lose_nested_to_exact_strings(_value: Any) -> str:
+        events.append("nested_unselected")
+        return "not-an-integer"
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        before: Mode | Annotated[int, BeforeValidator(select_before)]
+        plain: Mode | Annotated[int, PlainValidator(select_plain)]
+        nested_after: list[Mode] | list[Annotated[str, AfterValidator(select_nested_after)]]
+        nested_before: list[Mode] | list[Annotated[int, BeforeValidator(select_nested_before)]]
+        nested_plain: list[Mode] | list[Annotated[int, PlainValidator(select_nested_plain)]]
+        unselected: Mode | Annotated[int, BeforeValidator(lose_to_exact_string)] | str
+        nested_unselected: (
+            list[Mode]
+            | list[Annotated[int, BeforeValidator(lose_nested_to_exact_strings)]]
+            | list[str]
+        )
+
+    raw_values = {
+        "before": "active",
+        "plain": "active",
+        "nested_after": ["active"],
+        "nested_before": ["active"],
+        "nested_plain": ["active"],
+        "unselected": "active",
+        "nested_unselected": ["active"],
+    }
+    assert CurrentPayload.model_validate(raw_values).model_dump() == {
+        "before": 7,
+        "plain": 8,
+        "nested_after": [b"active"],
+        "nested_before": [10],
+        "nested_plain": [11],
+        "unselected": "active",
+        "nested_unselected": ["active"],
+    }
+    events.clear()
+    family = _transition_family(
+        CurrentPayload,
+        "strict_enum_union_before_plain_output",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(
+        before=Mode.active,
+        plain=Mode.active,
+        nested_after=[Mode.active],
+        nested_before=[Mode.active],
+        nested_plain=[Mode.active],
+        unselected=Mode.active,
+        nested_unselected=[Mode.active],
+    )
+
+    validated = family.validate(source, version="1").current_model
+
+    assert validated.model_dump() == {
+        "before": 7,
+        "plain": 8,
+        "nested_after": [b"active"],
+        "nested_before": [10],
+        "nested_plain": [11],
+        "unselected": "active",
+        "nested_unselected": ["active"],
+    }
+    assert events == [
+        "before",
+        "plain",
+        "nested_after",
+        "nested_before",
+        "nested_plain",
+        "unselected",
+        "nested_unselected",
     ]
+
+
+def test_wrap_cannot_swallow_carrier_cardinality_violation() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class HistoricalPayload(BaseModel):
+        items: set[Child]
+
+    events: list[str] = []
+
+    def waive_rejected_set(value: Any, handler: Any) -> Any:
+        events.append("wrap")
+        try:
+            handler(value)
+        except ValidationError:
+            return {"waived"}
+        raise ValueError("reject the set arm after parsing")
+
+    class DirectPayload(BaseModel):
+        items: Annotated[
+            set[Child],
+            WrapValidator(waive_rejected_set),
+            WrapValidator(waive_rejected_set),
+        ]
+
+    class UnionPayload(BaseModel):
+        items: Annotated[set[Child], WrapValidator(waive_rejected_set)] | tuple[Child, ...]
+
+    def collapse(data: dict[str, Any]) -> dict[str, Any]:
+        items = list(data["items"])
+        for item in items:
+            item["value"] = 0
+        return {**data, "items": items}
+
+    direct_family = _transition_family(
+        DirectPayload,
+        "direct_wrap_cardinality_failure",
+        collapse,
+        wire_model=HistoricalPayload,
+    )
+    union_family = _transition_family(
+        UnionPayload,
+        "union_wrap_cardinality_fallback",
+        collapse,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(items={Child(value=1), Child(value=2)})
+
+    with pytest.raises(InvalidMigrationError, match="set cardinality"):
+        direct_family.validate(source, version="1")
+    assert events == ["wrap", "wrap"]
+
+    events.clear()
+    validated = union_family.validate(source, version="1").current_model
+
+    assert isinstance(validated.items, tuple)
+    assert [item.value for item in validated.items] == [0, 0]
+    assert events == ["wrap"]
+    assert {item.value for item in source.items} == {1, 2}
+
+
+def test_reentrant_canonical_validation_isolates_application_frames() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class InnerPayload(BaseModel):
+        items: set[Child]
+
+    def collapse(data: dict[str, Any]) -> dict[str, Any]:
+        items = list(data["items"])
+        for item in items:
+            item["value"] = 0
+        return {**data, "items": items}
+
+    inner_family = _transition_family(
+        InnerPayload,
+        "reentrant_inner_cardinality",
+        collapse,
+        wire_model=InnerPayload,
+    )
+    inner_source = InnerPayload(items={Child(value=1), Child(value=2)})
+
+    class Mode(Enum):
+        active = "active"
+
+    class HistoricalPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        item: Mode
+
+    events: list[str] = []
+
+    def run_inner(value: str) -> str:
+        events.append("outer")
+        with pytest.raises(InvalidMigrationError, match="cardinality"):
+            inner_family.validate(inner_source, version="1")
+        events.append("caught")
+        return f"{value}!"
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        item: Mode | Annotated[str, AfterValidator(run_inner)]
+
+    family = _transition_family(
+        CurrentPayload,
+        "reentrant_outer_application",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+
+    validated = family.validate(
+        HistoricalPayload(item=Mode.active),
+        version="1",
+    ).current_model
+
+    assert validated.item == "active!"
+    assert events == ["outer", "caught"]
+    assert {item.value for item in inner_source.items} == {1, 2}
+
+
+def test_adapted_validation_preserves_authoritative_error_config_and_union_locations() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class HistoricalPayload(BaseModel):
+        item: Any
+        count: int
+
+    class CurrentPayload(BaseModel):
+        model_config = ConfigDict(
+            hide_input_in_errors=True,
+            strict=True,
+            title="Public Current Payload",
+            use_enum_values=True,
+        )
+
+        item: Mode | int
+        count: int = Field(gt=0)
+
+    family = _transition_family(
+        CurrentPayload,
+        "canonical_error_contract",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    raw = {"item": "bad", "count": -1}
+
+    with pytest.raises(ValidationError) as native_error:
+        CurrentPayload.model_validate(raw)
+    with pytest.raises(ValidationError) as family_error:
+        family.validate(raw, version="1")
+
+    native = native_error.value
+    adapted = family_error.value
+    assert adapted.title == native.title == "Public Current Payload"
+    assert [error["loc"] for error in adapted.errors()] == [
+        error["loc"] for error in native.errors()
+    ]
+    assert "input_value" not in str(adapted)
+    assert "input_type" not in str(adapted)
+
+
+@pytest.mark.parametrize("operation", ["validate", "render"])
+def test_strict_enum_unions_fail_closed_before_changing_stored_python_types(
+    operation: str,
+) -> None:
+    class Number(IntEnum):
+        one = 1
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        number: Number | float
+        reversed_literal: Literal[1.0, Number.one]  # ty: ignore[invalid-type-form]
+        boolean: Literal[1] | bool
+        listed: list[Number | float]
+        keyed: dict[Number | float, str]
+
+    class HistoricalPayload(Payload):
+        pass
+
+    seen: list[dict[str, Any]] = []
+
+    def inspect(data: dict[str, Any]) -> dict[str, Any]:
+        seen.append(dict(data))
+        return data
+
+    family = _transition_family(
+        Payload,
+        "strict_enum_python_type_preservation",
+        inspect,
+        wire_model=HistoricalPayload,
+    )
+    canonical_values = {
+        "number": Number.one,
+        "reversed_literal": Number.one,
+        "boolean": True,
+        "listed": [Number.one],
+        "keyed": {Number.one: "value"},
+    }
+    # These are the authoritative values Pydantic stores after validating the
+    # enum-bearing inputs. model_construct avoids a second native Literal pass
+    # changing bool to equal int before the canonical seam is exercised.
+    HistoricalPayload.model_validate(canonical_values)
+    stored_values: dict[str, Any] = {
+        "number": 1,
+        "reversed_literal": 1,
+        "boolean": True,
+        "listed": [1],
+        "keyed": {1: "value"},
+    }
+    with pytest.raises(InvalidMigrationError, match="stored enum value"):
+        if operation == "validate":
+            family.validate(
+                HistoricalPayload.model_construct(**stored_values),
+                version="1",
+            )
+        else:
+            family.dump(
+                version="1",
+                data=Payload.model_construct(**stored_values),
+            )
+
+    assert len(seen) == 1
+    payload = seen[0]
+    assert type(payload["number"]) is int
+    assert type(payload["reversed_literal"]) is int
+    assert type(payload["boolean"]) is bool
+    assert type(payload["listed"][0]) is int
+    assert type(next(iter(payload["keyed"]))) is int
+
+
+@pytest.mark.parametrize("operation", ["validate", "render"])
+def test_callback_wrong_fixed_tuple_arity_uses_pydantic_validation_error(
+    operation: str,
+) -> None:
+    class Payload(BaseModel):
+        values: tuple[int, int]
+
+    def remove_item(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "values": (data["values"][0],)}
+
+    family = _transition_family(
+        Payload,
+        f"fixed_tuple_arity_{operation}",
+        remove_item,
+        semantics="lossy",
+    )
+
+    with pytest.raises(ValidationError, match="Field required"):
+        if operation == "validate":
+            family.validate({"values": (1, 2)}, version="1")
+        else:
+            family.dump(version="1", data=Payload(values=(1, 2)))
+
+
+@pytest.mark.parametrize("operation", ["validate", "render"])
+@pytest.mark.parametrize("values", [(1,), (1, 2, 3)])
+def test_malformed_fixed_tuple_instance_uses_authoritative_validation(
+    operation: str,
+    values: tuple[int, ...],
+) -> None:
+    class Payload(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: tuple[int, int]
+
+    family = SchemaFamily(
+        model=Payload,
+        name=f"malformed_fixed_tuple_{operation}_{len(values)}",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    source_model = family.model_for("1") if operation == "validate" else Payload
+    source: Any = source_model.model_construct(value=values)
+
+    with pytest.raises(ValidationError) as exc_info:
+        if operation == "validate":
+            family.validate(source, version="1")
+        else:
+            family.dump(version="1", data=source)
+
+    assert exc_info.value.errors()[0]["type"] == ("missing" if len(values) == 1 else "too_long")
+    assert source.value == values
+
+
+def test_cyclic_revalidated_model_fails_closed_without_recursing() -> None:
+    class Node(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int
+        child: Self | None = None
+
+    family = SchemaFamily(
+        model=Node,
+        name="cyclic_revalidated_model",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    source = Node(value=1)
+    source.child = source
+
+    with pytest.raises(ValidationError) as native_error:
+        Node.model_validate(source)
+    assert native_error.value.errors()[0]["type"] == "recursion_loop"
+
+    with pytest.raises(ValidationError) as family_error:
+        family.dump(version="1", data=source)
+    assert family_error.value.errors()[0]["type"] == "recursion_loop"
+
+    assert source.child is source
+
+
+@pytest.mark.parametrize("operation", ["validate", "render"])
+def test_callback_mutation_cannot_hide_set_or_mapping_key_collapse(operation: str) -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    collapse_carriers = False
+
+    def collapse_hash_positions(data: dict[str, Any]) -> dict[str, Any]:
+        if collapse_carriers:
+            children = list(data["children"]) if operation == "render" else tuple(data["children"])
+            for child in children:
+                child["value"] = 0
+            data["children"] = children
+            for child in data["lookup"]:
+                child["value"] = 0
+            del data["required"]
+        data["ordinary"] = (item for item in (3,))
+        return data
+
+    class Payload(BaseModel):
+        children: set[Child]
+        lookup: dict[Child, int]
+        ordinary: set[int]
+        required: int
+
+    family = _transition_family(
+        Payload,
+        f"callback_hash_collapse_{operation}",
+        collapse_hash_positions,
+        semantics="lossy",
+    )
+    current = Payload(
+        children={Child(value=1), Child(value=2)},
+        lookup={Child(value=3): 1, Child(value=4): 2},
+        ordinary={1, 2},
+        required=1,
+    )
+    source = family.model_for("1").model_construct(
+        children=current.children,
+        lookup=current.lookup,
+        ordinary=current.ordinary,
+        required=current.required,
+    )
+    if operation == "render":
+        assert family.dump(version="1", data=current)["ordinary"] == [3]
+    else:
+        assert family.validate(source, version="1").current_model.ordinary == {3}
+
+    collapse_carriers = True
+    with pytest.raises(InvalidMigrationError, match="cardinality") as exc_info:
+        if operation == "render":
+            family.dump(version="1", data=current)
+        else:
+            family.validate(source, version="1")
+
+    errors = cast(ValidationError, exc_info.value.__cause__).errors()
+    assert {error["loc"] for error in errors} == {
+        ("children",),
+        ("lookup",),
+        ("required",),
+    }
+    assert {child.value for child in current.children} == {1, 2}
+    assert {child.value for child in current.lookup} == {3, 4}
+
+
+def test_hash_carriers_unwrap_at_non_hash_any_targets_without_leaking() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class HistoricalPayload(BaseModel):
+        items: set[Child]
+        nested: set[Child]
+        choice: set[Child]
+        opaque: set[Child]
+
+    class CurrentPayload(BaseModel):
+        items: list[Any]
+        nested: dict[str, list[Any]]
+        choice: list[Any] | tuple[Any, ...]
+        opaque: Any
+
+    def reshape(data: dict[str, Any]) -> dict[str, Any]:
+        opaque_item = next(iter(data["opaque"]))
+        cycle: list[Any] = []
+        cycle.append(cycle)
+        return {
+            "items": list(data["items"]),
+            "nested": {"values": list(data["nested"])},
+            "choice": list(data["choice"]),
+            "opaque": {
+                "list": [opaque_item],
+                "tuple": (opaque_item,),
+                "cycle": cycle,
+            },
+        }
+
+    family = _transition_family(
+        CurrentPayload,
+        "non_hash_any_carrier_unwrap",
+        reshape,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(
+        items={Child(value=1)},
+        nested={Child(value=2)},
+        choice={Child(value=3)},
+        opaque={Child(value=4)},
+    )
+
+    current = family.validate(source, version="1").current_model
+
+    assert current.items == [{"value": 1}]
+    assert current.nested == {"values": [{"value": 2}]}
+    assert isinstance(current.choice, list)
+    assert current.choice == [{"value": 3}]
+    assert current.opaque["list"] == [{"value": 4}]
+    assert current.opaque["tuple"] == ({"value": 4},)
+    assert current.opaque["cycle"][0] is current.opaque["cycle"]
+    assert all(type(item) is dict for item in current.items)
+    assert type(current.nested["values"][0]) is dict
+    assert type(current.choice[0]) is dict
+    assert type(current.opaque["list"][0]) is dict
+    assert type(current.opaque["tuple"][0]) is dict
+
+
+def test_carrier_unwrap_preserves_sibling_sets_and_unrelated_hash_values() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class HistoricalPayload(BaseModel):
+        items: set[Child]
+        tags: set[int]
+        opaque: set[str]
+
+    class CurrentPayload(BaseModel):
+        payload: Any
+        opaque: set[Any]
+
+    def reshape(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "payload": {
+                "projected": next(iter(data["items"])),
+                "tags": data["tags"],
+            },
+            "opaque": data["opaque"],
+        }
+
+    family = _transition_family(
+        CurrentPayload,
+        "carrier_unwrap_sibling_sets",
+        reshape,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(
+        items={Child(value=1)},
+        tags={2, 3},
+        opaque={"keep"},
+    )
+
+    current = family.validate(source, version="1").current_model
+
+    assert current.payload == {
+        "projected": {"value": 1},
+        "tags": {2, 3},
+    }
+    assert type(current.payload["projected"]) is dict
+    assert type(current.payload["tags"]) is set
+    assert current.opaque == {"keep"}
+    assert type(current.opaque) is set
+    assert source.items == {Child(value=1)}
+    assert source.tags == {2, 3}
+    assert source.opaque == {"keep"}
+
+
+def test_nested_mapping_key_carrier_fails_before_unhashable_any_materialization() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class HistoricalPayload(BaseModel):
+        keyed: dict[Child, int]
+
+    class CurrentPayload(BaseModel):
+        items: list[Any]
+
+    family = _transition_family(
+        CurrentPayload,
+        "nested_mapping_key_carrier_unwrap",
+        lambda data: {"items": [data["keyed"]]},
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(keyed={Child(value=1): 2})
+
+    with pytest.raises(InvalidMigrationError, match="private hash carrier"):
+        family.validate(source, version="1")
+
+    assert source.keyed == {Child(value=1): 2}
+
+
+def test_hash_carriers_fail_closed_at_opaque_hash_positions() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class HistoricalPayload(BaseModel):
+        items: set[Child]
+        opaque: set[Child]
+
+    class CurrentPayload(BaseModel):
+        items: set[Any]
+        opaque: Any
+
+    family = _transition_family(
+        CurrentPayload,
+        "opaque_hash_carrier_boundary",
+        lambda data: data,
+        wire_model=HistoricalPayload,
+    )
+    source = HistoricalPayload(
+        items={Child(value=1)},
+        opaque={Child(value=2)},
+    )
+
+    with pytest.raises(InvalidMigrationError, match="private hash carrier"):
+        family.validate(source, version="1")
+    assert {item.value for item in source.items} == {1}
+    assert {item.value for item in source.opaque} == {2}
+
+
+@pytest.mark.parametrize("position", ["set", "mapping_key"])
+@pytest.mark.parametrize("validator_kind", ["before", "plain", "wrap"])
+def test_opaque_hash_positions_reject_carriers_before_application_validators(
+    position: str,
+    validator_kind: str,
+) -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    seen: list[Any] = []
+
+    def observe(value: Any) -> Any:
+        seen.append(value)
+        return value
+
+    def observe_wrap(value: Any, handler: Any) -> Any:
+        seen.append(value)
+        return handler(value)
+
+    if validator_kind == "before":
+        opaque = Annotated[Any, BeforeValidator(observe)]
+    elif validator_kind == "plain":
+        opaque = Annotated[Any, PlainValidator(observe)]
+    else:
+        opaque = Annotated[Any, WrapValidator(observe_wrap)]
+    historical_annotation = set[Child] if position == "set" else dict[Child, int]
+    current_annotation = set[opaque] if position == "set" else dict[opaque, int]
+    historical_payload = create_model(
+        f"HistoricalOpaqueHash{position}{validator_kind}",
+        value=(historical_annotation, ...),
+    )
+    current_payload = create_model(
+        f"CurrentOpaqueHash{position}{validator_kind}",
+        value=(current_annotation, ...),
+    )
+    family = _transition_family(
+        current_payload,
+        f"opaque_hash_{position}_{validator_kind}",
+        lambda data: data,
+        wire_model=historical_payload,
+    )
+    source_value = {Child(value=1)} if position == "set" else {Child(value=1): 1}
+    source = historical_payload.model_validate({"value": source_value})
+
+    with pytest.raises(InvalidMigrationError, match="private hash carrier"):
+        family.validate(source, version="1")
+    assert seen == []
+
+
+@pytest.mark.parametrize("operation", ["validate", "render"])
+@pytest.mark.parametrize("position", ["set", "mapping_key"])
+@pytest.mark.parametrize("validator_kind", ["before", "wrap"])
+def test_outer_collection_validators_cannot_observe_or_swallow_private_carriers(
+    operation: str,
+    position: str,
+    validator_kind: str,
+) -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    seen: list[Any] = []
+
+    def observe(value: Any) -> Any:
+        seen.append(value)
+        return value
+
+    def swallow(value: Any, handler: Any) -> Any:
+        seen.append(value)
+        try:
+            return handler(value)
+        except ValidationError:
+            return set() if position == "set" else {}
+
+    typed_annotation = set[Child] if position == "set" else dict[Child, int]
+    opaque_container = set[Any] if position == "set" else dict[Any, int]
+    outer_validator = (
+        BeforeValidator(observe) if validator_kind == "before" else WrapValidator(swallow)
+    )
+    opaque_annotation = Annotated[opaque_container, outer_validator]
+    historical_annotation = opaque_annotation if operation == "render" else typed_annotation
+    current_annotation = typed_annotation if operation == "render" else opaque_annotation
+    historical_payload = create_model(
+        f"HistoricalOuterOpaque{operation}{position}{validator_kind}",
+        value=(historical_annotation, ...),
+    )
+    current_payload = create_model(
+        f"CurrentOuterOpaque{operation}{position}{validator_kind}",
+        value=(current_annotation, ...),
+    )
+    family = _transition_family(
+        current_payload,
+        f"outer_opaque_{operation}_{position}_{validator_kind}",
+        lambda data: data,
+        wire_model=historical_payload,
+    )
+    source_value = {Child(value=1)} if position == "set" else {Child(value=1): 1}
+
+    with pytest.raises(InvalidMigrationError, match="private hash carrier"):
+        if operation == "render":
+            family.dump(
+                version="1",
+                data=current_payload.model_validate({"value": source_value}),
+            )
+        else:
+            family.validate(
+                historical_payload.model_validate({"value": source_value}),
+                version="1",
+            )
+    assert seen == []

--- a/tests/unit/test_decorator_nested_boundaries.py
+++ b/tests/unit/test_decorator_nested_boundaries.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar, cast, get_args
+from uuid import UUID
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
 
 from pydantic_versions import (
     InvalidMigrationError,
@@ -182,6 +184,273 @@ def test_decorator_children_traverse_builtin_containers_and_wrappers() -> None:
     assert validate_versioned(Parent, rendered).current_model.direct.value == 1
 
 
+@pytest.mark.parametrize("operation", ["validate", "render"])
+@pytest.mark.parametrize("exclusion", ["exclude", "exclude_if"])
+def test_decorator_set_rejects_collapse_after_excluded_fields_are_omitted(
+    exclusion: str,
+    operation: str,
+) -> None:
+    omitted = (
+        Field(0, exclude=True)
+        if exclusion == "exclude"
+        else Field(0, exclude_if=lambda _value: True)
+    )
+
+    @versioned_schema(
+        name=f"decorator_excluded_set_child_{exclusion}_{operation}",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+        internal: int = omitted
+
+    def collapse(data: dict[str, Any]) -> dict[str, Any]:
+        children = list(data["children"]) if operation == "render" else tuple(data["children"])
+        for child in children:
+            child["value"] = 0
+        return {**data, "children": children}
+
+    @versioned_schema(
+        name=f"decorator_excluded_set_parent_{exclusion}_{operation}",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=collapse,
+                downgrade=collapse,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    class Parent(BaseModel):
+        children: set[Child]
+
+    source = {
+        "children": [
+            {"value": 1, "internal": 1},
+            {"value": 2, "internal": 2},
+        ],
+        "schema_version": "1",
+    }
+    current = Parent(
+        children={
+            Child(value=1, internal=1),
+            Child(value=2, internal=2),
+        }
+    )
+    with pytest.raises(InvalidMigrationError, match="cardinality"):
+        if operation == "render":
+            dump_versioned(Parent, version="1", data=current)
+        else:
+            validate_versioned(Parent, source)
+
+    assert {child.value for child in current.children} == {1, 2}
+    assert [child["value"] for child in source["children"]] == [1, 2]
+
+
+def test_decorator_children_keep_identity_through_nested_hash_containers() -> None:
+    observed_shapes: list[tuple[type[Any], type[Any]]] = []
+    identifiers = {index: UUID(int=index) for index in range(1, 6)}
+
+    @versioned_schema(name="nested_hash_child", versions=("1", "2"), current="2")
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        model_config = ConfigDict(strict=True, frozen=True)
+
+        value: UUID
+        internal: str = Field("private", exclude=True)
+
+    def inspect(data: dict[str, Any]) -> dict[str, Any]:
+        observed_shapes.append((type(data["tupled"]), type(data["grouped"])))
+        assert all(type(item) is tuple for item in data["tupled"])
+        assert all(type(item) is frozenset for item in data["grouped"])
+
+        clone_index = 0
+
+        def clone(item: Any) -> Any:
+            nonlocal clone_index
+            assert isinstance(item, Mapping)
+            assert "internal" not in item
+            if clone_index == 0:
+                result = item.copy()
+            elif clone_index == 1:
+                result = item | {}
+            elif clone_index == 2:
+                result = {} | item
+            else:
+                result = item.copy()
+                if clone_index == 3:
+                    result |= {}
+                else:
+                    result.setdefault("probe", True)
+                    result.update(probe=True)
+                    assert result.pop("probe") is True
+            clone_index += 1
+            assert result != item and not result == item
+            assert len({item, result}) == 2
+            assert dict(result) == dict(item)
+            return result
+
+        return {
+            **data,
+            "tupled": {(clone(child), index) for child, index in data["tupled"]},
+            "grouped": frozenset(
+                frozenset(clone(child) for child in group) for group in data["grouped"]
+            ),
+        }
+
+    @versioned_schema(
+        name="nested_hash_parent",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=inspect,
+                downgrade=inspect,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    class Parent(BaseModel):
+        model_config = ConfigDict(strict=True)
+
+        tupled: set[tuple[Child, int]]
+        grouped: frozenset[frozenset[Child]]
+
+    current = Parent(
+        tupled={
+            (Child(value=identifiers[1]), 10),
+            (Child(value=identifiers[2]), 20),
+        },
+        grouped=frozenset(
+            {
+                frozenset({Child(value=identifiers[3]), Child(value=identifiers[4])}),
+                frozenset({Child(value=identifiers[5])}),
+            }
+        ),
+    )
+    rendered = dump_versioned(Parent, version="1", data=current)
+    historical_parent = model_for_version(Parent, "1")
+    tuple_child = get_args(get_args(historical_parent.model_fields["tupled"].annotation)[0])[0]
+    grouped_child = get_args(get_args(historical_parent.model_fields["grouped"].annotation)[0])[0]
+    historical = cast(Any, historical_parent)(
+        tupled={
+            (tuple_child(legacy_value=identifiers[1]), 10),
+            (tuple_child(legacy_value=identifiers[2]), 20),
+        },
+        grouped=frozenset(
+            {
+                frozenset(
+                    {
+                        grouped_child(legacy_value=identifiers[3]),
+                        grouped_child(legacy_value=identifiers[4]),
+                    }
+                ),
+                frozenset({grouped_child(legacy_value=identifiers[5])}),
+            }
+        ),
+    )
+    validated = validate_versioned(Parent, historical, version="1")
+
+    tuple_values = {item[0]["legacy_value"] for item in rendered["tupled"]}
+    grouped_values = {item["legacy_value"] for group in rendered["grouped"] for item in group}
+    assert tuple_values | grouped_values == {str(value) for value in identifiers.values()}
+    assert validated.current_model == current
+    assert observed_shapes == [(set, frozenset)] * 2
+
+
+def test_nested_frozenset_dump_prunes_every_child_metadata_without_reordering() -> None:
+    @versioned_schema(
+        name="nested_frozenset_metadata_child",
+        versions=("1", "2"),
+        current="2",
+    )
+    @schema_version("1", patches=(field_renamed("value", "legacy_value"),))
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+        internal: int = Field(0, exclude=True)
+        conditional: int = Field(0, exclude_if=lambda value: value == 0)
+
+    @versioned_schema(
+        name="nested_frozenset_metadata_parent",
+        versions=("1", "2"),
+        current="2",
+    )
+    class Parent(BaseModel):
+        grouped: frozenset[frozenset[Child]]
+
+    for attempt in range(4):
+        expected: set[int] = set()
+        groups: list[frozenset[Child]] = []
+        for group_size in range(1, 9):
+            group = frozenset(
+                Child(
+                    value=attempt * 1_000 + group_size * 100 + item,
+                    internal=item,
+                )
+                for item in range(group_size)
+            )
+            groups.append(group)
+            expected.update(child.value for child in group)
+
+        rendered = dump_versioned(
+            Parent,
+            version="1",
+            data=Parent(grouped=frozenset(groups)),
+        )
+        children = [child for group in rendered["grouped"] for child in group]
+
+        assert rendered["schema_version"] == "1"
+        assert {child["legacy_value"] for child in children} == expected
+        assert all("schema_version" not in child for child in children)
+        assert all("internal" not in child for child in children)
+        assert all("conditional" not in child for child in children)
+
+
+def test_decorator_set_sibling_shifts_preserve_all_occurrences() -> None:
+    def shift(data: dict[str, Any]) -> dict[str, Any]:
+        return {**data, "value": data["value"] + 1}
+
+    @versioned_schema(
+        name="batched_set_child",
+        versions=("1", "2"),
+        current="2",
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                downgrade=shift,
+                downgrade_semantics="exact",
+            ),
+        ),
+    )
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    @versioned_schema(name="batched_set_parent", versions=("1", "2"), current="2")
+    class Parent(BaseModel):
+        children: set[Child]
+
+    rendered = dump_versioned(
+        Parent,
+        version="1",
+        data=Parent(children={Child(value=value) for value in range(32)}),
+    )
+
+    assert {item["value"] for item in rendered["children"]} == set(range(1, 33))
+
+
 def test_discriminated_union_preflights_stale_metadata_and_runs_validator_once() -> None:
     events: list[str] = []
     transitions: list[str] = []
@@ -293,7 +562,8 @@ def test_overlapping_union_rejects_ambiguous_raw_copies_before_next_callback() -
 
 
 def test_historical_overlapping_union_materializes_the_authoritative_current_branch_once() -> None:
-    events: list[str] = []
+    events: list[tuple[str, str]] = []
+    collapse = False
 
     def upgrade_a(data: dict[str, Any]) -> dict[str, Any]:
         return {**data, "value": f"{data['value']}:a"}
@@ -308,12 +578,14 @@ def test_historical_overlapping_union_materializes_the_authoritative_current_bra
         transitions=(VersionTransition("1", "2", upgrade=upgrade_a),),
     )
     class A(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
         value: str
 
         @field_validator("value")
         @classmethod
         def count_a(cls, value: str) -> str:
-            events.append("a")
+            events.append(("model-a", value))
             return value
 
     @versioned_schema(
@@ -323,27 +595,49 @@ def test_historical_overlapping_union_materializes_the_authoritative_current_bra
         transitions=(VersionTransition("1", "2", upgrade=upgrade_b),),
     )
     class B(BaseModel):
-        model_config = ConfigDict(revalidate_instances="always")
+        model_config = ConfigDict(frozen=True, revalidate_instances="always")
 
         value: str
 
         @field_validator("value")
         @classmethod
         def count_b(cls, value: str) -> str:
-            events.append("b")
+            events.append(("model", value))
             return value
+
+    def validate_selected_arm(value: B) -> B:
+        events.append(("arm", value.value))
+        return value.model_copy(update={"value": "same"}) if collapse else value
 
     @versioned_schema(name="materialized_parent", versions=("1", "2"), current="2")
     class Parent(BaseModel):
-        item: A | B
+        items: set[A | Annotated[B, AfterValidator(validate_selected_arm)]]
 
-    historical_b = model_for_version(B, "1").model_validate({"value": "x"})
-    historical_parent = model_for_version(Parent, "1").model_validate({"item": historical_b})
+    historical_parent_model = model_for_version(Parent, "1")
+    historical_union = get_args(
+        get_args(historical_parent_model.model_fields["items"].annotation)[0]
+    )
+    historical_b = historical_union[1]
+    historical_parent = historical_parent_model.model_validate(
+        {
+            "items": {
+                historical_b.model_validate({"value": "x"}),
+                historical_b.model_validate({"value": "y"}),
+            }
+        }
+    )
+    events.clear()
     result = validate_versioned(Parent, historical_parent, version="1")
 
-    assert type(result.current_model.item) is B
-    assert result.current_model.item.value == "x:b"
-    assert events == ["b"]
+    assert {type(item) for item in result.current_model.items} == {B}
+    assert {item.value for item in result.current_model.items} == {"x:b", "y:b"}
+    assert sorted(kind for kind, _value in events) == ["arm", "arm", "model", "model"]
+
+    collapse = True
+    events.clear()
+    with pytest.raises(InvalidMigrationError, match="set cardinality"):
+        validate_versioned(Parent, historical_parent, version="1")
+    assert sorted(kind for kind, _value in events) == ["arm", "arm", "model", "model"]
 
 
 def test_current_render_accepts_subclasses_with_narrower_route_annotations() -> None:
@@ -664,41 +958,7 @@ def test_mapping_keys_do_not_anchor_beneath_a_reordered_dynamic_parent() -> None
         )
 
 
-def test_decorator_set_projection_rejects_target_cardinality_collapse() -> None:
-    def collapse(data: dict[str, Any]) -> dict[str, Any]:
-        return {**data, "value": 0}
-
-    @versioned_schema(
-        name="collapse_child",
-        versions=("1", "2"),
-        current="2",
-        transitions=(
-            VersionTransition(
-                "1",
-                "2",
-                downgrade=collapse,
-                downgrade_semantics="lossy",
-            ),
-        ),
-    )
-    class Child(BaseModel):
-        model_config = ConfigDict(frozen=True)
-
-        value: int
-
-    @versioned_schema(name="collapse_parent", versions=("1", "2"), current="2")
-    class Parent(BaseModel):
-        children: set[Child]
-
-    with pytest.raises(InvalidMigrationError, match="set cardinality"):
-        dump_versioned(
-            Parent,
-            version="1",
-            data=Parent(children={Child(value=1), Child(value=2)}),
-        )
-
-
-def test_unselected_overlapping_union_route_checks_nested_set_cardinality() -> None:
+def test_unselected_overlapping_union_route_uses_selected_exact_list_arm() -> None:
     @versioned_schema(
         name="all_route_cardinality_grand",
         versions=("1", "2"),
@@ -740,11 +1000,10 @@ def test_unselected_overlapping_union_route_checks_nested_set_cardinality() -> N
     )
 
     assert type(source.item) is SelectedBranch
-    with pytest.raises(InvalidMigrationError, match="set cardinality") as error:
-        dump_versioned(Parent, version="1", data=source)
-
-    assert "all_route_cardinality_grand" in str(error.value)
-    assert "('values',)" in str(error.value)
+    assert dump_versioned(Parent, version="1", data=source) == {
+        "item": {"values": [{"value": 1}, {"value": "1"}]},
+        "schema_version": "1",
+    }
 
 
 def test_decorator_boundaries_recurse_across_decorated_families() -> None:

--- a/tests/unit/test_nested_runtime_paths.py
+++ b/tests/unit/test_nested_runtime_paths.py
@@ -1,4 +1,6 @@
-from typing import Annotated, Any, Self, cast
+from enum import Enum
+from typing import Annotated, Any, Self, TypedDict, cast, get_args
+from uuid import UUID
 
 import pytest
 from pydantic import (
@@ -65,6 +67,68 @@ def test_nested_runtime_does_not_search_unrelated_mapping_values(
 
     assert result.current_model.child is None
     assert result.current_model.opaque == opaque
+
+
+def test_generated_nested_enum_values_are_trusted_but_explicit_structures_are_not() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class Child(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        mode: Mode
+
+    child_family = SchemaFamily(
+        model=Child,
+        name="nested_enum_trust_child",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(VersionTransition("1", "2", upgrade=lambda data: data),),
+        version_metadata=None,
+    )
+
+    class Parent(BaseModel):
+        child: Child
+
+    generated_parent = SchemaFamily(
+        model=Parent,
+        name="generated_nested_enum_trust_parent",
+        versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(VersionTransition("1", "2", upgrade=lambda data: data),),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+        version_metadata=None,
+    )
+
+    assert (
+        generated_parent.validate(
+            {"child": {"mode": Mode.active}},
+            version="1",
+        ).current_model.child.mode
+        == "active"
+    )
+
+    class HistoricalChild(TypedDict):
+        mode: str
+
+    class HistoricalParent(BaseModel):
+        child: HistoricalChild
+
+    explicit_parent = SchemaFamily(
+        model=Parent,
+        name="explicit_nested_enum_trust_parent",
+        versions=(
+            SchemaVersion("1", wire_model=HistoricalParent),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=lambda data: data),),
+        nested=(NestedFamily("child", child_family, matching_labels()),),
+        version_metadata=None,
+    )
+
+    with pytest.raises(ValidationError, match="instance of .*Mode"):
+        explicit_parent.validate(
+            {"child": {"mode": "active"}},
+            version="1",
+        )
 
 
 def test_nested_projection_and_pruning_ignore_an_opaque_sibling() -> None:
@@ -559,51 +623,119 @@ def test_alias_path_does_not_overwrite_a_scalar_intermediate_field() -> None:
     assert raw == {"envelope": "preserve-me", "value": 7}
 
 
-def test_nested_validation_preserves_python_set_container_types() -> None:
-    class Child(BaseModel):
-        model_config = ConfigDict(frozen=True)
+@pytest.mark.parametrize("exclusion", ["exclude", "exclude_if"])
+def test_nested_families_preserve_strict_container_kinds_and_exclusions(
+    exclusion: str,
+) -> None:
+    identifier = UUID("12345678-1234-5678-1234-567812345678")
+    omitted = (
+        Field("private", exclude=True)
+        if exclusion == "exclude"
+        else Field("private", exclude_if=lambda _value: True)
+    )
 
-        value: int
+    class Child(BaseModel):
+        model_config = ConfigDict(strict=True, frozen=True)
+
+        value: UUID
+        secret: str = omitted
 
     child_family = SchemaFamily(
         model=Child,
-        name="python_collection_child",
+        name=f"strict_python_collection_child_{exclusion}",
         versions=(SchemaVersion("1"), SchemaVersion("2")),
         transitions=(
             VersionTransition(
                 "1",
                 "2",
-                upgrade=lambda data: {"value": data["value"] + 10},
+                upgrade=lambda data: data,
+                downgrade=lambda data: data,
+                downgrade_semantics="exact",
             ),
         ),
+        version_metadata=None,
     )
 
     class Parent(BaseModel):
-        values: set[Child]
+        model_config = ConfigDict(strict=True)
+
+        tupled: tuple[Child, ...]
+        set_values: set[Child]
         frozen_values: frozenset[Child]
 
-    parent_family = SchemaFamily(
+    seen_payloads: list[dict[str, Any]] = []
+
+    def inspect_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        seen_payloads.append(dict(payload))
+        return payload
+
+    family = SchemaFamily(
         model=Parent,
-        name="python_collection_parent",
+        name=f"strict_python_collection_parent_{exclusion}",
         versions=(SchemaVersion("1"), SchemaVersion("2")),
+        transitions=(
+            VersionTransition(
+                "1",
+                "2",
+                upgrade=inspect_payload,
+                downgrade=inspect_payload,
+                downgrade_semantics="exact",
+            ),
+        ),
         nested=(
-            NestedFamily("values", child_family, matching_labels()),
+            NestedFamily("tupled", child_family, matching_labels()),
+            NestedFamily("set_values", child_family, matching_labels()),
             NestedFamily("frozen_values", child_family, matching_labels()),
         ),
+        version_metadata=None,
     )
 
-    result = parent_family.validate(
-        {
-            "schema_version": "1",
-            "values": [{"schema_version": "1", "value": 1}],
-            "frozen_values": [{"schema_version": "1", "value": 2}],
-        },
+    historical_parent = family.model_for("1")
+    tuple_child = get_args(historical_parent.model_fields["tupled"].annotation)[0]
+    set_child = get_args(historical_parent.model_fields["set_values"].annotation)[0]
+    frozen_child = get_args(historical_parent.model_fields["frozen_values"].annotation)[0]
+    historical = cast(Any, historical_parent)(
+        tupled=(tuple_child(value=identifier),),
+        set_values={set_child(value=identifier)},
+        frozen_values=frozenset({frozen_child(value=identifier)}),
+    )
+    current = Parent(
+        tupled=(Child(value=identifier),),
+        set_values={Child(value=identifier)},
+        frozen_values=frozenset({Child(value=identifier)}),
     )
 
-    assert type(result.current_model.values) is set
-    assert type(result.current_model.frozen_values) is frozenset
-    assert {child.value for child in result.current_model.values} == {11}
-    assert {child.value for child in result.current_model.frozen_values} == {12}
+    validated = family.validate(historical, version="1")
+    rendered = family.dump(version="1", data=current)
+
+    assert validated.current_model == current
+    assert rendered == {
+        "tupled": [{"value": str(identifier)}],
+        "set_values": [{"value": str(identifier)}],
+        "frozen_values": [{"value": str(identifier)}],
+    }
+    assert len(seen_payloads) == 2
+    for payload in seen_payloads:
+        assert type(payload["tupled"]) is tuple
+        assert type(payload["set_values"]) is set
+        assert type(payload["frozen_values"]) is frozenset
+        for field_name in ("tupled", "set_values", "frozen_values"):
+            item = next(iter(payload[field_name]))
+            assert dict(item) == {"value": identifier}
+            assert "secret" not in item
+
+    with pytest.raises(InvalidMigrationError, match="cardinality"):
+        family.dump(
+            version="1",
+            data=Parent(
+                tupled=current.tupled,
+                set_values={
+                    Child(value=identifier, secret="first"),
+                    Child(value=identifier, secret="second"),
+                },
+                frozen_values=current.frozen_values,
+            ),
+        )
 
 
 @pytest.mark.parametrize("direction", ["upgrade", "downgrade"])

--- a/tests/unit/test_render_current_validation.py
+++ b/tests/unit/test_render_current_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, Self, cast
 
 import pytest
@@ -253,11 +254,22 @@ def test_model_owned_metadata_rejects_conflicts_at_any_accepted_name() -> None:
 
 
 def test_unrelated_models_are_structurally_validated_as_current_input() -> None:
+    class Mode(Enum):
+        active = "active"
+
     class CurrentPayload(BaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+
         value: int
+        mode: Mode = Field(strict=True)
 
     class CompatiblePayload(BaseModel):
         value: str
+        mode: Mode
+
+    class RawEnumPayload(BaseModel):
+        value: int
+        mode: str
 
     class IncompatiblePayload(BaseModel):
         other: str
@@ -269,8 +281,12 @@ def test_unrelated_models_are_structurally_validated_as_current_input() -> None:
         version_metadata=None,
     )
 
-    assert family.dump(version="1", data=cast(Any, CompatiblePayload(value="8"))) == {
+    assert family.dump(
+        version="1",
+        data=cast(Any, CompatiblePayload(value="8", mode=Mode.active)),
+    ) == {
         "value": 8,
+        "mode": "active",
     }
     with pytest.raises(ValidationError, match="CurrentPayload"):
         family.dump(
@@ -279,6 +295,11 @@ def test_unrelated_models_are_structurally_validated_as_current_input() -> None:
         )
     with pytest.raises(TypeError, match="current model instance or mapping"):
         family.dump(version="1", data=cast(Any, ["not", "render", "data"]))
+    with pytest.raises(ValidationError, match="instance of .*Mode"):
+        family.dump(
+            version="1",
+            data=cast(Any, RawEnumPayload(value=8, mode="active")),
+        )
 
 
 def test_generated_current_wire_does_not_bypass_unrelated_current_errors() -> None:
@@ -717,11 +738,59 @@ def test_generated_set_projection_rejects_parent_custom_init_before_execution() 
     assert init_types == []
 
 
+def test_generated_set_projection_rejects_inherited_custom_new_before_execution() -> None:
+    new_types: list[type[BaseModel]] = []
+
+    class CustomNewBase(BaseModel):
+        def __new__(cls, *args: Any, **kwargs: Any) -> Self:
+            new_types.append(cls)
+            return super().__new__(cls)
+
+    @versioned_schema(name="custom_new_set_child", versions=("1",), current="1")
+    class CustomNewChild(BaseModel):
+        value: int
+
+    @versioned_schema(name="custom_new_set_parent", versions=("1",), current="1")
+    class CustomNewParent(CustomNewBase):
+        children: set[CustomNewChild]
+
+    generated_current = model_for_version(CustomNewParent, "1").model_validate(
+        {"children": [{"value": 1}]},
+    )
+
+    with pytest.raises(
+        UnsupportedWireModelError,
+        match="custom __new__.*CustomNewParent",
+    ):
+        dump_versioned(
+            CustomNewParent,
+            version="1",
+            data=cast(Any, generated_current),
+        )
+    assert new_types == []
+
+
 def test_current_model_instances_follow_configured_revalidation_policy() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    events: list[Any] = []
+
     class RevalidatedPayload(BaseModel):
-        model_config = ConfigDict(revalidate_instances="always")
+        model_config = ConfigDict(
+            strict=True,
+            use_enum_values=True,
+            revalidate_instances="always",
+        )
 
         value: int = Field(gt=0)
+        mode: Mode
+
+        @field_validator("mode", mode="before")
+        @classmethod
+        def track(cls, value: Any) -> Any:
+            events.append(value)
+            return value
 
     family = SchemaFamily(
         model=RevalidatedPayload,
@@ -729,11 +798,128 @@ def test_current_model_instances_follow_configured_revalidation_policy() -> None
         versions=(SchemaVersion("1"),),
         version_metadata=None,
     )
-    current = RevalidatedPayload(value=1)
+    current = RevalidatedPayload(value=1, mode=Mode.active)
     current.value = -1
+    events.clear()
 
     with pytest.raises(ValidationError, match="greater than 0"):
         family.dump(version="1", data=current)
+    assert events == ["active"]
+
+    current.value = 1
+    events.clear()
+    assert family.dump(version="1", data=current) == {"value": 1, "mode": "active"}
+    assert events == ["active"]
+    with pytest.raises(ValidationError, match="instance of .*Mode"):
+        family.dump(version="1", data={"value": 1, "mode": "active"})
+
+    historical_family = SchemaFamily(
+        model=RevalidatedPayload,
+        name="revalidated_historical_enum_instance",
+        versions=(
+            SchemaVersion("1", wire_model=RevalidatedPayload),
+            SchemaVersion("2"),
+        ),
+        transitions=(VersionTransition("1", "2", upgrade=lambda data: data),),
+        version_metadata=None,
+    )
+    events.clear()
+    assert historical_family.validate(current, version="1").current_model.mode == "active"
+    assert events == ["active", "active"]
+    with pytest.raises(ValidationError, match="instance of .*Mode"):
+        historical_family.validate({"value": 1, "mode": "active"}, version="1")
+
+
+def test_adapted_current_revalidation_preserves_excluded_state_for_model_before() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    events: list[dict[str, Any]] = []
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(
+            revalidate_instances="always",
+            strict=True,
+            use_enum_values=True,
+        )
+
+        public: int
+        mode: Mode
+        internal: int = Field(0, exclude=True)
+
+        @model_validator(mode="before")
+        @classmethod
+        def include_internal(cls, value: Any) -> Any:
+            if isinstance(value, dict):
+                events.append(dict(value))
+                value = dict(value)
+                value["public"] += value.get("internal", 0)
+            return value
+
+    family = SchemaFamily(
+        model=Payload,
+        name="adapted_render_full_state",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    source = Payload.model_construct(public=1, mode="active", internal=2)
+
+    assert family.dump(version="1", data=source) == {"public": 3, "mode": "active"}
+    assert events == [{"public": 1, "mode": "active", "internal": 2}]
+    assert source.public == 1
+    assert source.internal == 2
+
+
+def test_unadapted_instance_revalidation_keeps_native_alias_policy() -> None:
+    class Payload(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always", validate_by_name=False)
+
+        value: int = Field(validation_alias="input")
+
+    family = SchemaFamily(
+        model=Payload,
+        name="native_revalidation_alias_policy",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    source = Payload.model_validate({"input": 1})
+
+    with pytest.raises(ValidationError) as native_error:
+        Payload.model_validate(source)
+    with pytest.raises(ValidationError) as family_error:
+        family.dump(version="1", data=source)
+
+    assert native_error.value.errors()[0]["loc"] == ("input",)
+    assert family_error.value.errors()[0]["loc"] == ("input",)
+
+
+def test_unadapted_instance_revalidation_uses_overridden_model_validate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[Any] = []
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(revalidate_instances="always")
+
+        value: int
+
+    original = Payload.model_validate
+
+    def tracked(_cls: type[Payload], value: Any, **kwargs: Any) -> Any:
+        events.append(value)
+        return original(value, **kwargs)
+
+    monkeypatch.setattr(Payload, "model_validate", classmethod(tracked))
+    family = SchemaFamily(
+        model=Payload,
+        name="native_overridden_model_validate",
+        versions=(SchemaVersion("1"),),
+        version_metadata=None,
+    )
+    source = Payload(value=1)
+
+    assert family.dump(version="1", data=source) == {"value": 1}
+    assert events == [source]
 
 
 def test_current_model_subclass_fields_stay_outside_canonical_payload() -> None:
@@ -771,7 +957,7 @@ def test_current_model_subclass_fields_stay_outside_canonical_payload() -> None:
     assert seen_payloads == [{"value": 1}]
 
 
-def test_declared_model_config_controls_top_level_canonical_scalars() -> None:
+def test_declared_model_config_only_controls_top_level_target_serialization() -> None:
     seen_payloads: list[dict[str, Any]] = []
 
     class CurrentPayload(BaseModel):
@@ -805,7 +991,7 @@ def test_declared_model_config_controls_top_level_canonical_scalars() -> None:
     assert family.dump(version="1", data=ExtendedPayload(value=b"abc")) == {
         "value": "abc",
     }
-    assert seen_payloads == [{"value": "abc"}, {"value": "abc"}]
+    assert seen_payloads == [{"value": b"abc"}, {"value": b"abc"}]
 
 
 def test_nested_subclass_fields_stay_outside_canonical_payload() -> None:
@@ -855,7 +1041,7 @@ def test_nested_subclass_fields_stay_outside_canonical_payload() -> None:
     assert seen_payloads == [rendered]
 
 
-def test_declared_model_config_controls_nested_canonical_scalars() -> None:
+def test_declared_model_config_only_controls_nested_target_serialization() -> None:
     seen_payloads: list[dict[str, Any]] = []
 
     class ChildPayload(BaseModel):
@@ -911,7 +1097,11 @@ def test_declared_model_config_controls_nested_canonical_scalars() -> None:
         )
         == expected
     )
-    assert seen_payloads == [expected, expected]
+    canonical = {
+        "child": {"value": b"abc"},
+        "items": [{"value": b"abc"}],
+    }
+    assert seen_payloads == [canonical, canonical]
 
 
 @pytest.mark.parametrize("subclass_first", [False, True])

--- a/tests/unit/test_runtime_coverage_contract.py
+++ b/tests/unit/test_runtime_coverage_contract.py
@@ -108,7 +108,7 @@ def test_mapping_render_copies_builtin_containers_and_preserves_canonical_scalar
         {"elapsed": dt.timedelta(seconds=2.5)},
         version="1",
     )
-    assert seen_elapsed == [2.5]
+    assert seen_elapsed == [dt.timedelta(seconds=2.5)]
 
 
 def test_historical_removed_nested_routes_are_conditionally_absent() -> None:

--- a/tests/unit/test_runtime_fast_paths.py
+++ b/tests/unit/test_runtime_fast_paths.py
@@ -2,19 +2,29 @@
 
 from __future__ import annotations
 
-import datetime as dt
 from enum import Enum
-from typing import Annotated, Any, NewType
-from uuid import UUID
+from typing import Annotated, Any, Literal, NewType
 
 import pytest
-from pydantic import BaseModel
-from pydantic_core import to_jsonable_python as core_to_jsonable_python
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    Strict,
+    ValidationError,
+)
 
 import pydantic_versions._runtime as runtime
 import pydantic_versions._runtime_nested as runtime_nested
 import pydantic_versions._runtime_payload as runtime_payload
-from pydantic_versions import SchemaFamily, SchemaVersion
+import pydantic_versions._runtime_validation as runtime_validation
+from pydantic_versions import (
+    InvalidMigrationError,
+    SchemaFamily,
+    SchemaVersion,
+)
 
 
 def test_empty_decorator_selection_skips_declared_tree_extraction(
@@ -141,69 +151,242 @@ def test_aliases_and_new_types_retain_annotation_normalization(
     assert normalized == [alias, new_type, annotated]
 
 
-def test_exact_json_scalars_skip_general_conversion(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def unexpected_conversion(_value: Any, **_kwargs: Any) -> Any:
-        raise AssertionError("exact JSON-native scalars must not enter pydantic-core")
+def test_hash_required_extraction_does_not_compare_adversarial_field_values() -> None:
+    class Opaque:
+        compare = False
 
-    monkeypatch.setattr(runtime_payload, "to_jsonable_python", unexpected_conversion)
+        def __init__(self, value: int) -> None:
+            self.value = value
 
-    values = (None, False, True, 0, 1, -1, 1.5, "payload")
+        def __hash__(self) -> int:
+            return 0
+
+        def __eq__(self, other: object) -> bool:
+            if self.compare:
+                raise AssertionError("canonical carrier insertion compared field content")
+            return isinstance(other, Opaque) and self.value == other.value
+
+    class Child(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+        value: Opaque
+
+    values = {Child(value=Opaque(index)) for index in range(64)}
+    Opaque.compare = True
+    try:
+        extracted = runtime_payload._extract_declared_value(
+            values,
+            annotation=set[Child],
+        )
+    finally:
+        Opaque.compare = False
+
+    assert len(extracted) == len(values)
+
+
+def test_field_level_strict_enum_values_round_trip_from_canonical_storage() -> None:
+    class Mode(Enum):
+        active = "active"
+
+    class FieldStrictPayload(BaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+
+        mode: Mode = Field(strict=True)
+
+    class AnnotatedStrictPayload(BaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+
+        mode: Annotated[Mode, Strict()]
+
+    class LiteralPayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        mode: Literal[Mode.active]
+
+    for model in (FieldStrictPayload, AnnotatedStrictPayload, LiteralPayload):
+        source = model(mode=Mode.active)
+        validated = runtime_validation._validate_canonical_model(
+            model,
+            {"mode": source.mode},
+        )
+
+        assert validated.mode == "active"
+        assert type(validated.mode) is str
+
+    class NativeLiteralPayload(BaseModel):
+        mode: Literal[Mode.active]
+
+    with pytest.raises(ValidationError):
+        runtime_validation._validate_canonical_model(
+            NativeLiteralPayload,
+            {"mode": "active"},
+        )
+
+    nan = float("nan")
+
+    class NonReflexive(Enum):
+        value = nan
+
+    class NonReflexivePayload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        value: NonReflexive
+
+    source = NonReflexivePayload(value=NonReflexive.value)
     assert (
-        tuple(runtime_payload._jsonable_declared_scalar(value, config={}) for value in values)
-        == values
+        runtime_validation._validate_canonical_model(
+            NonReflexivePayload,
+            {"value": source.value},
+        ).value
+        is nan
     )
 
 
-def test_non_exact_json_scalars_retain_general_conversion_paths(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class Text(str):
-        pass
+def test_model_unions_keep_native_smart_and_tagged_arm_selection() -> None:
+    events: list[str] = []
 
     class Mode(Enum):
-        READY = "ready"
+        active = "active"
 
-    class Opaque:
-        pass
+    def enum_after(value: Mode) -> Mode:
+        events.append("enum")
+        return value
 
-    calls: list[Any] = []
+    def string_after(value: str) -> str:
+        events.append("string")
+        return value
 
-    def tracking_conversion(value: Any, **kwargs: Any) -> Any:
-        calls.append(value)
-        return core_to_jsonable_python(value, **kwargs)
+    class EnumArm(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
 
-    monkeypatch.setattr(runtime_payload, "to_jsonable_python", tracking_conversion)
+        value: Annotated[Mode, AfterValidator(enum_after)]
 
-    opaque = Opaque()
-    values = (
-        Text("text"),
-        b"bytes",
-        dt.datetime(2020, 1, 2, 3, 4, 5, tzinfo=dt.UTC),
-        dt.date(2020, 1, 2),
-        dt.time(3, 4, 5),
-        dt.timedelta(seconds=1.5),
-        Mode.READY,
-        UUID("12345678-1234-5678-1234-567812345678"),
-        opaque,
-    )
-    converted = tuple(
-        runtime_payload._jsonable_declared_scalar(value, config={}) for value in values
+    class StringArm(BaseModel):
+        value: Annotated[str, AfterValidator(string_after)]
+
+    class Payload(BaseModel):
+        item: EnumArm | StringArm
+
+    validated = runtime_validation._validate_canonical_model(
+        Payload,
+        {"item": {"value": "active"}},
     )
 
-    assert calls == list(values)
-    assert converted == (
-        "text",
-        "bytes",
-        "2020-01-02T03:04:05Z",
-        "2020-01-02",
-        "03:04:05",
-        "PT1.5S",
-        "ready",
-        "12345678-1234-5678-1234-567812345678",
-        opaque,
+    assert isinstance(validated.item, StringArm)
+    assert events == ["string"]
+
+    class Cat(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        kind: Literal["cat"] = "cat"
+        mode: Mode
+
+    class Dog(BaseModel):
+        kind: Literal["dog"] = "dog"
+
+    class TaggedPayload(BaseModel):
+        item: Annotated[Cat | Dog, Field(discriminator="kind")]
+
+    source = TaggedPayload(item=Cat(mode=Mode.active))
+    assert isinstance(source.item, Cat)
+    tagged = runtime_validation._validate_canonical_model(
+        TaggedPayload,
+        {"item": {"kind": "cat", "mode": source.item.mode}},
     )
+    assert type(tagged.item) is Cat
+    assert tagged.item.mode == "active"
+
+
+def test_shared_enum_refs_and_noncarrier_values_keep_custom_init_native() -> None:
+    events: list[dict[str, Any]] = []
+
+    class Mode(Enum):
+        active = "active"
+
+    type SharedModes = list[Mode]
+
+    class CustomPayload(BaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+
+        modes: SharedModes
+        values: set[int]
+
+        def __init__(self, **data: Any) -> None:
+            events.append(dict(data))
+            super().__init__(**data)
+
+    class Payload(BaseModel):
+        model_config = ConfigDict(strict=True, use_enum_values=True)
+
+        modes: SharedModes
+        custom: CustomPayload
+
+    validated = runtime_validation._validate_canonical_model(
+        Payload,
+        {
+            "modes": ["active"],
+            "custom": {"modes": ["active"], "values": {1, 2}},
+        },
+    )
+
+    assert validated.modes == ["active"]
+    assert validated.custom.modes == ["active"]
+    assert validated.custom.values == {1, 2}
+    assert events == [{"modes": ["active"], "values": {1, 2}}]
+
+
+def test_collection_guard_preserves_native_strict_errors_and_after_validators() -> None:
+    class Child(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+
+    class ValidatedPayload(BaseModel):
+        children: Annotated[set[Child], AfterValidator(lambda value: {next(iter(value))})]
+
+    class BeforePayload(BaseModel):
+        children: Annotated[set[Child], BeforeValidator(list)]
+
+    source = ValidatedPayload.model_construct(
+        children={Child(value=1), Child(value=2)},
+    )
+    canonical = runtime_payload._extract_declared_fields(source, declared_model=ValidatedPayload)
+    assert (
+        len(runtime_validation._validate_canonical_model(ValidatedPayload, canonical).children) == 1
+    )
+
+    for model, container in ((BeforePayload, set), (ValidatedPayload, list)):
+        source = model.model_construct(children={Child(value=1), Child(value=2)})
+        canonical = runtime_payload._extract_declared_fields(source, declared_model=model)
+        canonical["children"] = container(canonical["children"])
+        for child in canonical["children"]:
+            child["value"] = 0
+        with pytest.raises(InvalidMigrationError, match="set cardinality"):
+            runtime_validation._validate_canonical_model(model, canonical)
+
+
+def test_recursive_schema_refs_keep_canonical_guards() -> None:
+    class ModelNode(BaseModel):
+        model_config = ConfigDict(frozen=True)
+
+        value: int
+        children: frozenset[ModelNode] = frozenset()
+
+    ModelNode.model_rebuild()
+    source = ModelNode(
+        value=0,
+        children=frozenset({ModelNode(value=1), ModelNode(value=2)}),
+    )
+    canonical = runtime_payload._extract_declared_fields(
+        source,
+        declared_model=ModelNode,
+    )
+
+    assert runtime_validation._validate_canonical_model(ModelNode, canonical) == source
+    for child in canonical["children"]:
+        child["value"] = 0
+    with pytest.raises(InvalidMigrationError, match="set cardinality"):
+        runtime_validation._validate_canonical_model(ModelNode, canonical)
 
 
 def test_duplicate_payload_detection_does_not_slice() -> None:


### PR DESCRIPTION
## Summary

- Preserve detached, declared, validated Python values across migration callbacks and historical rendering, including strict scalars, secrets, mapping keys, and exact built-in container kinds.
- Add bounded canonical validation that keeps Pydantic application-validator semantics while failing closed on data-losing carriers, erased enum shapes, unsupported validation overrides, and unordered child-metadata correlation.
- Extract the validation bridge into a focused runtime module and document the stable transition contract throughout the user guides and reference.

## Boundaries and compatibility

- Preserve the immutable 0.3.0 compatibility contract, including omission of `Field(exclude=True)` and `exclude_if` fields from wire projections.
- Keep extras, subclass-only state, and source serializers outside canonical payloads. JSON conversion remains the final target-serialization boundary.
- This PR adds no transport, capability-negotiation, trace, or post-1.0 API.

## Investigation

- Cover strict values, secrets, nested and decorator-discovered containers, enums, application validators, caller immutability, fail-closed boundaries, and child metadata nested through unordered containers.
- Update the migrations, rendering, application-exchange, API, stability-policy, and changelog documentation to explain the values callbacks receive, validation errors, ownership boundaries, and application-to-application responsibilities.

## Validation

- `make ci`: 1,008 tests passed at 95.15% coverage; Ruff, ty, strict mypy, and Vulture passed.
- Pydantic 2.12.3 minimum dependency suite: 1,008 tests passed at 95.08% coverage.
- `make docs-build-strict`: passed with no documentation issues.
- Immutable 0.3.0 contract and 1.0.0 release metadata checks: passed.
- Frozen dependency audit: passed with no known vulnerabilities.
- Fresh wheel and sdist: strict Twine checks and isolated installation smokes passed for both artifacts.

Closes #139
